### PR TITLE
feature/se-6-fix-errors-from-testing

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
@@ -122,7 +122,7 @@ import { DsDynamicAutocompleteComponent } from './models/autocomplete/ds-dynamic
 import { DYNAMIC_FORM_CONTROL_TYPE_AUTOCOMPLETE } from './models/autocomplete/ds-dynamic-autocomplete.model';
 import { DsDynamicSponsorAutocompleteComponent } from './models/sponsor-autocomplete/ds-dynamic-sponsor-autocomplete.component';
 import { SPONSOR_METADATA_NAME } from './models/ds-dynamic-complex.model';
-import {DsDynamicSponsorScrollableDropdownComponent} from './models/sponsor-scrollable-dropdown/dynamic-sponsor-scrollable-dropdown.component';
+import { DsDynamicSponsorScrollableDropdownComponent } from './models/sponsor-scrollable-dropdown/dynamic-sponsor-scrollable-dropdown.component';
 
 export function dsDynamicFormControlMapFn(model: DynamicFormControlModel): Type<DynamicFormControl> | null {
   switch (model.type) {

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
@@ -122,6 +122,7 @@ import { DsDynamicAutocompleteComponent } from './models/autocomplete/ds-dynamic
 import { DYNAMIC_FORM_CONTROL_TYPE_AUTOCOMPLETE } from './models/autocomplete/ds-dynamic-autocomplete.model';
 import { DsDynamicSponsorAutocompleteComponent } from './models/sponsor-autocomplete/ds-dynamic-sponsor-autocomplete.component';
 import { SPONSOR_METADATA_NAME } from './models/ds-dynamic-complex.model';
+import {DsDynamicSponsorScrollableDropdownComponent} from './models/sponsor-scrollable-dropdown/dynamic-sponsor-scrollable-dropdown.component';
 
 export function dsDynamicFormControlMapFn(model: DynamicFormControlModel): Type<DynamicFormControl> | null {
   switch (model.type) {
@@ -161,7 +162,11 @@ export function dsDynamicFormControlMapFn(model: DynamicFormControlModel): Type<
       return DsDynamicOneboxComponent;
 
     case DYNAMIC_FORM_CONTROL_TYPE_SCROLLABLE_DROPDOWN:
-      return DsDynamicScrollableDropdownComponent;
+      if (isNotEmpty(model.name) && model.name.startsWith(SPONSOR_METADATA_NAME)) {
+        return DsDynamicSponsorScrollableDropdownComponent;
+      } else {
+        return DsDynamicScrollableDropdownComponent;
+      }
 
     case DYNAMIC_FORM_CONTROL_TYPE_TAG:
       return DsDynamicTagComponent;

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/autocomplete/ds-dynamic-autocomplete.service.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/autocomplete/ds-dynamic-autocomplete.service.ts
@@ -1,4 +1,5 @@
 import { take } from 'rxjs/operators';
+import {isEmpty, isNotEmpty} from '../../../../../empty.util';
 
 /**
  * Util methods for the DsAutocompleteComponent.
@@ -6,6 +7,10 @@ import { take } from 'rxjs/operators';
 export class DsDynamicAutocompleteService {
 
   static pretifySuggestion(fundingProjectCode, fundingName, translateService) {
+    if (isEmpty(fundingProjectCode) || isEmpty(fundingName)) {
+      throw(new Error('The suggestion returns wrong data!'));
+    }
+
     // create variable with default values - they will be overridden
     let fundingCode = 'Funding code';
     let projectName = 'Project name';

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/autocomplete/ds-dynamic-autocomplete.service.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/autocomplete/ds-dynamic-autocomplete.service.ts
@@ -6,9 +6,6 @@ import { take } from 'rxjs/operators';
  * Util methods for the DsAutocompleteComponent.
  */
 export class DsDynamicAutocompleteService {
-  static removeAutocompletePrefix(formValue) {
-    return formValue.value.replace(AUTOCOMPLETE_COMPLEX_PREFIX + SEPARATOR, '');
-  }
 
   static pretifySuggestion(fundingProjectCode, fundingName, translateService) {
     // create variable with default values - they will be overridden

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/autocomplete/ds-dynamic-autocomplete.service.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/autocomplete/ds-dynamic-autocomplete.service.ts
@@ -1,5 +1,3 @@
-import { AUTOCOMPLETE_COMPLEX_PREFIX } from './ds-dynamic-autocomplete.model';
-import { SEPARATOR } from '../ds-dynamic-complex.model';
 import { take } from 'rxjs/operators';
 
 /**

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model.ts
@@ -15,6 +15,14 @@ export const EU_PROJECT_PREFIX = 'info:eu-repo';
 export const OPENAIRE_INPUT_NAME = 'openaire_id';
 
 /**
+ * The complex input type `local.sponsor` has `openaire_id` input field hidden if the funding type is not EU.
+ * This `opeanaire_id` input field is on the index 4.
+ * Funding type input field is on the index 0.
+ */
+export const EU_IDENTIFIER_INDEX = 4;
+export const FUNDING_TYPE_INDEX = 0;
+
+/**
  * Configuration for the DynamicComplexModel.
  */
 export interface DynamicComplexModelConfig extends DynamicConcatModelConfig {}
@@ -88,12 +96,6 @@ export class DynamicComplexModel extends DynamicConcatModel {
 
     // remove undefined values
     values = values.filter(v => v);
-
-    // Complex input type `local.sponsor` has `openaire_id` input field hidden if the funding type is not EU.
-    // This `opeanaire_id` input field is on the index 4.
-    // Funding type input field is on the index 0.
-    const EU_IDENTIFIER_INDEX = 4;
-    const FUNDING_TYPE_INDEX = 0;
 
     // if funding type is `EU`
     let isEUFund = false;

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model.ts
@@ -6,6 +6,7 @@ import { FormFieldMetadataValueObject } from '../../models/form-field-metadata-v
 import { DynamicConcatModel, DynamicConcatModelConfig } from './ds-dynamic-concat.model';
 import { AUTOCOMPLETE_COMPLEX_PREFIX } from './autocomplete/ds-dynamic-autocomplete.model';
 import { DsDynamicAutocompleteService } from './autocomplete/ds-dynamic-autocomplete.service';
+import { DEFAULT_EU_FUNDING_TYPES } from './sponsor-autocomplete/ds-dynamic-sponsor-autocomplete.model';
 
 export const COMPLEX_GROUP_SUFFIX = '_COMPLEX_GROUP';
 export const COMPLEX_INPUT_SUFFIX = '_COMPLEX_INPUT_';
@@ -89,15 +90,28 @@ export class DynamicComplexModel extends DynamicConcatModel {
     // remove undefined values
     values = values.filter(v => v);
 
+    // Complex input type `local.sponsor` has `openaire_id` input field hidden if the funding type is not EU.
+    // This `opeanaire_id` input field is on the index 4.
+    // Funding type input field is on the index 0.
+    const EU_IDENTIFIER_INDEX = 4;
+    const FUNDING_TYPE_INDEX = 0;
+
+    // if funding type is `EU`
+    let isEUFund = false;
     values.forEach((val, index) =>  {
       if (val.value) {
         (this.get(index) as DsDynamicInputModel).value = val;
-        // local.sponsor input type on the 4 index should be hidden if is empty or without EU_PROJECT_PREFIX
-        if (this.name === SPONSOR_METADATA_NAME && index === 4) {
-          if (val.value.includes(EU_PROJECT_PREFIX)) {
-            (this.get(index) as DsDynamicInputModel).hidden = false;
+        // for `local.sponsor` input field
+        if (this.name === SPONSOR_METADATA_NAME) {
+          // if funding type is `EU`
+          if (index === FUNDING_TYPE_INDEX && DEFAULT_EU_FUNDING_TYPES.includes(val.value)) {
+            isEUFund = true;
+          }
+          // if funding type is `EU` and input field is `openaire_id` -> show `openaire_id` readonly input field
+          if (index === EU_IDENTIFIER_INDEX && isEUFund && val.value.includes(EU_PROJECT_PREFIX)) {
+            (this.get(EU_IDENTIFIER_INDEX) as DsDynamicInputModel).hidden = false;
           } else {
-            (this.get(index) as DsDynamicInputModel).hidden = true;
+            (this.get(EU_IDENTIFIER_INDEX) as DsDynamicInputModel).hidden = true;
           }
         }
       } else if (hasValue((this.get(index) as DsDynamicInputModel))) {

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model.ts
@@ -5,7 +5,6 @@ import { DsDynamicInputModel } from './ds-dynamic-input.model';
 import { FormFieldMetadataValueObject } from '../../models/form-field-metadata-value.model';
 import { DynamicConcatModel, DynamicConcatModelConfig } from './ds-dynamic-concat.model';
 import { AUTOCOMPLETE_COMPLEX_PREFIX } from './autocomplete/ds-dynamic-autocomplete.model';
-import { DsDynamicAutocompleteService } from './autocomplete/ds-dynamic-autocomplete.service';
 import { DEFAULT_EU_FUNDING_TYPES } from './sponsor-autocomplete/ds-dynamic-sponsor-autocomplete.model';
 
 export const COMPLEX_GROUP_SUFFIX = '_COMPLEX_GROUP';
@@ -56,7 +55,7 @@ export class DynamicComplexModel extends DynamicConcatModel {
         if (isNotEmpty(formValue) && isNotEmpty(formValue.value) &&
           formValue.value.startsWith(AUTOCOMPLETE_COMPLEX_PREFIX)) {
           // remove AUTOCOMPLETE_COMPLEX_PREFIX from the value because it cannot be in the metadata value
-          value = DsDynamicAutocompleteService.removeAutocompletePrefix(formValue);
+          value = formValue.value.replace(AUTOCOMPLETE_COMPLEX_PREFIX + SEPARATOR, '');
         }
       });
     }

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/sponsor-autocomplete/ds-dynamic-sponsor-autocomplete.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/sponsor-autocomplete/ds-dynamic-sponsor-autocomplete.component.ts
@@ -69,13 +69,13 @@ export class DsDynamicSponsorAutocompleteComponent extends DsDynamicAutocomplete
     let fundingName = '';
     if (suggestion instanceof ExternalSourceEntry) {
       // suggestion from the openAIRE
-      fundingProjectCode = this.getProjectCodeFromId(suggestion.id);
+      fundingProjectCode = this.getProjectCodeFromId(suggestion?.id);
       fundingName = suggestion.metadata?.['project.funder.name']?.[0]?.value;
     } else if (suggestion instanceof  VocabularyEntry) {
-      // the value is in the format: `<FUNDING_TYPE>;<PROJECT_CODE>;<FUND_ORGANIZATION>;<PROJECT_NAME>;`
-      const fundingFields = suggestion.value.split(SEPARATOR);
-      fundingProjectCode = fundingFields[1];
-      fundingName = fundingFields[3];
+      // the value is in the format: `<FUNDING_TYPE>;<PROJECT_CODE>;<FUND_ORGANIZATION>;<FUNDING_NAME>;`
+      const fundingFields = suggestion.value?.split(SEPARATOR);
+      fundingProjectCode = fundingFields?.[1];
+      fundingName = fundingFields?.[3];
     }
     return DsDynamicAutocompleteService.pretifySuggestion(fundingProjectCode, fundingName, this.translateService);
   }
@@ -203,7 +203,7 @@ export class DsDynamicSponsorAutocompleteComponent extends DsDynamicAutocomplete
     const updatedId = id.match(regex);
 
     // updated value is in the updatedId[1]
-    return isNotEmpty(updatedId[1]) ? updatedId[1] : id;
+    return isNotEmpty(updatedId?.[1]) ? updatedId?.[1] : id;
   }
 
   /**

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/sponsor-autocomplete/ds-dynamic-sponsor-autocomplete.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/sponsor-autocomplete/ds-dynamic-sponsor-autocomplete.component.ts
@@ -160,10 +160,13 @@ export class DsDynamicSponsorAutocompleteComponent extends DsDynamicAutocomplete
    * @private
    */
   private loadEUFundingType() {
+    let euFundingType = null;
     this.translateService.get('autocomplete.suggestion.sponsor.eu')
       .pipe(take(1))
-      .subscribe( ft => { return ft; });
-    return null;
+      .subscribe( ft => {
+        euFundingType = ft;
+      });
+    return euFundingType;
   }
 
   /**
@@ -171,10 +174,13 @@ export class DsDynamicSponsorAutocompleteComponent extends DsDynamicAutocomplete
    * @private
    */
   private loadNoneSponsorFundingType() {
+    let noneFundingType = null;
     this.translateService.get('autocomplete.suggestion.sponsor.empty')
       .pipe(take(1))
-      .subscribe( ft => { return ft; });
-    return null;
+      .subscribe( ft => {
+        noneFundingType = ft;
+      });
+    return noneFundingType;
   }
 
   /**

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/sponsor-autocomplete/ds-dynamic-sponsor-autocomplete.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/sponsor-autocomplete/ds-dynamic-sponsor-autocomplete.component.ts
@@ -19,6 +19,7 @@ import { DsDynamicAutocompleteComponent } from '../autocomplete/ds-dynamic-autoc
 import { AUTOCOMPLETE_COMPLEX_PREFIX } from '../autocomplete/ds-dynamic-autocomplete.model';
 import { DsDynamicAutocompleteService } from '../autocomplete/ds-dynamic-autocomplete.service';
 import { DEFAULT_EU_FUNDING_TYPES } from './ds-dynamic-sponsor-autocomplete.model';
+import { VocabularyEntry } from '../../../../../../core/submission/vocabularies/models/vocabulary-entry.model';
 
 /**
  * Component representing a sponsor autocomplete input field in the complex input type.
@@ -64,15 +65,19 @@ export class DsDynamicSponsorAutocompleteComponent extends DsDynamicAutocomplete
    * @param suggestion raw suggestion value
    */
   suggestionFormatter = (suggestion: TemplateRef<any>) => {
+    let fundingProjectCode = '';
+    let fundingName = '';
     if (suggestion instanceof ExternalSourceEntry) {
       // suggestion from the openAIRE
-      const fundingProjectCode = this.getProjectCodeFromId(suggestion.id);
-      const fundingName = suggestion.metadata?.['project.funder.name']?.[0]?.value;
-      return DsDynamicAutocompleteService.pretifySuggestion(fundingProjectCode, fundingName, this.translateService);
-    } else {
-      // @ts-ignore
-      return suggestion.display;
+      fundingProjectCode = this.getProjectCodeFromId(suggestion.id);
+      fundingName = suggestion.metadata?.['project.funder.name']?.[0]?.value;
+    } else if (suggestion instanceof  VocabularyEntry) {
+      // the value is in the format: `<FUNDING_TYPE>;<PROJECT_CODE>;<FUND_ORGANIZATION>;<PROJECT_NAME>;`
+      const fundingFields = suggestion.value.split(SEPARATOR);
+      fundingProjectCode = fundingFields[1];
+      fundingName = fundingFields[3];
     }
+    return DsDynamicAutocompleteService.pretifySuggestion(fundingProjectCode, fundingName, this.translateService);
   }
 
   /**

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/sponsor-autocomplete/ds-dynamic-sponsor-autocomplete.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/sponsor-autocomplete/ds-dynamic-sponsor-autocomplete.component.ts
@@ -70,7 +70,8 @@ export class DsDynamicSponsorAutocompleteComponent extends DsDynamicAutocomplete
       const fundingName = suggestion.metadata?.['project.funder.name']?.[0]?.value;
       return DsDynamicAutocompleteService.pretifySuggestion(fundingProjectCode, fundingName, this.translateService);
     } else {
-      return super.suggestionFormatter(suggestion);
+      // @ts-ignore
+      return suggestion.display;
     }
   }
 

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/sponsor-autocomplete/ds-dynamic-sponsor-autocomplete.model.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/sponsor-autocomplete/ds-dynamic-sponsor-autocomplete.model.ts
@@ -5,7 +5,10 @@ import { isEmpty } from '../../../../../empty.util';
 
 export const DYNAMIC_FORM_CONTROL_TYPE_AUTOCOMPLETE = 'AUTOCOMPLETE';
 export const DEFAULT_MIN_CHARS_TO_AUTOCOMPLETE = 3;
-export const DEFAULT_EU_FUNDING_TYPES = ['euFunds', 'EU'];
+
+export const DEFAULT_EU_DISPLAY_VALUE = 'EU';
+export const DEFAULT_EU_STORAGE_VALUE = 'euFunds';
+export const DEFAULT_EU_FUNDING_TYPES = [DEFAULT_EU_DISPLAY_VALUE, DEFAULT_EU_STORAGE_VALUE];
 
 /**
  * Configuration for the DsDynamicSponsorAutocompleteModel.

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/sponsor-scrollable-dropdown/dynamic-sponsor-scrollable-dropdown.component.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/sponsor-scrollable-dropdown/dynamic-sponsor-scrollable-dropdown.component.spec.ts
@@ -1,0 +1,228 @@
+// Load the implementations that should be tested
+import { ChangeDetectorRef, Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { ComponentFixture, fakeAsync, inject, TestBed, tick, waitForAsync, } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { TranslateModule } from '@ngx-translate/core';
+import { InfiniteScrollModule } from 'ngx-infinite-scroll';
+import { DynamicFormLayoutService, DynamicFormsCoreModule, DynamicFormValidationService } from '@ng-dynamic-forms/core';
+import { DynamicFormsNGBootstrapUIModule } from '@ng-dynamic-forms/ui-ng-bootstrap';
+
+import { VocabularyOptions } from '../../../../../../core/submission/vocabularies/models/vocabulary-options.model';
+import { VocabularyService } from '../../../../../../core/submission/vocabularies/vocabulary.service';
+import { VocabularyServiceStub } from '../../../../../testing/vocabulary-service.stub';
+import { DsDynamicScrollableDropdownComponent } from './dynamic-scrollable-dropdown.component';
+import { DynamicScrollableDropdownModel } from './dynamic-scrollable-dropdown.model';
+import { VocabularyEntry } from '../../../../../../core/submission/vocabularies/models/vocabulary-entry.model';
+import { createTestComponent, hasClass } from '../../../../../testing/utils.test';
+import {
+  mockDynamicFormLayoutService,
+  mockDynamicFormValidationService
+} from '../../../../../testing/dynamic-form-mock-services';
+
+export const SD_TEST_GROUP = new FormGroup({
+  dropdown: new FormControl(),
+});
+
+export const SD_TEST_MODEL_CONFIG = {
+  vocabularyOptions: {
+    closed: false,
+    name: 'common_iso_languages'
+  } as VocabularyOptions,
+  disabled: false,
+  errorMessages: { required: 'Required field.' },
+  id: 'dropdown',
+  label: 'Language',
+  maxOptions: 10,
+  name: 'dropdown',
+  placeholder: 'Language',
+  readOnly: false,
+  required: false,
+  repeatable: false,
+  value: undefined,
+  metadataFields: [],
+  submissionId: '1234',
+  hasSelectableMetadata: false
+};
+
+describe('Dynamic Dynamic Scrollable Dropdown component', () => {
+
+  let testComp: TestComponent;
+  let scrollableDropdownComp: DsDynamicScrollableDropdownComponent;
+  let testFixture: ComponentFixture<TestComponent>;
+  let scrollableDropdownFixture: ComponentFixture<DsDynamicScrollableDropdownComponent>;
+  let html;
+  let modelValue;
+
+  const vocabularyServiceStub = new VocabularyServiceStub();
+
+  // waitForAsync beforeEach
+  beforeEach(waitForAsync(() => {
+
+    TestBed.configureTestingModule({
+      imports: [
+        DynamicFormsCoreModule,
+        DynamicFormsNGBootstrapUIModule,
+        FormsModule,
+        InfiniteScrollModule,
+        ReactiveFormsModule,
+        NgbModule,
+        TranslateModule.forRoot()
+      ],
+      declarations: [
+        DsDynamicScrollableDropdownComponent,
+        TestComponent,
+      ], // declare the test component
+      providers: [
+        ChangeDetectorRef,
+        DsDynamicScrollableDropdownComponent,
+        { provide: VocabularyService, useValue: vocabularyServiceStub },
+        { provide: DynamicFormLayoutService, useValue: mockDynamicFormLayoutService },
+        { provide: DynamicFormValidationService, useValue: mockDynamicFormValidationService }
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    });
+
+  }));
+
+  describe('', () => {
+    // synchronous beforeEach
+    beforeEach(() => {
+      html = `
+      <ds-dynamic-scrollable-dropdown [bindId]="bindId"
+                                      [group]="group"
+                                      [model]="model"
+                                      (blur)="onBlur($event)"
+                                      (change)="onValueChange($event)"
+                                      (focus)="onFocus($event)"></ds-dynamic-scrollable-dropdown>`;
+
+      testFixture = createTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
+      testComp = testFixture.componentInstance;
+    });
+
+    it('should create DsDynamicScrollableDropdownComponent', inject([DsDynamicScrollableDropdownComponent], (app: DsDynamicScrollableDropdownComponent) => {
+
+      expect(app).toBeDefined();
+    }));
+  });
+
+  describe('', () => {
+    describe('when init model value is empty', () => {
+      beforeEach(() => {
+
+        scrollableDropdownFixture = TestBed.createComponent(DsDynamicScrollableDropdownComponent);
+        scrollableDropdownComp = scrollableDropdownFixture.componentInstance; // FormComponent test instance
+        scrollableDropdownComp.group = SD_TEST_GROUP;
+        scrollableDropdownComp.model = new DynamicScrollableDropdownModel(SD_TEST_MODEL_CONFIG);
+        scrollableDropdownFixture.detectChanges();
+      });
+
+      afterEach(() => {
+        scrollableDropdownFixture.destroy();
+        scrollableDropdownComp = null;
+      });
+
+      it('should init component properly', () => {
+        expect(scrollableDropdownComp.optionsList).toBeDefined();
+        expect(scrollableDropdownComp.optionsList).toEqual(vocabularyServiceStub.getList());
+      });
+
+      it('should display dropdown menu entries', () => {
+        const de = scrollableDropdownFixture.debugElement.query(By.css('input.form-control'));
+        const btnEl = de.nativeElement;
+
+        const deMenu = scrollableDropdownFixture.debugElement.query(By.css('div.scrollable-dropdown-menu'));
+        const menuEl = deMenu.nativeElement;
+
+        btnEl.click();
+        scrollableDropdownFixture.detectChanges();
+
+        expect(hasClass(menuEl, 'show')).toBeTruthy();
+      });
+
+      it('should fetch the next set of results when the user scroll to the end of the list', fakeAsync(() => {
+        scrollableDropdownComp.pageInfo.currentPage = 1;
+        scrollableDropdownComp.pageInfo.totalPages = 2;
+
+        scrollableDropdownFixture.detectChanges();
+
+        scrollableDropdownComp.onScroll();
+        tick();
+
+        expect(scrollableDropdownComp.optionsList.length).toBe(4);
+      }));
+
+      it('should select a results entry properly', fakeAsync(() => {
+        const selectedValue = Object.assign(new VocabularyEntry(), { authority: 1, display: 'one', value: 1 });
+
+        let de: any = scrollableDropdownFixture.debugElement.query(By.css('input.form-control'));
+        let btnEl = de.nativeElement;
+
+        btnEl.click();
+        scrollableDropdownFixture.detectChanges();
+
+        de = scrollableDropdownFixture.debugElement.queryAll(By.css('button.dropdown-item'));
+        btnEl = de[0].nativeElement;
+
+        btnEl.click();
+
+        scrollableDropdownFixture.detectChanges();
+
+        expect((scrollableDropdownComp.model as any).value).toEqual(selectedValue);
+      }));
+
+      it('should emit blur Event onBlur', () => {
+        spyOn(scrollableDropdownComp.blur, 'emit');
+        scrollableDropdownComp.onBlur(new Event('blur'));
+        expect(scrollableDropdownComp.blur.emit).toHaveBeenCalled();
+      });
+
+      it('should emit focus Event onFocus', () => {
+        spyOn(scrollableDropdownComp.focus, 'emit');
+        scrollableDropdownComp.onFocus(new Event('focus'));
+        expect(scrollableDropdownComp.focus.emit).toHaveBeenCalled();
+      });
+
+    });
+
+    describe('when init model value is not empty', () => {
+      beforeEach(() => {
+
+        scrollableDropdownFixture = TestBed.createComponent(DsDynamicScrollableDropdownComponent);
+        scrollableDropdownComp = scrollableDropdownFixture.componentInstance; // FormComponent test instance
+        scrollableDropdownComp.group = SD_TEST_GROUP;
+        modelValue = Object.assign(new VocabularyEntry(), { authority: 1, display: 'one', value: 1 });
+        scrollableDropdownComp.model = new DynamicScrollableDropdownModel(SD_TEST_MODEL_CONFIG);
+        scrollableDropdownComp.model.value = modelValue;
+        scrollableDropdownFixture.detectChanges();
+      });
+
+      afterEach(() => {
+        scrollableDropdownFixture.destroy();
+        scrollableDropdownComp = null;
+      });
+
+      it('should init component properly', () => {
+        expect(scrollableDropdownComp.optionsList).toBeDefined();
+        expect(scrollableDropdownComp.optionsList).toEqual(vocabularyServiceStub.getList());
+        expect(scrollableDropdownComp.model.value).toEqual(modelValue);
+      });
+    });
+  });
+});
+
+// declare a test component
+@Component({
+  selector: 'ds-test-cmp',
+  template: ``
+})
+class TestComponent {
+
+  group: FormGroup = SD_TEST_GROUP;
+
+  model = new DynamicScrollableDropdownModel(SD_TEST_MODEL_CONFIG);
+
+  showErrorMessages = false;
+
+}

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/sponsor-scrollable-dropdown/dynamic-sponsor-scrollable-dropdown.component.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/sponsor-scrollable-dropdown/dynamic-sponsor-scrollable-dropdown.component.spec.ts
@@ -1,31 +1,29 @@
-import {FormControl, FormGroup, FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {VocabularyOptions} from '../../../../../../core/submission/vocabularies/models/vocabulary-options.model';
-import {ComponentFixture, inject, TestBed, waitForAsync} from '@angular/core/testing';
-import {VocabularyServiceStub} from '../../../../../testing/vocabulary-service.stub';
-import {DynamicFormLayoutService, DynamicFormsCoreModule, DynamicFormValidationService} from '@ng-dynamic-forms/core';
-import {DynamicFormsNGBootstrapUIModule} from '@ng-dynamic-forms/ui-ng-bootstrap';
-import {InfiniteScrollModule} from 'ngx-infinite-scroll';
-import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
-import {TranslateModule} from '@ngx-translate/core';
-import {ChangeDetectorRef, Component, CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
-import {VocabularyService} from '../../../../../../core/submission/vocabularies/vocabulary.service';
+import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { VocabularyOptions } from '../../../../../../core/submission/vocabularies/models/vocabulary-options.model';
+import { ComponentFixture, inject, TestBed, waitForAsync } from '@angular/core/testing';
+import { VocabularyServiceStub } from '../../../../../testing/vocabulary-service.stub';
+import { DynamicFormLayoutService, DynamicFormsCoreModule, DynamicFormValidationService } from '@ng-dynamic-forms/core';
+import { DynamicFormsNGBootstrapUIModule } from '@ng-dynamic-forms/ui-ng-bootstrap';
+import { InfiniteScrollModule } from 'ngx-infinite-scroll';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { TranslateModule } from '@ngx-translate/core';
+import { ChangeDetectorRef, Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { VocabularyService } from '../../../../../../core/submission/vocabularies/vocabulary.service';
 import {
   mockDynamicFormLayoutService,
   mockDynamicFormValidationService
-} from '../../../../../testing/dynamic-form-mock-services';
-import {createTestComponent} from '../../../../../testing/utils.test';
-import {DynamicScrollableDropdownModel} from '../scrollable-dropdown/dynamic-scrollable-dropdown.model';
-import {DsDynamicSponsorScrollableDropdownComponent} from './dynamic-sponsor-scrollable-dropdown.component';
-import {DsDynamicScrollableDropdownComponent} from '../scrollable-dropdown/dynamic-scrollable-dropdown.component';
-import {VocabularyEntry} from '../../../../../../core/submission/vocabularies/models/vocabulary-entry.model';
-import {EU_PROJECT_PREFIX, SEPARATOR} from '../ds-dynamic-complex.model';
+ } from '../../../../../testing/dynamic-form-mock-services';
+import { createTestComponent } from '../../../../../testing/utils.test';
+import { DynamicScrollableDropdownModel } from '../scrollable-dropdown/dynamic-scrollable-dropdown.model';
+import { DsDynamicSponsorScrollableDropdownComponent } from './dynamic-sponsor-scrollable-dropdown.component';
+import { VocabularyEntry } from '../../../../../../core/submission/vocabularies/models/vocabulary-entry.model';
 import {
   DEFAULT_EU_DISPLAY_VALUE,
   DEFAULT_EU_STORAGE_VALUE
-} from '../sponsor-autocomplete/ds-dynamic-sponsor-autocomplete.model';
-import {take} from 'rxjs/operators';
-import {Observable} from 'rxjs';
-import {isNotEmpty} from '../../../../../empty.util';
+ } from '../sponsor-autocomplete/ds-dynamic-sponsor-autocomplete.model';
+import { take } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { isNotEmpty } from '../../../../../empty.util';
 
 export const SD_TEST_GROUP = new FormGroup({
   dropdown: new FormControl(),

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/sponsor-scrollable-dropdown/dynamic-sponsor-scrollable-dropdown.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/sponsor-scrollable-dropdown/dynamic-sponsor-scrollable-dropdown.component.ts
@@ -1,0 +1,85 @@
+import { ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+import { Observable, of as observableOf } from 'rxjs';
+import { catchError, distinctUntilChanged, map, tap } from 'rxjs/operators';
+import { NgbDropdown } from '@ng-bootstrap/ng-bootstrap';
+import { DynamicFormLayoutService, DynamicFormValidationService } from '@ng-dynamic-forms/core';
+
+import { VocabularyEntry } from '../../../../../../core/submission/vocabularies/models/vocabulary-entry.model';
+import { PageInfo } from '../../../../../../core/shared/page-info.model';
+import { isEmpty } from '../../../../../empty.util';
+import { VocabularyService } from '../../../../../../core/submission/vocabularies/vocabulary.service';
+import { getFirstSucceededRemoteDataPayload } from '../../../../../../core/shared/operators';
+import {
+  PaginatedList,
+  buildPaginatedList
+} from '../../../../../../core/data/paginated-list.model';
+import { FormFieldMetadataValueObject } from '../../../models/form-field-metadata-value.model';
+import {DsDynamicScrollableDropdownComponent} from '../scrollable-dropdown/dynamic-scrollable-dropdown.component';
+import { DynamicScrollableDropdownModel } from '../scrollable-dropdown/dynamic-scrollable-dropdown.model';
+import {
+  DEFAULT_EU_DISPLAY_VALUE,
+  DEFAULT_EU_FUNDING_TYPES
+} from '../sponsor-autocomplete/ds-dynamic-sponsor-autocomplete.model';
+import {SEPARATOR} from '../ds-dynamic-complex.model';
+
+// The default value for the EU sponsor in the complex input type looks like `EU;;;;`
+const EU_TYPE_DEFAULT_VALUE = DEFAULT_EU_DISPLAY_VALUE + SEPARATOR.repeat(4);
+
+/**
+ * Component representing a dropdown input field
+ */
+@Component({
+  selector: 'ds-dynamic-sponsor-scrollable-dropdown',
+  styleUrls: ['../scrollable-dropdown/dynamic-scrollable-dropdown.component.scss'],
+  templateUrl: '../scrollable-dropdown/dynamic-scrollable-dropdown.component.html'
+})
+export class DsDynamicSponsorScrollableDropdownComponent extends DsDynamicScrollableDropdownComponent implements OnInit {
+  @Input() bindId = true;
+  @Input() group: FormGroup;
+  @Input() model: DynamicScrollableDropdownModel;
+
+  @Output() blur: EventEmitter<any> = new EventEmitter<any>();
+  @Output() change: EventEmitter<any> = new EventEmitter<any>();
+  @Output() focus: EventEmitter<any> = new EventEmitter<any>();
+
+  public currentValue: Observable<string>;
+  public loading = false;
+  public pageInfo: PageInfo;
+  public optionsList: any;
+
+  constructor(protected vocabularyService: VocabularyService,
+              protected cdr: ChangeDetectorRef,
+              protected layoutService: DynamicFormLayoutService,
+              protected validationService: DynamicFormValidationService
+  ) {
+    super(vocabularyService, cdr, layoutService, validationService);
+  }
+
+  /**
+   * Sets the current value with the given value.
+   * @param value The value to set.
+   * @param init Representing if is init value or not.
+   */
+  setCurrentValue(value: any, init = false): void {
+    let result: Observable<string>;
+
+    if (init) {
+      result = this.getInitValueFromModel().pipe(
+        map((formValue: FormFieldMetadataValueObject) => formValue.display)
+      );
+    } else {
+      if (isEmpty(value)) {
+        result = observableOf('');
+      } else if (typeof value === 'string') {
+        result = observableOf(value);
+      } else {
+        result = observableOf(value.display);
+      }
+    }
+
+    this.currentValue = result;
+  }
+
+}

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/sponsor-scrollable-dropdown/dynamic-sponsor-scrollable-dropdown.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/sponsor-scrollable-dropdown/dynamic-sponsor-scrollable-dropdown.component.ts
@@ -1,37 +1,24 @@
 import { ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-
 import { Observable, of as observableOf } from 'rxjs';
-import {catchError, distinctUntilChanged, map, take, tap} from 'rxjs/operators';
-import { NgbDropdown } from '@ng-bootstrap/ng-bootstrap';
+import { map, take } from 'rxjs/operators';
 import { DynamicFormLayoutService, DynamicFormValidationService } from '@ng-dynamic-forms/core';
-
-import { VocabularyEntry } from '../../../../../../core/submission/vocabularies/models/vocabulary-entry.model';
 import { PageInfo } from '../../../../../../core/shared/page-info.model';
 import { isEmpty } from '../../../../../empty.util';
 import { VocabularyService } from '../../../../../../core/submission/vocabularies/vocabulary.service';
-import { getFirstSucceededRemoteDataPayload } from '../../../../../../core/shared/operators';
-import {
-  PaginatedList,
-  buildPaginatedList
-} from '../../../../../../core/data/paginated-list.model';
 import { FormFieldMetadataValueObject } from '../../../models/form-field-metadata-value.model';
-import {DsDynamicScrollableDropdownComponent} from '../scrollable-dropdown/dynamic-scrollable-dropdown.component';
+import { DsDynamicScrollableDropdownComponent } from '../scrollable-dropdown/dynamic-scrollable-dropdown.component';
 import {
-  DYNAMIC_FORM_CONTROL_TYPE_SCROLLABLE_DROPDOWN,
   DynamicScrollableDropdownModel
 } from '../scrollable-dropdown/dynamic-scrollable-dropdown.model';
 import {
   DEFAULT_EU_DISPLAY_VALUE,
-  DEFAULT_EU_FUNDING_TYPES, DsDynamicSponsorAutocompleteModel
+  DsDynamicSponsorAutocompleteModel
 } from '../sponsor-autocomplete/ds-dynamic-sponsor-autocomplete.model';
-import {DynamicComplexModel, EU_IDENTIFIER_INDEX, EU_PROJECT_PREFIX, SEPARATOR} from '../ds-dynamic-complex.model';
-import {DsDynamicInputModel} from '../ds-dynamic-input.model';
-import {DYNAMIC_FORM_CONTROL_TYPE_AUTOCOMPLETE} from '../autocomplete/ds-dynamic-autocomplete.model';
-import {isEqual, startsWith} from 'lodash';
-
-// The default value for the EU sponsor in the complex input type looks like `EU;;;;`
-const EU_TYPE_DEFAULT_VALUE = DEFAULT_EU_DISPLAY_VALUE + SEPARATOR.repeat(4);
+import { DynamicComplexModel, EU_IDENTIFIER_INDEX, SEPARATOR } from '../ds-dynamic-complex.model';
+import { DsDynamicInputModel } from '../ds-dynamic-input.model';
+import { DYNAMIC_FORM_CONTROL_TYPE_AUTOCOMPLETE } from '../autocomplete/ds-dynamic-autocomplete.model';
+import { isEqual } from 'lodash';
 
 const DYNAMIC_INPUT_TYPE = 'INPUT';
 
@@ -66,16 +53,6 @@ export class DsDynamicSponsorScrollableDropdownComponent extends DsDynamicScroll
   }
 
   /**
-   * Emits a change event and set the current value with the given value.
-   * @param event The value to emit.
-   */
-  onSelect(event) {
-    this.group.markAsDirty();
-    this.dispatchUpdate(event);
-    this.setCurrentValue(event);
-  }
-
-  /**
    * Sets the current value with the given value.
    * @param value The value to set.
    * @param init Representing if is init value or not.
@@ -99,10 +76,10 @@ export class DsDynamicSponsorScrollableDropdownComponent extends DsDynamicScroll
 
     // tslint:disable-next-line:no-shadowed-variable
     result.pipe(take(1)).subscribe(value => {
-      if (!this.shouldCleanInputs(value, this.model.parent)) {
+      if (!this.shouldCleanInputs(value, this.model?.parent)) {
         return;
       }
-      this.cleanSponsorInputs(value, this.model.parent);
+      this.cleanSponsorInputs(value, this.model?.parent);
     });
 
     this.currentValue = result;
@@ -147,7 +124,7 @@ export class DsDynamicSponsorScrollableDropdownComponent extends DsDynamicScroll
    * @private
    */
   private shouldCleanInputs(fundingTypeValue, complexInputField) {
-    const euIdentifierValue = (complexInputField.group[EU_IDENTIFIER_INDEX] as DsDynamicInputModel).value;
+    const euIdentifierValue = (complexInputField?.group?.[EU_IDENTIFIER_INDEX] as DsDynamicInputModel)?.value;
 
     // if the funding type is EU and doesn't have EU identifier `info:eu..` -> clean inputs
     if (isEqual(fundingTypeValue, DEFAULT_EU_DISPLAY_VALUE) && isEmpty(euIdentifierValue)) {
@@ -161,5 +138,4 @@ export class DsDynamicSponsorScrollableDropdownComponent extends DsDynamicScroll
 
     return false;
   }
-
 }

--- a/src/app/shared/form/builder/parsers/complex-field-parser.ts
+++ b/src/app/shared/form/builder/parsers/complex-field-parser.ts
@@ -141,7 +141,6 @@ export class ComplexFieldParser extends FieldParser {
         case ParserType.Autocomplete:
           if (id === SPONSOR_METADATA_NAME) {
             inputModel = new DsDynamicSponsorAutocompleteModel(inputConfig, clsInput);
-            inputModel.hidden = complexDefinitionInput.name === OPENAIRE_INPUT_NAME;
           } else {
             inputModel = new DsDynamicAutocompleteModel(inputConfig, clsInput);
           }
@@ -151,6 +150,8 @@ export class ComplexFieldParser extends FieldParser {
           break;
       }
 
+      // for non-EU funds hide EU identifier read only input field
+      inputModel.hidden = complexDefinitionInput.name === OPENAIRE_INPUT_NAME;
       concatGroup.group.push(inputModel);
     });
 

--- a/src/app/shared/form/form.module.ts
+++ b/src/app/shared/form/form.module.ts
@@ -32,6 +32,7 @@ import { CustomSwitchComponent } from './builder/ds-dynamic-form-ui/models/custo
 import { DynamicFormsNGBootstrapUIModule } from '@ng-dynamic-forms/ui-ng-bootstrap';
 import { DsDynamicAutocompleteComponent } from './builder/ds-dynamic-form-ui/models/autocomplete/ds-dynamic-autocomplete.component';
 import { DsDynamicSponsorAutocompleteComponent } from './builder/ds-dynamic-form-ui/models/sponsor-autocomplete/ds-dynamic-sponsor-autocomplete.component';
+import { DsDynamicSponsorScrollableDropdownComponent } from './builder/ds-dynamic-form-ui/models/sponsor-scrollable-dropdown/dynamic-sponsor-scrollable-dropdown.component';
 
 const COMPONENTS = [
   CustomSwitchComponent,
@@ -48,6 +49,7 @@ const COMPONENTS = [
   DsDynamicTagComponent,
   DsDynamicAutocompleteComponent,
   DsDynamicSponsorAutocompleteComponent,
+  DsDynamicSponsorScrollableDropdownComponent,
   DsDynamicOneboxComponent,
   DsDynamicRelationGroupComponent,
   DsDatePickerComponent,


### PR DESCRIPTION
| Phases            | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  5+2.5+1  |    0 |    0 |      0 |         0 |
| Review             |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -   |   -     |        0 |
## Problem description
After testing another errors were discovered: https://github.com/dataquest-dev/DSpace/issues/17#issuecomment-1210311269

Fix:
- [ ] wrong behavior of the red warnings
- [x] The EU identifier was still there - cannot remove
- [x] The EU identifier was uploading for the non EU funds too
- [x] Non EU funds suggestion was different than the EU funds suggestions
### Reported issues
Fix: wrong behavior of the red warnings
This issue is not so important to solve now because the Funding input type is not required and the red warning won't be occurred in the production.
I created issue for that: https://github.com/dataquest-dev/dspace-angular/issues/83

### Not-reported issues

