### PR TITLE
feature/se-11-create-user-on-dev5

### DIFF
--- a/build-scripts/run/start.bat
+++ b/build-scripts/run/start.bat
@@ -11,7 +11,7 @@ call start.frontend.bat nopause
 
 pushd ..\..
 docker-compose --env-file %ENVFILE% -p dq-d7 -f docker/cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
-docker-compose --env-file $ENVFILE% -p dq-d7 -f docker/cli.yml run --rm dspace-cli user --add -m test@user.edu.sk -g User -s Userovic -p user -l en
+docker-compose --env-file $ENVFILE% -p dq-d7 -f docker/cli.yml run --rm dspace-cli user --add -m test@user.edu -g User -s Userovic -p user -l en
 docker-compose --env-file %ENVFILE% -p dq-d7 -f docker/cli.yml run --rm dspace-cli version
 popd
 

--- a/build-scripts/run/start.bat
+++ b/build-scripts/run/start.bat
@@ -10,7 +10,7 @@ call start.backend.bat nopause
 call start.frontend.bat nopause
 
 pushd ..\..
-docker-compose --env-file %ENVFILE% -p dq-d7 -f docker/cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
+docker-compose --env-file %ENVFILE% -p dq-d7 -f docker/cli.yml run --rm dspace-cli create-administrator -e test@admin.edu -f admin -l user -p admin -c en
 docker-compose --env-file $ENVFILE% -p dq-d7 -f docker/cli.yml run --rm dspace-cli user --add -m test@user.edu -g Vladimir -s Vladimirovic -p user -l en
 docker-compose --env-file %ENVFILE% -p dq-d7 -f docker/cli.yml run --rm dspace-cli version
 popd

--- a/build-scripts/run/start.bat
+++ b/build-scripts/run/start.bat
@@ -11,7 +11,7 @@ call start.frontend.bat nopause
 
 pushd ..\..
 docker-compose --env-file %ENVFILE% -p dq-d7 -f docker/cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
-docker-compose --env-file $ENVFILE% -p dq-d7 -f docker/cli.yml run --rm dspace-cli user --add -m test@user.edu -g User -s Userovic -p user -l en
+docker-compose --env-file $ENVFILE% -p dq-d7 -f docker/cli.yml run --rm dspace-cli user --add -m test@user.edu -g Vladimir -s Vladimirovic -p user -l en
 docker-compose --env-file %ENVFILE% -p dq-d7 -f docker/cli.yml run --rm dspace-cli version
 popd
 

--- a/build-scripts/run/start.bat
+++ b/build-scripts/run/start.bat
@@ -11,6 +11,7 @@ call start.frontend.bat nopause
 
 pushd ..\..
 docker-compose --env-file %ENVFILE% -p dq-d7 -f docker/cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
+docker-compose --env-file $ENVFILE% -p dq-d7 -f docker/cli.yml run --rm dspace-cli user --add -m test@user.edu.sk -g User -s Userovic -p user -l en
 docker-compose --env-file %ENVFILE% -p dq-d7 -f docker/cli.yml run --rm dspace-cli version
 popd
 

--- a/build-scripts/run/start.sh
+++ b/build-scripts/run/start.sh
@@ -18,6 +18,6 @@ popd
 # set DOCKER_OWNER to match our image (see cli.yml)
 pushd ../..
 docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
-docker-compose --env-file $ENVFILE% -p dq-d7 -f docker/cli.yml run --rm dspace-cli user --add -m test@user.edu.sk -g User -s Userovic -p user -l en
+docker-compose --env-file $ENVFILE% -p dq-d7 -f docker/cli.yml run --rm dspace-cli user --add -m test@user.edu -g User -s Userovic -p user -l en
 docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli version
 popd

--- a/build-scripts/run/start.sh
+++ b/build-scripts/run/start.sh
@@ -18,5 +18,6 @@ popd
 # set DOCKER_OWNER to match our image (see cli.yml)
 pushd ../..
 docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
+docker-compose --env-file $ENVFILE% -p dq-d7 -f docker/cli.yml run --rm dspace-cli user --add -m test@user.edu.sk -g User -s Userovic -p user -l en
 docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli version
 popd

--- a/build-scripts/run/start.sh
+++ b/build-scripts/run/start.sh
@@ -17,7 +17,7 @@ popd
 # Create admin user
 # set DOCKER_OWNER to match our image (see cli.yml)
 pushd ../..
-docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli create-administrator -e test@admin.edu -f admin -l user -p admin -c en
-docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli user --add -m test@user.edu -g Vladimir -s Vladimirovic -p user -l en
-docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli version
+# docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli create-administrator -e test@admin.edu -f admin -l user -p admin -c en
+# docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli user --add -m test@user.edu -g Vladimir -s Vladimirovic -p user -l en
+# docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli version
 popd

--- a/build-scripts/run/start.sh
+++ b/build-scripts/run/start.sh
@@ -18,6 +18,6 @@ popd
 # set DOCKER_OWNER to match our image (see cli.yml)
 pushd ../..
 docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
-docker-compose --env-file $ENVFILE% -p dq-d7 -f docker/cli.yml run --rm dspace-cli user --add -m test@user.edu -g User -s Userovic -p user -l en
+docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli user --add -m test@user.edu -g User -s Userovic -p user -l en
 docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli version
 popd

--- a/build-scripts/run/start.sh
+++ b/build-scripts/run/start.sh
@@ -18,6 +18,6 @@ popd
 # set DOCKER_OWNER to match our image (see cli.yml)
 pushd ../..
 docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
-docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli user --add -m test@user.edu -g User -s Userovic -p user -l en
+docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli user --add -m test@user.edu -g Vladimir -s Vladimirovic -p user -l en
 docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli version
 popd

--- a/build-scripts/run/start.sh
+++ b/build-scripts/run/start.sh
@@ -17,7 +17,7 @@ popd
 # Create admin user
 # set DOCKER_OWNER to match our image (see cli.yml)
 pushd ../..
-docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
+docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli create-administrator -e test@admin.edu -f admin -l user -p admin -c en
 docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli user --add -m test@user.edu -g Vladimir -s Vladimirovic -p user -l en
 docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli version
 popd

--- a/build-scripts/run/start.sh
+++ b/build-scripts/run/start.sh
@@ -17,7 +17,7 @@ popd
 # Create admin user
 # set DOCKER_OWNER to match our image (see cli.yml)
 pushd ../..
-# docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli create-administrator -e test@admin.edu -f admin -l user -p admin -c en
-# docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli user --add -m test@user.edu -g Vladimir -s Vladimirovic -p user -l en
+docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli create-administrator -e test@admin.edu -f admin -l user -p admin -c en
+docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli user --add -m test@user.edu -g Vladimir -s Vladimirovic -p user -l en
 # docker-compose --env-file $ENVFILE -p dq-d7 -f docker/cli.yml run --rm dspace-cli version
 popd


### PR DESCRIPTION
| Phases            | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  3  |    0 |    0 |      0 |         0 |
| Review             |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -   |   -     |        0 |
## Problem description
The test user doesn't exist in the dev5, create it for test purposes.

### Reported issues
Loading error: https://github.com/dataquest-dev/dspace-angular/issues/58

## Problems
### 1. Loading error
I cannot login after I created an user or admin as administrator on the _dev5_, the page just freezes in logging process with loading icon. In the console the FE throws error: 
![image](https://user-images.githubusercontent.com/90026355/178921052-a0d35bde-87c9-4b5c-bc46-f41a70097643.png)

I was trying to reproduce this error on local docker. I just built the dataquest docker images locally and tryied to create user as administrator. But the error doesn't occured, I successfuly logged in as the user. That means there is problem with dev5.

**Temporary solution:** The admin is successfuly added to the dev5 from the github action. I just added command to create a new user after creating a new admin in the _building_scripts/run/start_.
