### PR TITLE
feature/de-6-google-scholar-metadata-mapping

### DIFF
--- a/src/app/core/metadata/metadata.service.spec.ts
+++ b/src/app/core/metadata/metadata.service.spec.ts
@@ -100,7 +100,7 @@ describe('MetadataService', () => {
     (metadataService as any).processRouteChange({
       data: {
         value: {
-          dso: createSuccessfulRemoteDataObject(ItemMock),
+          dso: createSuccessfulRemoteDataObject(mockType(ItemMock, 'Thesis')),
         }
       }
     });
@@ -119,7 +119,7 @@ describe('MetadataService', () => {
     expect(meta.addTag).toHaveBeenCalledWith({ name: 'citation_language', content: 'en' });
     expect(meta.addTag).toHaveBeenCalledWith({
       name: 'citation_keywords',
-      content: 'keyword1; keyword2; keyword3'
+      content: 'keyword1; keyword2; keyword3; Thesis'
     });
   }));
 

--- a/src/app/core/metadata/metadata.service.ts
+++ b/src/app/core/metadata/metadata.service.ts
@@ -264,8 +264,9 @@ export class MetadataService {
       this.addMetaTag('citation_dissertation_institution', value);
     } else if (this.isTechReport()) {
       this.addMetaTag('citation_technical_report_institution', value);
+    } else {
+      this.addMetaTag('citation_publisher', value);
     }
-    this.addMetaTag('citation_publisher', value);
   }
 
   /**

--- a/src/app/core/metadata/metadata.service.ts
+++ b/src/app/core/metadata/metadata.service.ts
@@ -152,6 +152,16 @@ export class MetadataService {
       this.setCitationDissertationNameTag();
     }
 
+    // added to be equivalent to clarin
+    this.setCitationDateTag();
+    this.setDatasetKeywordsTag();
+    this.setDatasetLicenseTag();
+    this.setDatasetUrlTag();
+    this.setDatasetCitationTag();
+    this.setDatasetIdentifierTag();
+    this.setDatasetCreatorTag();
+    //
+
     // this.setCitationJournalTitleTag();
     // this.setCitationVolumeTag();
     // this.setCitationIssueTag();
@@ -199,8 +209,8 @@ export class MetadataService {
    * Add <meta name="citation_author" ... >  to the <head>
    */
   private setCitationAuthorTags(): void {
-    const values: string[] = this.getMetaTagValues(['dc.author', 'dc.contributor.author', 'dc.creator']);
-    this.addMetaTags('citation_author', values);
+    const values: string = this.getFirstMetaTagValue(['dc.author', 'dc.contributor.author', 'dc.creator']);
+    this.addMetaTag('citation_author', values);
   }
 
   /**
@@ -231,7 +241,7 @@ export class MetadataService {
    * Add <meta name="citation_language" ... >  to the <head>
    */
   private setCitationLanguageTag(): void {
-    const value = this.getFirstMetaTagValue(['dc.language', 'dc.language.iso']);
+    const value = this.getMetaTagValue('dc.language.iso');
     this.addMetaTag('citation_language', value);
   }
 
@@ -248,21 +258,18 @@ export class MetadataService {
    */
   private setCitationPublisherTag(): void {
     const value = this.getMetaTagValue('dc.publisher');
-    if (this.isDissertation()) {
       this.addMetaTag('citation_dissertation_institution', value);
-    } else if (this.isTechReport()) {
       this.addMetaTag('citation_technical_report_institution', value);
-    } else {
       this.addMetaTag('citation_publisher', value);
     }
-  }
+
 
   /**
    * Add <meta name="citation_keywords" ... >  to the <head>
    */
   private setCitationKeywordsTag(): void {
-    const value = this.getMetaTagValuesAndCombine('dc.subject');
-    this.addMetaTag('citation_keywords', value);
+    const value: string[] = this.getMetaTagValues(['dc.subject', 'dc.type']);
+    this.addMetaTags('citation_keywords', value);
   }
 
   /**
@@ -277,6 +284,42 @@ export class MetadataService {
       this.addMetaTag('citation_abstract_html_url', url);
     }
   }
+
+  private setCitationDateTag(): void {
+    const value = this.getMetaTagValue('dc.date.issued');
+    this.addMetaTag('citation_date', value);
+  }
+
+  private setDatasetKeywordsTag(): void {
+      const value = this.getMetaTagValue('dc.subject');
+      this.addMetaTag('dataset_keywords', value);
+  }
+
+  private setDatasetLicenseTag(): void {
+        const value = this.getMetaTagValue('dc.rights.uri');
+        this.addMetaTag('dataset_license', value);
+  }
+
+  private setDatasetUrlTag(): void {
+        const value = this.getMetaTagValue('dc.identifier.uri');
+        this.addMetaTag('dataset_url', value);
+  }
+
+  private setDatasetCitationTag(): void {
+        const value = this.getMetaTagValue('dc.relation.isreferencedby');
+        this.addMetaTag('dataset_citation', value);
+  }
+
+  private setDatasetIdentifierTag(): void {
+        const value = this.getMetaTagValue('dc.identifier.uri');
+        this.addMetaTag('dataset_identifier', value);
+  }
+
+  private setDatasetCreatorTag(): void {
+        const value = this.getMetaTagValue('dc.contributor.author');
+        this.addMetaTag('dataset_creator', value);
+  }
+
 
   /**
    * Add <meta name="citation_pdf_url" ... >  to the <head>

--- a/src/app/core/metadata/metadata.service.ts
+++ b/src/app/core/metadata/metadata.service.ts
@@ -241,7 +241,7 @@ export class MetadataService {
    * Add <meta name="citation_language" ... >  to the <head>
    */
   private setCitationLanguageTag(): void {
-    const value = this.getMetaTagValue('dc.language.iso');
+    const value = this.getFirstMetaTagValue(['dc.language.iso', 'dc.language']);
     this.addMetaTag('citation_language', value);
   }
 
@@ -249,8 +249,10 @@ export class MetadataService {
    * Add <meta name="citation_dissertation_name" ... >  to the <head>
    */
   private setCitationDissertationNameTag(): void {
-    const value = this.getMetaTagValue('dc.title');
-    this.addMetaTag('citation_dissertation_name', value);
+    if (this.isDissertation()) {
+      const value = this.getMetaTagValue('dc.title');
+      this.addMetaTag('citation_dissertation_name', value);
+    }
   }
 
   /**
@@ -258,18 +260,20 @@ export class MetadataService {
    */
   private setCitationPublisherTag(): void {
     const value = this.getMetaTagValue('dc.publisher');
+    if (this.isDissertation()) {
       this.addMetaTag('citation_dissertation_institution', value);
+    } else if (this.isTechReport()) {
       this.addMetaTag('citation_technical_report_institution', value);
-      this.addMetaTag('citation_publisher', value);
     }
-
+    this.addMetaTag('citation_publisher', value);
+  }
 
   /**
    * Add <meta name="citation_keywords" ... >  to the <head>
    */
   private setCitationKeywordsTag(): void {
-    const value: string[] = this.getMetaTagValues(['dc.subject', 'dc.type']);
-    this.addMetaTags('citation_keywords', value);
+    const value = this.getMetaTagValues(['dc.subject', 'dc.type']).join('; ');
+    this.addMetaTag('citation_keywords', value);
   }
 
   /**
@@ -300,6 +304,8 @@ export class MetadataService {
         this.addMetaTag('dataset_license', value);
   }
 
+
+
   private setDatasetUrlTag(): void {
         const value = this.getMetaTagValue('dc.identifier.uri');
         this.addMetaTag('dataset_url', value);
@@ -310,10 +316,12 @@ export class MetadataService {
         this.addMetaTag('dataset_citation', value);
   }
 
+
   private setDatasetIdentifierTag(): void {
         const value = this.getMetaTagValue('dc.identifier.uri');
         this.addMetaTag('dataset_identifier', value);
   }
+
 
   private setDatasetCreatorTag(): void {
         const value = this.getMetaTagValue('dc.contributor.author');


### PR DESCRIPTION
| Phases            | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|-----:|-----:|-------:|
| ETA                  |  5.6  |    10 |     0 |      0 |        0 |
| Developing      |  0  |    2 |    0 |      0 |         0 |
| Review             |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -   |   -     |        0 |
## Problem description
Wiki: https://wiki.lyrasis.org/display/DSDOC7x/Google+Scholar+Metadata+Mappings
Google scholar is supported in DSpace7. However, meta tags are no longer configurable in the configuration file google-metadata.properties. Currently, metadata fields configuration is accessible by updating the file metadata.service.ts.

#### How to test it:
- Check out metadata tags in clarin repo, e.g. 
https://lindat.mff.cuni.cz/repository/xmlui/handle/11234/1-4804
press F12 (or right click and Inspect) and in head elements, look for metadata tags, like this:
![image](https://user-images.githubusercontent.com/88670521/182636304-527cac55-ee24-49fd-a115-ea4db4e10a19.png)
- Use existing item or create new in frontend.
- Check out mapping in clarin file: https://github.com/ufal/clarin-dspace/blob/clarin/dspace/config/crosswalks/google-metadata.properties

There are lines like this `google.citation_title = dc.title` . That means, we expect metadata tag `citation_title` which has value of metadata field `dc.title` . 

Lines without assigned value on the right are ignored. 

Add every metadata to item and check if tags in html on item page are present.


### Reported issues
### Not-reported issues
