### PR TITLE
feature/se-3-define-complex-input-types

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model.ts
@@ -11,7 +11,7 @@ import {forEach} from 'lodash';
 import {DynamicConcatModel, DynamicConcatModelConfig} from './ds-dynamic-concat.model';
 
 export const COMPLEX_GROUP_SUFFIX = '_COMPLEX_GROUP';
-export const COMPLEX_INPUT_SUFFIX = '_COMPLEX_INPUT';
+export const COMPLEX_INPUT_SUFFIX = '_COMPLEX_INPUT_';
 
 export interface DynamicComplexModelConfig extends DynamicConcatModelConfig {}
 
@@ -19,6 +19,35 @@ export class DynamicComplexModel extends DynamicConcatModel {
 
   constructor(config: DynamicComplexModelConfig, layout?: DynamicFormControlLayout) {
     super(config, layout);
+    this.separator = ';';
+  }
+
+  get value() {
+    const formValues = this.group.map((inputModel: DsDynamicInputModel) =>
+      (typeof inputModel.value === 'string') ?
+        Object.assign(new FormFieldMetadataValueObject(), { value: inputModel.value, display: inputModel.value }) :
+        (inputModel.value as any));
+
+    let indexOfEmptyValues: number[] = [];
+    let value = '';
+    formValues.forEach((formValue, index) => {
+      if (isNotEmpty(formValue) && isNotEmpty(formValue.value)) {
+        value += formValue.value + this.separator;
+      } else {
+        indexOfEmptyValues.push(index);
+      }
+    });
+
+    value = value.slice(0, -1);
+
+    if (isNotEmpty(formValues)) {
+      const dumpArrayOfIndex = Array.from(Array(formValues.length).keys());
+      const indexesOfNonEmptyFormValues = dumpArrayOfIndex.filter(x => !indexOfEmptyValues.includes(x));
+      return Object.assign(new FormFieldMetadataValueObject(),
+        formValues[Object.keys(formValues)[indexesOfNonEmptyFormValues[0]]],{ value: value });
+    }
+    return null;
+
   }
 
   set value(value: string | FormFieldMetadataValueObject) {
@@ -43,16 +72,6 @@ export class DynamicComplexModel extends DynamicConcatModel {
         (this.get(index) as DsDynamicInputModel).value = undefined;
       }
     });
-    // if (values[0].value) {
-    //   (this.get(0) as DsDynamicInputModel).value = values[0];
-    // } else {
-    //   (this.get(0) as DsDynamicInputModel).value = undefined;
-    // }
-    // if (values[1].value) {
-    //   (this.get(1) as DsDynamicInputModel).value = values[1];
-    // } else {
-    //   (this.get(1) as DsDynamicInputModel).value = undefined;
-    // }
   }
 
 }

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model.ts
@@ -1,0 +1,58 @@
+import { DynamicFormControlLayout, DynamicFormGroupModel, DynamicFormGroupModelConfig, serializable } from '@ng-dynamic-forms/core';
+
+import { Subject } from 'rxjs';
+
+import { hasNoValue, isNotEmpty } from '../../../../empty.util';
+import { DsDynamicInputModel } from './ds-dynamic-input.model';
+import { FormFieldMetadataValueObject } from '../../models/form-field-metadata-value.model';
+import { RelationshipOptions } from '../../models/relationship-options.model';
+import { MetadataValue } from '../../../../../core/shared/metadata.models';
+import {forEach} from 'lodash';
+import {DynamicConcatModel, DynamicConcatModelConfig} from './ds-dynamic-concat.model';
+
+export const COMPLEX_GROUP_SUFFIX = '_COMPLEX_GROUP';
+export const COMPLEX_INPUT_SUFFIX = '_COMPLEX_INPUT';
+
+export interface DynamicComplexModelConfig extends DynamicConcatModelConfig {}
+
+export class DynamicComplexModel extends DynamicConcatModel {
+
+  constructor(config: DynamicComplexModelConfig, layout?: DynamicFormControlLayout) {
+    super(config, layout);
+  }
+
+  set value(value: string | FormFieldMetadataValueObject) {
+    let values;
+    let tempValue: string;
+
+    if (typeof value === 'string') {
+      tempValue = value;
+    } else {
+      tempValue = value.value;
+    }
+    if (hasNoValue(tempValue)) {
+      tempValue = '';
+    }
+    values = [...tempValue.split(this.separator), null].map((v) =>
+      Object.assign(new FormFieldMetadataValueObject(), value, { display: v, value: v }));
+
+    values.forEach((val, index) =>  {
+      if (val.value) {
+        (this.get(index) as DsDynamicInputModel).value = val;
+      } else {
+        (this.get(index) as DsDynamicInputModel).value = undefined;
+      }
+    });
+    // if (values[0].value) {
+    //   (this.get(0) as DsDynamicInputModel).value = values[0];
+    // } else {
+    //   (this.get(0) as DsDynamicInputModel).value = undefined;
+    // }
+    // if (values[1].value) {
+    //   (this.get(1) as DsDynamicInputModel).value = values[1];
+    // } else {
+    //   (this.get(1) as DsDynamicInputModel).value = undefined;
+    // }
+  }
+
+}

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model.ts
@@ -1,13 +1,8 @@
-import { DynamicFormControlLayout, DynamicFormGroupModel, DynamicFormGroupModelConfig, serializable } from '@ng-dynamic-forms/core';
-
-import { Subject } from 'rxjs';
+import { DynamicFormControlLayout } from '@ng-dynamic-forms/core';
 
 import { hasNoValue, isNotEmpty } from '../../../../empty.util';
 import { DsDynamicInputModel } from './ds-dynamic-input.model';
 import { FormFieldMetadataValueObject } from '../../models/form-field-metadata-value.model';
-import { RelationshipOptions } from '../../models/relationship-options.model';
-import { MetadataValue } from '../../../../../core/shared/metadata.models';
-import {forEach} from 'lodash';
 import {DynamicConcatModel, DynamicConcatModelConfig} from './ds-dynamic-concat.model';
 
 export const COMPLEX_GROUP_SUFFIX = '_COMPLEX_GROUP';
@@ -28,7 +23,8 @@ export class DynamicComplexModel extends DynamicConcatModel {
         Object.assign(new FormFieldMetadataValueObject(), { value: inputModel.value, display: inputModel.value }) :
         (inputModel.value as any));
 
-    let indexOfEmptyValues: number[] = [];
+    let indexOfEmptyValues: number[];
+    indexOfEmptyValues = [];
     let value = '';
     formValues.forEach((formValue, index) => {
       if (isNotEmpty(formValue) && isNotEmpty(formValue.value)) {

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model.ts
@@ -69,5 +69,4 @@ export class DynamicComplexModel extends DynamicConcatModel {
       }
     });
   }
-
 }

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model.ts
@@ -25,16 +25,23 @@ export class DynamicComplexModel extends DynamicConcatModel {
 
     let indexOfEmptyValues: number[];
     indexOfEmptyValues = [];
+
     let value = '';
+    let areFormValuesEmpty = true;
     formValues.forEach((formValue, index) => {
       if (isNotEmpty(formValue) && isNotEmpty(formValue.value)) {
         value += formValue.value + this.separator;
+        areFormValuesEmpty = false;
       } else {
+        value += this.separator;
         indexOfEmptyValues.push(index);
       }
     });
-
     value = value.slice(0, -1);
+
+    if (areFormValuesEmpty) {
+      value = '';
+    }
 
     if (isNotEmpty(formValues)) {
       const dumpArrayOfIndex = Array.from(Array(formValues.length).keys());

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model.ts
@@ -1,6 +1,6 @@
 import { DynamicFormControlLayout } from '@ng-dynamic-forms/core';
 
-import { hasNoValue, isNotEmpty } from '../../../../empty.util';
+import { hasNoValue, hasValue, isNotEmpty } from '../../../../empty.util';
 import { DsDynamicInputModel } from './ds-dynamic-input.model';
 import { FormFieldMetadataValueObject } from '../../models/form-field-metadata-value.model';
 import {DynamicConcatModel, DynamicConcatModelConfig} from './ds-dynamic-concat.model';
@@ -27,11 +27,11 @@ export class DynamicComplexModel extends DynamicConcatModel {
     indexOfEmptyValues = [];
 
     let value = '';
-    let areFormValuesEmpty = true;
+    let allFormValuesEmpty = true;
     formValues.forEach((formValue, index) => {
       if (isNotEmpty(formValue) && isNotEmpty(formValue.value)) {
         value += formValue.value + this.separator;
-        areFormValuesEmpty = false;
+        allFormValuesEmpty = false;
       } else {
         value += this.separator;
         indexOfEmptyValues.push(index);
@@ -39,7 +39,7 @@ export class DynamicComplexModel extends DynamicConcatModel {
     });
     value = value.slice(0, -1);
 
-    if (areFormValuesEmpty) {
+    if (allFormValuesEmpty) {
       value = '';
     }
 
@@ -71,7 +71,7 @@ export class DynamicComplexModel extends DynamicConcatModel {
     values.forEach((val, index) =>  {
       if (val.value) {
         (this.get(index) as DsDynamicInputModel).value = val;
-      } else {
+      } else if (hasValue((this.get(index) as DsDynamicInputModel))) {
         (this.get(index) as DsDynamicInputModel).value = undefined;
       }
     });

--- a/src/app/shared/form/builder/models/form-field.model.ts
+++ b/src/app/shared/form/builder/models/form-field.model.ts
@@ -118,4 +118,10 @@ export class FormFieldModel {
    */
   @autoserialize
   value: any;
+
+  /**
+   * Containing the definition of the complex input types - multiple inputs
+   */
+  @autoserialize
+  complexDefinition: string;
 }

--- a/src/app/shared/form/builder/models/form-field.model.ts
+++ b/src/app/shared/form/builder/models/form-field.model.ts
@@ -120,7 +120,7 @@ export class FormFieldModel {
   value: any;
 
   /**
-   * Containing the definition of the complex input types - multiple inputs
+   * Containing the definition of the complex input types - multiple inputs in one row
    */
   @autoserialize
   complexDefinition: string;

--- a/src/app/shared/form/builder/parsers/complex-field-parser.spec.ts
+++ b/src/app/shared/form/builder/parsers/complex-field-parser.spec.ts
@@ -5,7 +5,7 @@ import {DynamicRowArrayModel} from '../ds-dynamic-form-ui/models/ds-dynamic-row-
 
 describe('ComplexFieldParser test suite', () => {
   let field: FormFieldModel;
-  let initFormValues: any = {};
+  const initFormValues: any = {};
 
   const submissionId = '1234';
   const parserOptions: ParserOptions = {

--- a/src/app/shared/form/builder/parsers/complex-field-parser.spec.ts
+++ b/src/app/shared/form/builder/parsers/complex-field-parser.spec.ts
@@ -30,11 +30,11 @@ describe('ComplexFieldParser test suite', () => {
         }
       ],
       languageCodes: [],
-      complexDefinition: '{"affiliation":{"name":"affiliation","input-type":"text","label":"Affiliation",' +
-        '"required":"true"},"givenname":{"name":"givenname","input-type":"text","label":"Given name",' +
-        '"required":"true"},"surname":{"name":"surname","input-type":"text","label":"Surname","required":"true"},' +
-        '"email":{"name":"email","regex":"[^@]+@[^\\\\.@]+\\\\.[^@]+","input-type":"text","label":"Email",' +
-        '"required":"true"}}'
+      complexDefinition: '[{"givenname":{"name":"givenname","input-type":"text","label":"Given name",' +
+        '"required":"true"}},{"surname":{"name":"surname","input-type":"text","label":"Surname",' +
+        '"required":"true"}},{"email":{"name":"email","regex":"[^@]+@[^\\\\.@]+\\\\.[^@]+","input-type":' +
+        '"text","label":"Email","required":"true"}},{"affiliation":{"name":"affiliation","input-type":' +
+        '"text","label":"Affiliation"}}]'
     } as FormFieldModel;
 
   });

--- a/src/app/shared/form/builder/parsers/complex-field-parser.spec.ts
+++ b/src/app/shared/form/builder/parsers/complex-field-parser.spec.ts
@@ -1,0 +1,58 @@
+import {FormFieldModel} from '../models/form-field.model';
+import {ParserOptions} from './parser-options';
+import {ComplexFieldParser} from './complex-field-parser';
+import {DynamicRowArrayModel} from '../ds-dynamic-form-ui/models/ds-dynamic-row-array-model';
+
+describe('ComplexFieldParser test suite', () => {
+  let field: FormFieldModel;
+  let initFormValues: any = {};
+
+  const submissionId = '1234';
+  const parserOptions: ParserOptions = {
+    readOnly: false,
+    submissionScope: null,
+    collectionUUID: null
+  };
+  const separator = ';';
+
+  beforeEach(() => {
+    field = {
+      input: {
+        type: 'complex'
+      },
+      mandatory: 'false',
+      label: 'Contact person',
+      repeatable: true,
+      hints: 'This is contact person',
+      selectableMetadata: [
+        {
+          metadata: 'local.contact.person',
+        }
+      ],
+      languageCodes: [],
+      complexDefinition: '{"affiliation":{"name":"affiliation","input-type":"text","label":"Affiliation",' +
+        '"required":"true"},"givenname":{"name":"givenname","input-type":"text","label":"Given name",' +
+        '"required":"true"},"surname":{"name":"surname","input-type":"text","label":"Surname","required":"true"},' +
+        '"email":{"name":"email","regex":"[^@]+@[^\\\\.@]+\\\\.[^@]+","input-type":"text","label":"Email",' +
+        '"required":"true"}}'
+    } as FormFieldModel;
+
+  });
+
+  it('should init parser properly', () => {
+    const parser = new ComplexFieldParser(submissionId, field, initFormValues, parserOptions, separator, []);
+
+    expect(parser instanceof ComplexFieldParser).toBe(true);
+  });
+
+  it('should return a DynamicRowArrayModel object with expected label', () => {
+    const parser = new ComplexFieldParser(submissionId, field, initFormValues, parserOptions, separator, []);
+
+    const expectedValue = 'Contact person';
+    const fieldModel = parser.parse();
+
+    expect(fieldModel instanceof DynamicRowArrayModel).toBe(true);
+    expect(fieldModel.label).toBe(expectedValue);
+  });
+
+});

--- a/src/app/shared/form/builder/parsers/complex-field-parser.ts
+++ b/src/app/shared/form/builder/parsers/complex-field-parser.ts
@@ -82,7 +82,8 @@ export class ComplexFieldParser extends FieldParser {
     }
 
     inputConfigs.forEach((inputConfig, index) => {
-      const complexDefinitionInput = complexDefinitionJSON[Object.keys(complexDefinitionJSON)[index]];
+      let complexDefinitionInput = complexDefinitionJSON[index];
+      complexDefinitionInput = complexDefinitionInput[Object.keys(complexDefinitionInput)[0]];
 
       if (hasValue(complexDefinitionInput.label)) {
         inputConfig.label = complexDefinitionInput.label;

--- a/src/app/shared/form/builder/parsers/complex-field-parser.ts
+++ b/src/app/shared/form/builder/parsers/complex-field-parser.ts
@@ -42,9 +42,15 @@ export class ComplexFieldParser extends FieldParser {
     let clsInput: DynamicFormControlLayout;
     const id: string = this.configData.selectableMetadata[0].metadata;
 
+    clsGroup = {
+      element: {
+        control: 'form-row',
+      }
+    };
+
     clsInput = {
       grid: {
-        host: 'col-sm-6'
+        host: 'col-sm-12'
       }
     };
 
@@ -56,10 +62,11 @@ export class ComplexFieldParser extends FieldParser {
 
     let inputConfigs: DynamicInputModelConfig[] = [];
 
-    const configDataComplex = ['one', 'two', 'three'];
-    configDataComplex.forEach(() => {
+    const complexDefinitionJSON = JSON.parse(this.configData.complexDefinition);
+
+    Object.keys(complexDefinitionJSON).forEach((input, index) => {
       inputConfigs.push(this.initModel(
-        id + COMPLEX_INPUT_SUFFIX,
+        id + COMPLEX_INPUT_SUFFIX + index,
         false,
         true,
         true,
@@ -67,62 +74,43 @@ export class ComplexFieldParser extends FieldParser {
       ));
     });
 
-
-    // const input1ModelConfig: DynamicInputModelConfig = this.initModel(
-    //   id + COMPLEX_INPUT_SUFFIX,
-    //   false,
-    //   true,
-    //   true,
-    //   false
-    // );
-    // const input2ModelConfig: DynamicInputModelConfig = thvbg is.initModel(
-    //   id + COMPLEX_INPUT_SUFFIX,
-    //   false,
-    //   true,
-    //   true,
-    //   false
-    // );
-
-    // if (hasNoValue(concatGroup.hint) && hasValue(input1ModelConfig.hint) && hasNoValue(input2ModelConfig.hint)) {
-    //   concatGroup.hint = input1ModelConfig.hint;
-    //   input1ModelConfig.hint = undefined;
-    // }
-
     if (this.configData.mandatory) {
       concatGroup.required = true;
-      // input1ModelConfig.required = true;
     }
 
-    // @TODO set placeholders
-    // if (isNotEmpty(this.firstPlaceholder)) {
-    //   input1ModelConfig.placeholder = this.firstPlaceholder;
-    // }
-    //
-    // if (isNotEmpty(this.secondPlaceholder)) {
-    //   input2ModelConfig.placeholder = this.secondPlaceholder;
-    // }
+    inputConfigs.forEach((inputConfig, index) => {
+      const complexDefinitionInput = complexDefinitionJSON[Object.keys(complexDefinitionJSON)[index]];
 
-    // Split placeholder if is like 'placeholder1/placeholder2'
-    const placeholder = this.configData.label.split('/');
-    // if (placeholder.length === 2) {
-    //   input1ModelConfig.placeholder = placeholder[0];
-    //   input2ModelConfig.placeholder = placeholder[1];
-    // }
+      if (hasValue(complexDefinitionInput.label)) {
+        inputConfig.label = complexDefinitionInput.label;
+        inputConfig.placeholder = complexDefinitionInput.label;
+      }
 
-    inputConfigs.forEach((input) => {
-      concatGroup.group.push(new DynamicInputModel(input, clsInput));
+      if (hasValue(complexDefinitionInput.placeholder)) {
+        inputConfig.placeholder = complexDefinitionInput.placeholder;
+      }
+
+      if (hasValue(complexDefinitionInput.hint)) {
+        inputConfig.hint = complexDefinitionInput.hint;
+      }
+
+      if (hasValue(complexDefinitionInput.style)) {
+        clsInput = {
+          grid: {
+            host: complexDefinitionInput.style
+          }
+        };
+      }
+
+      if (this.configData.mandatory) {
+        if (hasValue(complexDefinitionInput.required)) {
+          inputConfig.required = complexDefinitionInput.required;
+        }
+      }
+
+      concatGroup.group.push(new DynamicInputModel(inputConfig, clsInput));
     });
 
-    // const model1 = new DynamicInputModel(input1ModelConfig, clsInput);
-    // const model2 = new DynamicInputModel(input2ModelConfig, clsInput);
-    // concatGroup.group.push(model1);
-    // concatGroup.group.push(model2);
-    //
-    clsGroup = {
-      element: {
-        control: 'form-row',
-      }
-    };
     const complexModel = new DynamicComplexModel(concatGroup, clsGroup);
     complexModel.name = this.getFieldId();
 

--- a/src/app/shared/form/builder/parsers/complex-field-parser.ts
+++ b/src/app/shared/form/builder/parsers/complex-field-parser.ts
@@ -13,7 +13,7 @@ import {
   DynamicComplexModelConfig,
 
 } from '../ds-dynamic-form-ui/models/ds-dynamic-complex.model';
-import { hasNoValue, hasValue, isNotEmpty } from '../../../empty.util';
+import { hasValue, isNotEmpty } from '../../../empty.util';
 import { ParserOptions } from './parser-options';
 import {
   CONFIG_DATA,
@@ -60,7 +60,8 @@ export class ComplexFieldParser extends FieldParser {
     concatGroup.group = [];
     concatGroup.separator = this.separator;
 
-    let inputConfigs: DynamicInputModelConfig[] = [];
+    let inputConfigs: DynamicInputModelConfig[];
+    inputConfigs = [];
 
     const complexDefinitionJSON = JSON.parse(this.configData.complexDefinition);
 

--- a/src/app/shared/form/builder/parsers/complex-field-parser.ts
+++ b/src/app/shared/form/builder/parsers/complex-field-parser.ts
@@ -2,9 +2,11 @@ import { Inject } from '@angular/core';
 import { FormFieldModel } from '../models/form-field.model';
 import { FormFieldMetadataValueObject } from '../models/form-field-metadata-value.model';
 import {
+  DsDynamicInputModel,
+  DsDynamicInputModelConfig
+} from '../ds-dynamic-form-ui/models/ds-dynamic-input.model';
+import {
   DynamicFormControlLayout,
-  DynamicInputModel,
-  DynamicInputModelConfig
 } from '@ng-dynamic-forms/core';
 import {
   COMPLEX_GROUP_SUFFIX,
@@ -60,7 +62,7 @@ export class ComplexFieldParser extends FieldParser {
     concatGroup.group = [];
     concatGroup.separator = this.separator;
 
-    let inputConfigs: DynamicInputModelConfig[];
+    let inputConfigs: DsDynamicInputModelConfig[];
     inputConfigs = [];
 
     const complexDefinitionJSON = JSON.parse(this.configData.complexDefinition);
@@ -104,12 +106,10 @@ export class ComplexFieldParser extends FieldParser {
       }
 
       if (this.configData.mandatory) {
-        if (hasValue(complexDefinitionInput.required)) {
-          inputConfig.required = complexDefinitionInput.required;
-        }
+        inputConfig.required = hasValue(complexDefinitionInput.required) && complexDefinitionInput.required === 'true';
       }
 
-      concatGroup.group.push(new DynamicInputModel(inputConfig, clsInput));
+      concatGroup.group.push(new DsDynamicInputModel(inputConfig, clsInput));
     });
 
     const complexModel = new DynamicComplexModel(concatGroup, clsGroup);

--- a/src/app/shared/form/builder/parsers/complex-field-parser.ts
+++ b/src/app/shared/form/builder/parsers/complex-field-parser.ts
@@ -1,0 +1,137 @@
+import { Inject } from '@angular/core';
+import { FormFieldModel } from '../models/form-field.model';
+import { FormFieldMetadataValueObject } from '../models/form-field-metadata-value.model';
+import {
+  DynamicFormControlLayout,
+  DynamicInputModel,
+  DynamicInputModelConfig
+} from '@ng-dynamic-forms/core';
+import {
+  COMPLEX_GROUP_SUFFIX,
+  COMPLEX_INPUT_SUFFIX,
+  DynamicComplexModel,
+  DynamicComplexModelConfig,
+
+} from '../ds-dynamic-form-ui/models/ds-dynamic-complex.model';
+import { hasNoValue, hasValue, isNotEmpty } from '../../../empty.util';
+import { ParserOptions } from './parser-options';
+import {
+  CONFIG_DATA,
+  FieldParser,
+  INIT_FORM_VALUES,
+  PARSER_OPTIONS,
+  SUBMISSION_ID
+} from './field-parser';
+
+export class ComplexFieldParser extends FieldParser {
+
+  constructor(
+    @Inject(SUBMISSION_ID) submissionId: string,
+    @Inject(CONFIG_DATA) configData: FormFieldModel,
+    @Inject(INIT_FORM_VALUES) initFormValues,
+    @Inject(PARSER_OPTIONS) parserOptions: ParserOptions,
+    protected separator: string,
+    protected placeholders: string[]) {
+    super(submissionId, configData, initFormValues, parserOptions);
+    this.separator = separator;
+  }
+
+  public modelFactory(fieldValue?: FormFieldMetadataValueObject | any, label?: boolean): any {
+
+    let clsGroup: DynamicFormControlLayout;
+    let clsInput: DynamicFormControlLayout;
+    const id: string = this.configData.selectableMetadata[0].metadata;
+
+    clsInput = {
+      grid: {
+        host: 'col-sm-6'
+      }
+    };
+
+    const groupId = id.replace(/\./g, '_') + COMPLEX_GROUP_SUFFIX;
+    const concatGroup: DynamicComplexModelConfig = this.initModel(groupId, label, false, true);
+
+    concatGroup.group = [];
+    concatGroup.separator = this.separator;
+
+    let inputConfigs: DynamicInputModelConfig[] = [];
+
+    const configDataComplex = ['one', 'two', 'three'];
+    configDataComplex.forEach(() => {
+      inputConfigs.push(this.initModel(
+        id + COMPLEX_INPUT_SUFFIX,
+        false,
+        true,
+        true,
+        false
+      ));
+    });
+
+
+    // const input1ModelConfig: DynamicInputModelConfig = this.initModel(
+    //   id + COMPLEX_INPUT_SUFFIX,
+    //   false,
+    //   true,
+    //   true,
+    //   false
+    // );
+    // const input2ModelConfig: DynamicInputModelConfig = thvbg is.initModel(
+    //   id + COMPLEX_INPUT_SUFFIX,
+    //   false,
+    //   true,
+    //   true,
+    //   false
+    // );
+
+    // if (hasNoValue(concatGroup.hint) && hasValue(input1ModelConfig.hint) && hasNoValue(input2ModelConfig.hint)) {
+    //   concatGroup.hint = input1ModelConfig.hint;
+    //   input1ModelConfig.hint = undefined;
+    // }
+
+    if (this.configData.mandatory) {
+      concatGroup.required = true;
+      // input1ModelConfig.required = true;
+    }
+
+    // @TODO set placeholders
+    // if (isNotEmpty(this.firstPlaceholder)) {
+    //   input1ModelConfig.placeholder = this.firstPlaceholder;
+    // }
+    //
+    // if (isNotEmpty(this.secondPlaceholder)) {
+    //   input2ModelConfig.placeholder = this.secondPlaceholder;
+    // }
+
+    // Split placeholder if is like 'placeholder1/placeholder2'
+    const placeholder = this.configData.label.split('/');
+    // if (placeholder.length === 2) {
+    //   input1ModelConfig.placeholder = placeholder[0];
+    //   input2ModelConfig.placeholder = placeholder[1];
+    // }
+
+    inputConfigs.forEach((input) => {
+      concatGroup.group.push(new DynamicInputModel(input, clsInput));
+    });
+
+    // const model1 = new DynamicInputModel(input1ModelConfig, clsInput);
+    // const model2 = new DynamicInputModel(input2ModelConfig, clsInput);
+    // concatGroup.group.push(model1);
+    // concatGroup.group.push(model2);
+    //
+    clsGroup = {
+      element: {
+        control: 'form-row',
+      }
+    };
+    const complexModel = new DynamicComplexModel(concatGroup, clsGroup);
+    complexModel.name = this.getFieldId();
+
+    // Init values
+    if (isNotEmpty(fieldValue)) {
+      complexModel.value = fieldValue;
+    }
+
+    return complexModel;
+  }
+
+}

--- a/src/app/shared/form/builder/parsers/complex-field-parser.ts
+++ b/src/app/shared/form/builder/parsers/complex-field-parser.ts
@@ -122,5 +122,4 @@ export class ComplexFieldParser extends FieldParser {
 
     return complexModel;
   }
-
 }

--- a/src/app/shared/form/builder/parsers/parser-factory.ts
+++ b/src/app/shared/form/builder/parsers/parser-factory.ts
@@ -19,6 +19,7 @@ import { SeriesFieldParser } from './series-field-parser';
 import { TagFieldParser } from './tag-field-parser';
 import { TextareaFieldParser } from './textarea-field-parser';
 import { DisabledFieldParser } from './disabled-field-parser';
+import { ComplexFieldParser } from './complex-field-parser';
 
 const fieldParserDeps = [
   SUBMISSION_ID,
@@ -107,6 +108,13 @@ export class ParserFactory {
         return {
           provide: FieldParser,
           useClass: TextareaFieldParser,
+          deps: [...fieldParserDeps]
+        };
+      }
+      case ParserType.Complex: {
+        return {
+          provide: FieldParser,
+          useClass: ComplexFieldParser,
           deps: [...fieldParserDeps]
         };
       }

--- a/src/app/shared/form/builder/parsers/parser-type.ts
+++ b/src/app/shared/form/builder/parsers/parser-type.ts
@@ -10,5 +10,6 @@ export enum ParserType {
   Name = 'name',
   Series = 'series',
   Tag = 'tag',
-  Textarea = 'textarea'
+  Textarea = 'textarea',
+  Complex = 'complex'
 }


### PR DESCRIPTION
| Phases            | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|-----:|-----:|-------:|
| ETA                  |  16  |    0 |     0 |      0 |        0 |
| Developing      |  1.5+6+4+4+3+2+1  |    0 |    0 |      0 |         0 |
| Review             |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -   |   -     |        0 |
## Problem description
Extend Submission UI for getting enough information about the resource with many required fields. Concept of complex (or component) fields.
Example: Fields composed from other fields (First_Name + Last_Name + Email + Affiliation, or Project_Name + Project_Code + Funder).

- [x] Create a new DynamicComplexModel which extends DynamicConcatModel because in the DynamicConcatModel are concating input fields into one row as we needs.
- [x] Create a new Parser for parsing BE Response to the DynamicComplexModel - complex-field-parser.
- [x] Create a tests for a new parser.

## Problems
1. After filling out some of the complex definition input fields in the DynamicComplexModel value wasn't any separator for recognizing which input field was filled out. 
**Solution**: The separator ";" was added to the DynamicComplexModel. The DynamicComplexModel value is extended by the separator after each input field definition and the default value of the DynamicComplexModel was set to empty string with number of the separators based on the number of the input fields. Example: DynamicComplexModel has 3 input fields it means the default value will be ";;;"
The another problem has occured based on this solution.

2. The default value of the DynamicComplexModel with the separators causes calling the wrong Action in the Submission UI. When was creating a new Item the Action ADD should be called but was called the action REPLACE (because default value of the DynamicComplexModel wasn't empty) and in the BE wasn't created such Item so BE throws error. 
**Solution**: Set the default value of the DynamicComplexModel as empty string and add a new check: If were filled out some input fields of the complex model add separators to the default value.