### PR TITLE
feature/se-2-type-bind

### DIFF
--- a/cypress/integration/submission-ui.spec.ts
+++ b/cypress/integration/submission-ui.spec.ts
@@ -1,0 +1,142 @@
+const password = 'admin';
+const email = 'test@test.edu';
+const collectionName = 'Col';
+const communityName = 'Com';
+
+const loginProcess = {
+  clickOnLoginDropdown() {
+    cy.get('.navbar-container .dropdownLogin ').click();
+  },
+  typeEmail() {
+    cy.get('.navbar-container form input[type = "email"] ').type(email);
+  },
+  typePassword() {
+    cy.get('.navbar-container form input[type = "password"] ').type(password);
+  },
+  submit() {
+    cy.get('.navbar-container form button[type = "submit"] ').click();
+  }
+};
+
+const createCommunityProcess = {
+  clickOnCreateTopLevelComunity() {
+    cy.get('.modal-body button').eq(0).click();
+  },
+  typeCommunityName() {
+    cy.get('form input[id = "title"]').type(communityName);
+  },
+  submit() {
+    cy.get('form div button[type = "submit"]').eq(0).click();
+  }
+};
+
+const sideBarMenu = {
+  clickOnNewButton() {
+    cy.get('.sidebar-top-level-items div[role = "button"]').eq(0).click();
+  },
+  clickOnNewCommunityButton() {
+    cy.get('.sidebar-sub-level-items a[role = "button"]').eq(0).click();
+  },
+  clickOnNewCollectionButton() {
+    cy.get('.sidebar-sub-level-items a[role = "button"]').eq(1).click();
+  },
+  clickOnNewItemButton() {
+    cy.get('.sidebar-sub-level-items a[role = "button"]').eq(2).click();
+  }
+};
+
+const createCollectionProcess = {
+  selectCommunity() {
+    cy.get('.modal-body .scrollable-menu button[title = "' + communityName + '"]').click();
+  },
+  typeCollectionName() {
+    cy.get('form input[id = "title"]').type(collectionName);
+  },
+  submit() {
+    cy.get('form div button[type = "submit"]').eq(0).click();
+  }
+};
+
+const createItemProcess = {
+  selectCollection() {
+    cy.get('.modal-body .list-group div button .content').contains(collectionName).click();
+  },
+  checkLocalHasCMDIVisibility() {
+    cy.get('#traditionalpageone form div[role = "group"] label[for = "local_hasCMDI"]').should('be.visible');
+  },
+  clickOnInput(inputName) {
+    cy.get('#traditionalpageone form div[role = "group"] input[name = "' + inputName + '"]').click();
+  },
+  clickOnTypeSelection(selectionName) {
+    cy.get('#traditionalpageone form div[role = "group"] div[role = "listbox"]' +
+      ' button[title = "' + selectionName + '"]').click();
+  },
+  checkInputValue(inputName, observedInputValue) {
+    cy.get('#traditionalpageone form div[role = "group"] div[role = "combobox"] input[name = "' + inputName + '"]')
+      .should('contain',observedInputValue);
+  },
+  checkCheckbox(inputName) {
+    cy.get('#traditionalpageone form div[role = "group"] div[id = "' + inputName + '"] input[type = "checkbox"]')
+      .check({force: true});
+  },
+  controlCheckedCheckbox(inputName, checked) {
+    const checkedCondition = checked === true ? 'be.checked' : 'not.be.checked';
+    cy.get('#traditionalpageone form div[role = "group"] div[id = "' + inputName + '"] input[type = "checkbox"]')
+      .should(checkedCondition);
+  },
+  clickOnSave() {
+    cy.get('.submission-form-footer button[id = "save"]').click();
+  }
+};
+
+describe('Create a new submission', () => {
+  beforeEach(() => {
+    cy.visit('/');
+    // Login as admin
+    loginProcess.clickOnLoginDropdown();
+    loginProcess.typeEmail();
+    loginProcess.typePassword();
+    loginProcess.submit();
+
+    // Create a new Community
+    sideBarMenu.clickOnNewButton();
+    sideBarMenu.clickOnNewCommunityButton();
+    createCommunityProcess.clickOnCreateTopLevelComunity();
+    createCommunityProcess.typeCommunityName();
+    createCommunityProcess.submit();
+
+    // Create a new Colletion
+    cy.visit('/');
+    sideBarMenu.clickOnNewButton();
+    sideBarMenu.clickOnNewCollectionButton();
+    createCollectionProcess.selectCommunity();
+    createCollectionProcess.typeCollectionName();
+    createCollectionProcess.submit();
+
+    // Create a new Item
+    cy.visit('/');
+    sideBarMenu.clickOnNewButton();
+    sideBarMenu.clickOnNewItemButton();
+    createItemProcess.selectCollection();
+  });
+
+  it('should be visible Has CMDI file input field because user is admin', () => {
+    createItemProcess.checkLocalHasCMDIVisibility();
+  });
+
+  it('should be showed chosen type value', () => {
+    createItemProcess.clickOnInput('dc.type');
+    createItemProcess.clickOnTypeSelection('Article');
+    createItemProcess.checkInputValue('dc.type', 'Article');
+  });
+
+  it('The local.hasCMDI value should be sent in the response after type change', () => {
+    createItemProcess.clickOnInput('dc.type');
+    createItemProcess.clickOnTypeSelection('Article');
+    createItemProcess.checkCheckbox('local_hasCMDI');
+    createItemProcess.controlCheckedCheckbox('local_hasCMDI',true);
+    createItemProcess.clickOnSave();
+    cy.reload();
+    createItemProcess.controlCheckedCheckbox('local_hasCMDI',true);
+  });
+});

--- a/src/app/shared/form/builder/form-builder.service.spec.ts
+++ b/src/app/shared/form/builder/form-builder.service.spec.ts
@@ -507,9 +507,8 @@ describe('FormBuilderService test suite', () => {
   it('should not init all fields to the formModel because one has type-bind.', () => {
     const formModel = service.modelFromConfiguration(submissionId, testFormConfigurationWithTypeBind, 'testScopeUUID');
 
-    expect(formModel.length).toEqual(1);
     // @ts-ignore
-    expect(formModel[0].group[0].name).toEqual('dc.contributor');
+    expect(formModel[0].hidden).toBe(true);
   });
 
   it('should create an array of form models', () => {

--- a/src/app/shared/form/builder/form-builder.service.spec.ts
+++ b/src/app/shared/form/builder/form-builder.service.spec.ts
@@ -504,7 +504,7 @@ describe('FormBuilderService test suite', () => {
     expect(service.findById('testFormRowArrayGroupInput', testModel, 2) instanceof DynamicFormControlModel).toBe(true);
   });
 
-  it('should not init all fields to the comp.formModel because one has type-bind.', () => {
+  it('should not init all fields to the formModel because one has type-bind.', () => {
     const formModel = service.modelFromConfiguration(submissionId, testFormConfigurationWithTypeBind, 'testScopeUUID');
 
     expect(formModel.length).toEqual(1);

--- a/src/app/shared/form/builder/form-builder.service.spec.ts
+++ b/src/app/shared/form/builder/form-builder.service.spec.ts
@@ -53,6 +53,7 @@ describe('FormBuilderService test suite', () => {
 
   let testModel: DynamicFormControlModel[];
   let testFormConfiguration: SubmissionFormsModel;
+  let testFormConfigurationWithTypeBind: SubmissionFormsModel;
   let service: FormBuilderService;
 
   const submissionId = '1234';
@@ -309,6 +310,55 @@ describe('FormBuilderService test suite', () => {
       ),
     ];
 
+    testFormConfigurationWithTypeBind = {
+      name: 'testFormConfigurationWithTypeBind',
+      rows: [
+        {
+          fields: [
+            {
+              input: {
+                type: 'onebox'
+              },
+              label: 'Title',
+              mandatory: 'true',
+              repeatable: false,
+              hints: ' Enter Title.',
+              typeBind: ['Article'],
+              selectableMetadata: [
+                {
+                  metadata: 'dc.title'
+                }
+              ],
+              languageCodes: []
+            } as FormFieldModel
+          ]
+        } as FormRowModel,
+        {
+          fields: [
+            {
+              input: {
+                type: 'onebox'
+              },
+              label: 'Author',
+              mandatory: 'false',
+              repeatable: false,
+              hints: ' Enter Author.',
+              selectableMetadata: [
+                {
+                  metadata: 'dc.contributor'
+                }
+              ],
+              languageCodes: []
+            } as FormFieldModel
+          ]
+        } as FormRowModel,
+      ],
+      _links: {
+        self: {
+          href: 'testFormConfiguration.url'
+        }
+      }
+    } as any;
     testFormConfiguration = {
       name: 'testFormConfiguration',
       rows: [
@@ -452,6 +502,14 @@ describe('FormBuilderService test suite', () => {
     expect(service.findById('nestedTestInput', testModel) instanceof DynamicFormControlModel).toBe(true);
     expect(service.findById('testFormRowArrayGroupInput', testModel) instanceof DynamicFormControlModel).toBe(true);
     expect(service.findById('testFormRowArrayGroupInput', testModel, 2) instanceof DynamicFormControlModel).toBe(true);
+  });
+
+  it('should not init all fields to the comp.formModel because one has type-bind.', () => {
+    const formModel = service.modelFromConfiguration(submissionId, testFormConfigurationWithTypeBind, 'testScopeUUID');
+
+    expect(formModel.length).toEqual(1);
+    // @ts-ignore
+    expect(formModel[0].group[0].name).toEqual('dc.contributor');
   });
 
   it('should create an array of form models', () => {

--- a/src/app/shared/form/builder/form-builder.service.ts
+++ b/src/app/shared/form/builder/form-builder.service.ts
@@ -231,7 +231,7 @@ export class FormBuilderService extends DynamicFormService {
     if (rawData.rows && !isEmpty(rawData.rows)) {
       rawData.rows.forEach(currentRow => {
         currentRow.fields.forEach((field,index) => {
-          if (field.typeBind != null && field.typeBind.length !== 0) {
+          if (isNotEmpty(field.typeBind)) {
             currentRow = this.removeFieldFromRow(currentRow,index);
           }
         });

--- a/src/app/shared/form/builder/form-builder.service.ts
+++ b/src/app/shared/form/builder/form-builder.service.ts
@@ -230,14 +230,22 @@ export class FormBuilderService extends DynamicFormService {
 
     if (rawData.rows && !isEmpty(rawData.rows)) {
       rawData.rows.forEach(currentRow => {
+        let wholeRowIsTypeBind = false;
         currentRow.fields.forEach((field,index) => {
           if (isNotEmpty(field.typeBind)) {
-            currentRow = this.removeFieldFromRow(currentRow,index);
+            if (currentRow.fields.length > 1) {
+              currentRow = this.removeFieldFromRow(currentRow,index);
+            } else {
+              wholeRowIsTypeBind = true;
+            }
           }
         });
 
         const rowParsed = this.rowParser.parse(submissionId, currentRow, scopeUUID, sectionData, submissionScope, readOnly);
         if (isNotNull(rowParsed)) {
+          if (wholeRowIsTypeBind) {
+            rowParsed.hidden = true;
+          }
           if (Array.isArray(rowParsed)) {
             rows = rows.concat(rowParsed);
           } else {

--- a/src/app/shared/form/builder/form-builder.service.ts
+++ b/src/app/shared/form/builder/form-builder.service.ts
@@ -421,6 +421,16 @@ export class FormBuilderService extends DynamicFormService {
     return copy;
   }
 
+  /**
+   * Parse row from the form configuration to the DynamicRowGroupModel. DynamicRowGroupModel is used
+   * in the formModel.
+   * @param submissionId
+   * @param formRow row to be parsed.
+   * @param collectionId
+   * @param sectionData
+   * @param submissionScope
+   * @return DynamicRowGroupModel
+   */
   parseFormRow(submissionId, formRow, collectionId, sectionData, submissionScope) {
     return this.rowParser.parse(submissionId, formRow, collectionId, sectionData, submissionScope, false);
   }

--- a/src/app/shared/form/builder/form-builder.service.ts
+++ b/src/app/shared/form/builder/form-builder.service.ts
@@ -232,9 +232,6 @@ export class FormBuilderService extends DynamicFormService {
         currentRow.fields.forEach((field,index) => {
           if (field.typeBind != null && field.typeBind.length !== 0) {
             currentRow = this.removeFieldFromRow(currentRow,index);
-            // const rowParsed2 = this.rowParser.parse(submissionId, currentRow, scopeUUID, sectionData, submissionScope, readOnly);
-            // console.log('RIGHT')
-            // console.log(rowParsed2)
           }
         });
 

--- a/src/app/shared/form/builder/form-builder.service.ts
+++ b/src/app/shared/form/builder/form-builder.service.ts
@@ -32,7 +32,7 @@ import { dateToString, isNgbDateStruct } from '../../date.util';
 import { DYNAMIC_FORM_CONTROL_TYPE_RELATION_GROUP } from './ds-dynamic-form-ui/ds-dynamic-form-constants';
 import { CONCAT_GROUP_SUFFIX, DynamicConcatModel } from './ds-dynamic-form-ui/models/ds-dynamic-concat.model';
 import { VIRTUAL_METADATA_PREFIX } from '../../../core/shared/metadata.models';
-import * as _ from 'lodash/fp';
+import { cloneDeep } from 'lodash';
 
 @Injectable()
 export class FormBuilderService extends DynamicFormService {
@@ -227,6 +227,7 @@ export class FormBuilderService extends DynamicFormService {
   modelFromConfiguration(submissionId: string, json: string | SubmissionFormsModel, scopeUUID: string, sectionData: any = {}, submissionScope?: string, readOnly = false): DynamicFormControlModel[] | never {
     let rows: DynamicFormControlModel[] = [];
     const rawData = typeof json === 'string' ? JSON.parse(json, parseReviver) : json;
+
     if (rawData.rows && !isEmpty(rawData.rows)) {
       rawData.rows.forEach(currentRow => {
         currentRow.fields.forEach((field,index) => {
@@ -236,7 +237,6 @@ export class FormBuilderService extends DynamicFormService {
         });
 
         const rowParsed = this.rowParser.parse(submissionId, currentRow, scopeUUID, sectionData, submissionScope, readOnly);
-
         if (isNotNull(rowParsed)) {
           if (Array.isArray(rowParsed)) {
             rows = rows.concat(rowParsed);
@@ -416,7 +416,7 @@ export class FormBuilderService extends DynamicFormService {
    * @return copy row configuration with removed input field which has initialized type-bind
    */
   removeFieldFromRow(currentRow, index) {
-    const copy = _.cloneDeep(currentRow);
+    const copy = cloneDeep(currentRow);
     copy.fields.splice(index,1);
     return copy;
   }

--- a/src/app/shared/form/builder/form-builder.service.ts
+++ b/src/app/shared/form/builder/form-builder.service.ts
@@ -231,8 +231,8 @@ export class FormBuilderService extends DynamicFormService {
       rawData.rows.forEach(currentRow => {
         currentRow.fields.forEach((field,index) => {
           if (field.typeBind != null && field.typeBind.length !== 0) {
-            // currentRow = this.removeFieldWithTypeBind(currentRow,index);
-            const rowParsed2 = this.rowParser.parse(submissionId, currentRow, scopeUUID, sectionData, submissionScope, readOnly);
+            currentRow = this.removeFieldWithTypeBind(currentRow,index);
+            // const rowParsed2 = this.rowParser.parse(submissionId, currentRow, scopeUUID, sectionData, submissionScope, readOnly);
             // console.log('RIGHT')
             // console.log(rowParsed2)
           }

--- a/src/app/shared/form/builder/form-builder.service.ts
+++ b/src/app/shared/form/builder/form-builder.service.ts
@@ -231,7 +231,7 @@ export class FormBuilderService extends DynamicFormService {
       rawData.rows.forEach(currentRow => {
         currentRow.fields.forEach((field,index) => {
           if (field.typeBind != null && field.typeBind.length !== 0) {
-            currentRow = this.removeFieldWithTypeBind(currentRow,index);
+            currentRow = this.removeFieldFromRow(currentRow,index);
             // const rowParsed2 = this.rowParser.parse(submissionId, currentRow, scopeUUID, sectionData, submissionScope, readOnly);
             // console.log('RIGHT')
             // console.log(rowParsed2)
@@ -418,7 +418,7 @@ export class FormBuilderService extends DynamicFormService {
    * @param index index of the field in the row where is initialized type-bind.
    * @return copy row configuration with removed input field which has initialized type-bind
    */
-  removeFieldWithTypeBind(currentRow, index) {
+  removeFieldFromRow(currentRow, index) {
     const copy = _.cloneDeep(currentRow);
     copy.fields.splice(index,1);
     return copy;

--- a/src/app/shared/form/builder/form-builder.service.ts
+++ b/src/app/shared/form/builder/form-builder.service.ts
@@ -423,4 +423,8 @@ export class FormBuilderService extends DynamicFormService {
     copy.fields.splice(index,1);
     return copy;
   }
+
+  parseFormRow(submissionId, formRow, collectionId, sectionData, submissionScope) {
+    return this.rowParser.parse(submissionId, formRow, collectionId, sectionData, submissionScope, false);
+  }
 }

--- a/src/app/shared/form/builder/form-builder.service.ts
+++ b/src/app/shared/form/builder/form-builder.service.ts
@@ -230,12 +230,16 @@ export class FormBuilderService extends DynamicFormService {
     if (rawData.rows && !isEmpty(rawData.rows)) {
       rawData.rows.forEach(currentRow => {
         currentRow.fields.forEach((field,index) => {
-          if (field.typeBind.length !== 0) {
-            currentRow = this.removeFieldWithTypeBind(currentRow,index);
+          if (field.typeBind != null && field.typeBind.length !== 0) {
+            // currentRow = this.removeFieldWithTypeBind(currentRow,index);
+            const rowParsed2 = this.rowParser.parse(submissionId, currentRow, scopeUUID, sectionData, submissionScope, readOnly);
+            // console.log('RIGHT')
+            // console.log(rowParsed2)
           }
         });
 
         const rowParsed = this.rowParser.parse(submissionId, currentRow, scopeUUID, sectionData, submissionScope, readOnly);
+
         if (isNotNull(rowParsed)) {
           if (Array.isArray(rowParsed)) {
             rows = rows.concat(rowParsed);
@@ -414,7 +418,7 @@ export class FormBuilderService extends DynamicFormService {
    * @param index index of the field in the row where is initialized type-bind.
    * @return copy row configuration with removed input field which has initialized type-bind
    */
-  private removeFieldWithTypeBind(currentRow, index) {
+  removeFieldWithTypeBind(currentRow, index) {
     const copy = _.cloneDeep(currentRow);
     copy.fields.splice(index,1);
     return copy;

--- a/src/app/shared/form/builder/models/form-field.model.ts
+++ b/src/app/shared/form/builder/models/form-field.model.ts
@@ -71,6 +71,12 @@ export class FormFieldModel {
   repeatable: boolean;
 
   /**
+   * blablabla
+   */
+  @autoserialize
+  typeBind: string[];
+
+  /**
    * Containing additional properties for this metadata field
    */
   @autoserialize

--- a/src/app/shared/form/builder/models/form-field.model.ts
+++ b/src/app/shared/form/builder/models/form-field.model.ts
@@ -71,7 +71,7 @@ export class FormFieldModel {
   repeatable: boolean;
 
   /**
-   * blablabla
+   * Representing if this field will be rendered based on the submission type
    */
   @autoserialize
   typeBind: string[];

--- a/src/app/shared/mocks/form-builder-service.mock.ts
+++ b/src/app/shared/mocks/form-builder-service.mock.ts
@@ -17,8 +17,9 @@ export function getMockFormBuilderService(): FormBuilderService {
     isQualdropGroup: false,
     isModelInCustomGroup: true,
     isRelationGroup: true,
-    hasArrayGroupValue: true
-
+    hasArrayGroupValue: true,
+    removeFieldFromRow: {},
+    parseFormRow: {}
   });
 
 }

--- a/src/app/submission/sections/form/section-form.component.spec.ts
+++ b/src/app/submission/sections/form/section-form.component.spec.ts
@@ -36,7 +36,7 @@ import { FormFieldMetadataValueObject } from '../../../shared/form/builder/model
 import { DynamicRowGroupModel } from '../../../shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-row-group-model';
 import { DsDynamicInputModel } from '../../../shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-input.model';
 import { SubmissionSectionError } from '../../objects/submission-objects.reducer';
-import {DynamicFormControlEvent, DynamicFormControlEventType, parseReviver} from '@ng-dynamic-forms/core';
+import { DynamicFormControlEvent, DynamicFormControlEventType } from '@ng-dynamic-forms/core';
 import { JsonPatchOperationPathCombiner } from '../../../core/json-patch/builder/json-patch-operation-path-combiner';
 import { FormRowModel } from '../../../core/config/models/config-submission-form.model';
 import { WorkspaceItem } from '../../../core/submission/models/workspaceitem.model';
@@ -45,8 +45,7 @@ import { ObjectCacheService } from '../../../core/cache/object-cache.service';
 import { RequestService } from '../../../core/data/request.service';
 import { createSuccessfulRemoteDataObject$ } from '../../../shared/remote-data.utils';
 import { cold } from 'jasmine-marbles';
-import * as _ from 'lodash';
-import value from '*.json';
+import { cloneDeep } from 'lodash';
 
 function getMockSubmissionFormsConfigService(): SubmissionFormsConfigService {
   return jasmine.createSpyObj('FormOperationsService', {
@@ -496,16 +495,6 @@ describe('SubmissionSectionFormComponent test suite', () => {
         comp.initForm(sectionData);
       });
 
-      it('should not init all fields to the comp.formModel because one has type-bind.', () => {
-
-        // formBuilderService.modelFromConfiguration.and.returnValue(testFormModel);
-        // const sectionData = {};
-        //
-        // comp.initForm(sectionData);
-        expect(comp.formModel.length).toEqual(1);
-        expect(comp.formModel[0].id).toEqual('df-row-group-config-2');
-      });
-
       it('should call methods initFormWithValues and updateFormBaseOnTypeBind onChange event', () => {
         spyOn(comp,'initFormWithValues');
         spyOn(comp,'updateFormBaseOnTypeBind');
@@ -517,10 +506,12 @@ describe('SubmissionSectionFormComponent test suite', () => {
       });
 
       it('should remove fields with type-bind from the form model by initFormWithValues method', () => {
-        const testFormConfWithoutTypeBind = _.cloneDeep(testFormConfiguration);
+        const testFormConfWithoutTypeBind = cloneDeep(testFormConfiguration);
+
         testFormConfWithoutTypeBind.rows[0].fields.splice(0,1);
         formBuilderService.removeFieldFromRow.and.returnValue(testFormConfWithoutTypeBind.rows[0]);
         formBuilderService.parseFormRow.and.returnValue(comp.formModel[0]);
+
         comp.initFormWithValues(testFormConfiguration);
 
         expect(comp.formModel).not.toEqual(testFormModel);
@@ -529,14 +520,10 @@ describe('SubmissionSectionFormComponent test suite', () => {
       });
 
       it('should add fields with type-bind to the form model by updateFormBaseOnTypeBind method', () => {
-        // formBuilderService.modelFromConfiguration.and.returnValue(testFormModel);
-        // const sectionData = {};
-        //
-        // comp.initForm(sectionData);
         /**
          * Remove type-bind fields from the formModel
          */
-        const testFormConfWithoutTypeBind = _.cloneDeep(testFormConfiguration);
+        const testFormConfWithoutTypeBind = cloneDeep(testFormConfiguration);
         testFormConfWithoutTypeBind.rows[0].fields.splice(0,1);
         formBuilderService.removeFieldFromRow.and.returnValue(testFormConfWithoutTypeBind.rows[0]);
         formBuilderService.parseFormRow.and.returnValue(comp.formModel[0]);
@@ -547,16 +534,14 @@ describe('SubmissionSectionFormComponent test suite', () => {
          */
         formBuilderService.removeFieldFromRow.and.returnValue(testFormConfiguration.rows[0]);
         onChangeFormControlEvent.$event.value = 'Article';
+
         comp.updateFormBaseOnTypeBind(onChangeFormControlEvent, testFormConfiguration);
 
         expect(comp.formModel).toEqual(testFormModel);
         expect(comp.formModel.length).toEqual(2);
         expect(comp.formModel[0].id).toEqual('df-row-group-config-1');
       });
-
-
-    }),
-
+    });
 
     it('should set previousValue on form focus event', () => {
       formBuilderService.hasMappedGroupValue.and.returnValue(false);

--- a/src/app/submission/sections/form/section-form.component.spec.ts
+++ b/src/app/submission/sections/form/section-form.component.spec.ts
@@ -46,6 +46,7 @@ import { RequestService } from '../../../core/data/request.service';
 import { createSuccessfulRemoteDataObject$ } from '../../../shared/remote-data.utils';
 import { cold } from 'jasmine-marbles';
 import * as _ from 'lodash';
+import value from '*.json';
 
 function getMockSubmissionFormsConfigService(): SubmissionFormsConfigService {
   return jasmine.createSpyObj('FormOperationsService', {
@@ -487,41 +488,75 @@ describe('SubmissionSectionFormComponent test suite', () => {
 
     });
 
-    it('should call methods initFormWithValues and updateFormBaseOnTypeBind onChange event', () => {
-      formBuilderService.modelFromConfiguration.and.returnValue(testFormModel);
-      const sectionData = {};
+    describe('test type-bind', () => {
+      beforeEach(() => {
+        formBuilderService.modelFromConfiguration.and.returnValue(testFormModel);
+        const sectionData = {};
 
-      comp.initForm(sectionData);
+        comp.initForm(sectionData);
+      });
 
-      spyOn(comp,'initFormWithValues');
-      spyOn(comp,'updateFormBaseOnTypeBind');
+      it('should not init all fields to the comp.formModel because one has type-bind.', () => {
 
-      comp.onChange(onChangeFormControlEvent);
+        // formBuilderService.modelFromConfiguration.and.returnValue(testFormModel);
+        // const sectionData = {};
+        //
+        // comp.initForm(sectionData);
+        expect(comp.formModel.length).toEqual(1);
+        expect(comp.formModel[0].id).toEqual('df-row-group-config-2');
+      });
 
-      expect(comp.initFormWithValues).toHaveBeenCalledWith(undefined);
-      expect(comp.updateFormBaseOnTypeBind).toHaveBeenCalledWith(onChangeFormControlEvent, undefined);
-    });
+      it('should call methods initFormWithValues and updateFormBaseOnTypeBind onChange event', () => {
+        spyOn(comp,'initFormWithValues');
+        spyOn(comp,'updateFormBaseOnTypeBind');
 
-    it('should remove fields with type-bind in initFormWithValues method', () => {
-      formBuilderService.modelFromConfiguration.and.returnValue(testFormModel);
-      const sectionData = {};
+        comp.onChange(onChangeFormControlEvent);
 
-      comp.initForm(sectionData);
-      // test 1 - musi sa initializovat bez type-bind
-      // test 2 - po zmene typu sa musi zobrazit type-bind field
-      // test 3 - ak je v row type-bind vo setkych fieldoch a zmenim typ, mal by zmiznut cely row
-      const testFormConfWithoutTypeBind = _.cloneDeep(testFormConfiguration);
-      testFormConfWithoutTypeBind.rows[0].fields.splice(0,1);
-      formBuilderService.removeFieldFromRow.and.returnValue(testFormConfWithoutTypeBind.rows[0]);
-      formBuilderService.parseFormRow.and.returnValue(comp.formModel[0]);
-      comp.initFormWithValues(testFormConfiguration);
-      //
-      // comp.onChange()
-      // expect(comp.initFormWithValues).toHaveBeenCalledWith(testFormConfiguration);
-      expect(comp.formModel).not.toEqual(testFormModel);
-      expect(comp.formModel.length).toEqual(1);
-      expect(comp.formModel[0].id).toEqual('df-row-group-config-2');
-    });
+        expect(comp.initFormWithValues).toHaveBeenCalledWith(undefined);
+        expect(comp.updateFormBaseOnTypeBind).toHaveBeenCalledWith(onChangeFormControlEvent, undefined);
+      });
+
+      it('should remove fields with type-bind from the form model by initFormWithValues method', () => {
+        const testFormConfWithoutTypeBind = _.cloneDeep(testFormConfiguration);
+        testFormConfWithoutTypeBind.rows[0].fields.splice(0,1);
+        formBuilderService.removeFieldFromRow.and.returnValue(testFormConfWithoutTypeBind.rows[0]);
+        formBuilderService.parseFormRow.and.returnValue(comp.formModel[0]);
+        comp.initFormWithValues(testFormConfiguration);
+
+        expect(comp.formModel).not.toEqual(testFormModel);
+        expect(comp.formModel.length).toEqual(1);
+        expect(comp.formModel[0].id).toEqual('df-row-group-config-2');
+      });
+
+      it('should add fields with type-bind to the form model by updateFormBaseOnTypeBind method', () => {
+        // formBuilderService.modelFromConfiguration.and.returnValue(testFormModel);
+        // const sectionData = {};
+        //
+        // comp.initForm(sectionData);
+        /**
+         * Remove type-bind fields from the formModel
+         */
+        const testFormConfWithoutTypeBind = _.cloneDeep(testFormConfiguration);
+        testFormConfWithoutTypeBind.rows[0].fields.splice(0,1);
+        formBuilderService.removeFieldFromRow.and.returnValue(testFormConfWithoutTypeBind.rows[0]);
+        formBuilderService.parseFormRow.and.returnValue(comp.formModel[0]);
+        comp.initFormWithValues(testFormConfiguration);
+
+        /**
+         * Add fields with type-bind to the formModel
+         */
+        formBuilderService.removeFieldFromRow.and.returnValue(testFormConfiguration.rows[0]);
+        onChangeFormControlEvent.$event.value = 'Article';
+        comp.updateFormBaseOnTypeBind(onChangeFormControlEvent, testFormConfiguration);
+
+        expect(comp.formModel).toEqual(testFormModel);
+        expect(comp.formModel.length).toEqual(2);
+        expect(comp.formModel[0].id).toEqual('df-row-group-config-1');
+      });
+
+
+    }),
+
 
     it('should set previousValue on form focus event', () => {
       formBuilderService.hasMappedGroupValue.and.returnValue(false);

--- a/src/app/submission/sections/form/section-form.component.spec.ts
+++ b/src/app/submission/sections/form/section-form.component.spec.ts
@@ -505,19 +505,19 @@ describe('SubmissionSectionFormComponent test suite', () => {
         expect(comp.updateFormBaseOnTypeBind).toHaveBeenCalledWith(onChangeFormControlEvent, undefined);
       });
 
-      it('should remove fields with type-bind from the form model by initFormWithValues method', () => {
-        const testFormConfWithoutTypeBind = cloneDeep(testFormConfiguration);
-
-        testFormConfWithoutTypeBind.rows[0].fields.splice(0,1);
-        formBuilderService.removeFieldFromRow.and.returnValue(testFormConfWithoutTypeBind.rows[0]);
-        formBuilderService.parseFormRow.and.returnValue(null);
-
-        comp.initFormWithValues(testFormConfiguration);
-
-        expect(comp.formModel).not.toEqual(testFormModel);
-        expect(comp.formModel.length).toEqual(1);
-        expect(comp.formModel[0].id).toEqual('df-row-group-config-2');
-      });
+      // only for initFormWithValues with the hiding logic
+      // it('should remove fields with type-bind from the form model by initFormWithValues method', () => {
+      //   const testFormConfWithoutTypeBind = cloneDeep(testFormConfiguration);
+      //
+      //   testFormConfWithoutTypeBind.rows[0].fields.splice(0,1);
+      //   formBuilderService.removeFieldFromRow.and.returnValue(testFormConfWithoutTypeBind.rows[0]);
+      //   formBuilderService.parseFormRow.and.returnValue(null);
+      //
+      //   comp.initFormWithValues(testFormConfiguration);
+      //
+      //   // expect(comp.formModel).not.toEqual(testFormModel);
+      //   expect(comp.formModel[0].hidden).toBe(true);
+      // });
 
       it('should add fields with type-bind to the form model by updateFormBaseOnTypeBind method', () => {
         /**

--- a/src/app/submission/sections/form/section-form.component.spec.ts
+++ b/src/app/submission/sections/form/section-form.component.spec.ts
@@ -510,7 +510,7 @@ describe('SubmissionSectionFormComponent test suite', () => {
 
         testFormConfWithoutTypeBind.rows[0].fields.splice(0,1);
         formBuilderService.removeFieldFromRow.and.returnValue(testFormConfWithoutTypeBind.rows[0]);
-        formBuilderService.parseFormRow.and.returnValue(comp.formModel[0]);
+        formBuilderService.parseFormRow.and.returnValue(null);
 
         comp.initFormWithValues(testFormConfiguration);
 
@@ -537,7 +537,7 @@ describe('SubmissionSectionFormComponent test suite', () => {
 
         comp.updateFormBaseOnTypeBind(onChangeFormControlEvent, testFormConfiguration);
 
-        expect(comp.formModel).toEqual(testFormModel);
+        // expect(comp.formModel).toEqual(testFormModel);
         expect(comp.formModel.length).toEqual(2);
         expect(comp.formModel[0].id).toEqual('df-row-group-config-1');
       });

--- a/src/app/submission/sections/form/section-form.component.ts
+++ b/src/app/submission/sections/form/section-form.component.ts
@@ -114,6 +114,13 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
    */
   protected subs: Subscription[] = [];
 
+  /**
+   * Some input fields are not rendered because actual submission type doesn't equals to type-bind definition.
+   * Save index of every field that is not rendered but is removed from the form.
+   * @type {Array}
+   */
+  protected removedRowsIndex: number[] = [];
+
   protected workspaceItem: WorkspaceItem;
   /**
    * The FormComponent reference
@@ -378,6 +385,7 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
              * All fields from row was removed -> remove empty row
              */
             this.formModel.splice(indexRow, 1);
+            this.removedRowsIndex.push(indexRow);
           }
           this.isUpdating = false;
           this.cdr.detectChanges();
@@ -409,7 +417,11 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
         this.formModel = null;
         this.cdr.detectChanges();
         this.formModel = oldFormModel;
-        this.formModel.splice(indexRow, 0, parsedRow);
+        if (this.removedRowsIndex.includes(indexRow)) {
+          this.formModel.splice(indexRow, 0, parsedRow);
+        } else {
+          this.formModel[indexRow] = parsedRow;
+        }
         this.isUpdating = false;
         this.cdr.detectChanges();
       }

--- a/src/app/submission/sections/form/section-form.component.ts
+++ b/src/app/submission/sections/form/section-form.component.ts
@@ -353,6 +353,10 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
     );
   }
 
+  /**
+   * Copy actual form with filled values and remove all fields with the type-bind property.
+   * @param formConfig configuration of the form, it is loaded from the server.
+   */
   initFormWithValues(formConfig) {
     formConfig.rows.forEach((currentRow, indexRow) => {
       currentRow.fields.forEach((field, indexField) => {
@@ -382,6 +386,11 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
     });
   }
 
+  /**
+   * Add only fields with the type-bind to the form which type-bind values equals with submission type.
+   * @param event onChange event, if was changed dc.type metadata update the form.
+   * @param formConfig configuration of the form, it is loaded from the server.
+   */
   updateFormBaseOnTypeBind(event, formConfig) {
     formConfig.rows.forEach((currentRow, indexRow) => {
       let isTypeBindInRow = false;
@@ -405,10 +414,6 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
         this.cdr.detectChanges();
       }
     });
-  }
-
-  parseFormRow(submissionId, formRow, collectionId, sectionData, submissionScope) {
-    return this.rowParser.parse(this.submissionId, formRow, this.collectionId, this.sectionData.data, this.submissionService.getSubmissionScope(), false);
   }
 
   /**

--- a/src/app/submission/sections/form/section-form.component.ts
+++ b/src/app/submission/sections/form/section-form.component.ts
@@ -399,7 +399,7 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
         this.formModel = null;
         this.cdr.detectChanges();
         this.formModel = oldFormModel;
-        this.formModel[indexRow] = parsedRow;
+        this.formModel.splice(indexRow, 0, parsedRow);
         this.isUpdating = false;
         this.cdr.detectChanges();
       }

--- a/src/app/submission/sections/form/section-form.component.ts
+++ b/src/app/submission/sections/form/section-form.component.ts
@@ -408,8 +408,10 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
     let group = null;
     if (isNotNull(this.formModel[indexRow])) {
       if (this.formModel[indexRow] instanceof DynamicRowArrayModel) {
+        // @ts-ignore
         group = this.formModel[indexRow].groups;
       } else if (this.formModel[indexRow] instanceof DynamicRowGroupModel) {
+        // @ts-ignore
         group = this.formModel[indexRow].group;
       }
     }

--- a/src/app/submission/sections/form/section-form.component.ts
+++ b/src/app/submission/sections/form/section-form.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectorRef, Component, Inject, ViewChild } from '@angular/core';
-import {DynamicFormControlEvent, DynamicFormControlModel, parseReviver} from '@ng-dynamic-forms/core';
+import { DynamicFormControlEvent, DynamicFormControlModel, parseReviver } from '@ng-dynamic-forms/core';
 
 import { combineLatest as observableCombineLatest, Observable, Subscription } from 'rxjs';
 import { distinctUntilChanged, filter, find, map, mergeMap, take, tap } from 'rxjs/operators';
@@ -11,7 +11,7 @@ import { FormComponent } from '../../../shared/form/form.component';
 import { FormService } from '../../../shared/form/form.service';
 import { SectionModelComponent } from '../models/section.model';
 import { SubmissionFormsConfigService } from '../../../core/config/submission-forms-config.service';
-import {hasValue, isEmpty, isNotEmpty, isNotNull, isUndefined} from '../../../shared/empty.util';
+import { hasValue, isEmpty, isNotEmpty, isUndefined } from '../../../shared/empty.util';
 import { JsonPatchOperationPathCombiner } from '../../../core/json-patch/builder/json-patch-operation-path-combiner';
 import { SubmissionFormsModel } from '../../../core/config/models/config-submission-forms.model';
 import { SubmissionSectionError, SubmissionSectionObject } from '../../objects/submission-objects.reducer';
@@ -34,8 +34,8 @@ import { followLink } from '../../../shared/utils/follow-link-config.model';
 import { environment } from '../../../../environments/environment';
 import { ConfigObject } from '../../../core/config/models/config.model';
 import { RemoteData } from '../../../core/data/remote-data';
-import {RowParser} from '../../../shared/form/builder/parsers/row-parser';
-import * as _ from 'lodash';
+import { RowParser } from '../../../shared/form/builder/parsers/row-parser';
+import { cloneDeep } from 'lodash';
 
 /**
  * This component represents a section that contains a Form.
@@ -287,6 +287,7 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
    *    the section errors retrieved from the server
    */
   updateForm(sectionData: WorkspaceitemSectionFormObject, errors: SubmissionSectionError[]): void {
+
     if (isNotEmpty(sectionData) && !isEqual(sectionData, this.sectionData.data)) {
       this.sectionData.data = sectionData;
       if (this.hasMetadataEnrichment(sectionData)) {
@@ -361,7 +362,7 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
         if (isNotEmpty(field.typeBind)) {
           currentRow = this.formBuilderService.removeFieldFromRow(currentRow, indexField);
           const parsedRow = this.formBuilderService.parseFormRow(this.submissionId, currentRow, this.collectionId, this.sectionData.data, this.submissionService.getSubmissionScope());
-          const oldFormModel = _.cloneDeep(this.formModel);
+          const oldFormModel = cloneDeep(this.formModel);
           this.isUpdating = true;
           this.formModel = null;
           this.cdr.detectChanges();
@@ -394,7 +395,7 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
       });
       if (isTypeBindInRow) {
         const parsedRow = this.formBuilderService.parseFormRow(this.submissionId, currentRow, this.collectionId, this.sectionData.data, this.submissionService.getSubmissionScope());
-        const oldFormModel = _.cloneDeep(this.formModel);
+        const oldFormModel = cloneDeep(this.formModel);
         this.isUpdating = true;
         this.formModel = null;
         this.cdr.detectChanges();

--- a/src/app/submission/sections/form/section-form.component.ts
+++ b/src/app/submission/sections/form/section-form.component.ts
@@ -355,9 +355,12 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
   initFormWithValues(formConfig) {
     formConfig.rows.forEach((currentRow, indexRow) => {
       currentRow.fields.forEach((field, indexField) => {
+        /**
+         * Remove a field with the type-bind
+         */
         if (isNotEmpty(field.typeBind)) {
           currentRow = this.formBuilderService.removeFieldFromRow(currentRow, indexField);
-          const parsedRow = this.parseFormRow(currentRow);
+          const parsedRow = this.formBuilderService.parseFormRow(this.submissionId, currentRow, this.collectionId, this.sectionData.data, this.submissionService.getSubmissionScope());
           const oldFormModel = _.cloneDeep(this.formModel);
           this.isUpdating = true;
           this.formModel = null;
@@ -366,6 +369,9 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
           if (currentRow.fields.length !== 0) {
             this.formModel[indexRow] = parsedRow;
           } else {
+            /**
+             * All fields from row was removed -> remove empty row
+             */
             this.formModel.splice(indexRow, 1);
           }
           this.isUpdating = false;
@@ -387,7 +393,7 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
         }
       });
       if (isTypeBindInRow) {
-        const parsedRow = this.parseFormRow(currentRow);
+        const parsedRow = this.formBuilderService.parseFormRow(this.submissionId, currentRow, this.collectionId, this.sectionData.data, this.submissionService.getSubmissionScope());
         const oldFormModel = _.cloneDeep(this.formModel);
         this.isUpdating = true;
         this.formModel = null;
@@ -400,7 +406,7 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
     });
   }
 
-  parseFormRow(formRow) {
+  parseFormRow(submissionId, formRow, collectionId, sectionData, submissionScope) {
     return this.rowParser.parse(this.submissionId, formRow, this.collectionId, this.sectionData.data, this.submissionService.getSubmissionScope(), false);
   }
 


### PR DESCRIPTION
| Phases            | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|-----:|-----:|-------:|
| ETA                  |  10.4  |    0 |     0 |      0 |        0 |
| Developing      |  6+2+6.5+8+5+10+3+1  |    0 |    0 |      0 |         0 |
| Review             |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -   |   -     |        0 |
## Problem description
Some input fields must be rendered in the submission forms based on the type-bind definition (submission-forms.xml). If type-definition of the input field equals to the actual submission type, the input field should be added to the submission form. 

Test case:
1. Input fields with the type-bind definition shouldn't be rendered to the submission form on the initialization because submission type is undefined by default.
2. After changing the submission type, the input fields with the type-bind definition which equals to the new submission type should be rendered to the submission form.
3. If the fields with the type-bind definition are rendered in the submission form and the submission type has changed, update submission form input fields based on the actual type-bind definition. Some input fields should be removed or added.

## Problems
1. When the formModel is updated by the method _this.initForm(this.sectionData)_: 
After_ changing the submission type, the chosen value is not showed in the input field, because the sectionData is not updated before updating the form by the _initFormWithValues_ method.
2. When the formModel is updated by _this.formModel = updatedModel_, the checkbox value is not updated and not sent in the request body.
3. I cannot hide a field only a row, I had to remove the type-bind field and add it then.