### PR TITLE
feature/pid-5-fix-unknown-error

### DIFF
--- a/cypress/integration/community-list.spec.ts
+++ b/cypress/integration/community-list.spec.ts
@@ -10,7 +10,7 @@ describe('Community List Page', () => {
         cy.get('ds-community-list-page').should('exist');
 
         // Open first Community (to show Collections)...that way we scan sub-elements as well
-        cy.get('ds-community-list :nth-child(1) > .btn-group > .btn').click();
+        cy.get('ds-community-list :nth-child(3) > .btn-group > .btn').click();
 
         // Analyze <ds-community-list-page> for accessibility issues
         // Disable heading-order checks until it is fixed

--- a/src/app/handle-page/handle-table/handle-table.component.spec.ts
+++ b/src/app/handle-page/handle-table/handle-table.component.spec.ts
@@ -4,23 +4,20 @@ import { HandleDataService } from '../../core/data/handle-data.service';
 import { PaginationService } from '../../core/pagination/pagination.service';
 import { Router } from '@angular/router';
 import { RequestService } from '../../core/data/request.service';
-import { createSuccessfulRemoteDataObject$ } from '../../shared/remote-data.utils';
 import { of as observableOf } from 'rxjs';
 import { SharedModule } from '../../shared/shared.module';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Handle } from '../../core/handle/handle.model';
 import { PaginationServiceStub } from '../../shared/testing/pagination-service.stub';
 import { RouterStub } from '../../shared/testing/router.stub';
 import { getHandleTableModulePath } from '../../app-routing-paths';
 import { defaultPagination } from './handle-table-pagination';
-import { buildPaginatedList } from '../../core/data/paginated-list.model';
-import { PageInfo } from '../../core/shared/page-info.model';
 import { HANDLE_TABLE_EDIT_HANDLE_PATH } from '../handle-page-routing-paths';
 import { NotificationsServiceStub } from '../../shared/testing/notifications-service.stub';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
+import { mockHandle, mockHandleRD$, successfulResponse, selectedHandleId } from '../../shared/mocks/handle-mock';
 
 /**
  * The test for testing HandleTableComponent.
@@ -32,25 +29,6 @@ describe('HandleTableComponent', () => {
   let handleDataService: HandleDataService;
   let requestService: RequestService;
   let notificationService: NotificationsServiceStub;
-
-  const selectedHandleId = 1;
-  const successfulResponse = {
-    response: {
-      statusCode: 200
-    }};
-  const mockHandle = Object.assign(new Handle(), {
-    id: selectedHandleId,
-    handle: '123456',
-    resourceTypeID: 0,
-    url: 'handle.url',
-    _links: {
-      self: {
-        href: 'url.123456'
-      }
-    }
-  });
-
-  const mockHandleRD$ = createSuccessfulRemoteDataObject$(buildPaginatedList(new PageInfo(), [mockHandle]));
 
   beforeEach(async () => {
     notificationService = new NotificationsServiceStub();

--- a/src/app/handle-page/new-handle-page/new-handle-page.component.spec.ts
+++ b/src/app/handle-page/new-handle-page/new-handle-page.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, TestBed} from '@angular/core/testing';
 import { NewHandlePageComponent } from './new-handle-page.component';
 import { NotificationsServiceStub } from '../../shared/testing/notifications-service.stub';
 import { of as observableOf } from 'rxjs';
@@ -11,6 +11,8 @@ import { RequestService } from '../../core/data/request.service';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { getMockTranslateService } from '../../shared/mocks/translate.service.mock';
 import { Store } from '@ngrx/store';
+import { HandleDataService } from '../../core/data/handle-data.service';
+import { mockCreatedHandleRD$ } from '../../shared/mocks/handle-mock';
 
 /**
  * The test class for the NewHandlePageComponent.
@@ -20,7 +22,7 @@ describe('NewHandlePageComponent', () => {
   let fixture: ComponentFixture<NewHandlePageComponent>;
 
   let notificationService: NotificationsServiceStub;
-  let requestService = RequestService;
+  let handleDataService: HandleDataService;
 
   const successfulResponse = {
     response: {
@@ -29,10 +31,10 @@ describe('NewHandlePageComponent', () => {
 
   beforeEach(async () => {
     notificationService = new NotificationsServiceStub();
-    requestService = jasmine.createSpyObj('requestService', {
-      send: observableOf('response'),
-      getByUUID: observableOf(successfulResponse),
-      generateRequestId: observableOf('123456'),
+
+    handleDataService = jasmine.createSpyObj('handleDataService', {
+      create: mockCreatedHandleRD$,
+      getLinkPath: observableOf('')
     });
 
     await TestBed.configureTestingModule({
@@ -45,9 +47,8 @@ describe('NewHandlePageComponent', () => {
       ],
       declarations: [ NewHandlePageComponent ],
       providers: [
-        { provide: RequestService, useValue: requestService },
         { provide: NotificationsService, useValue: notificationService },
-        { provide: TranslateService, useValue: getMockTranslateService() },
+        { provide: HandleDataService, useValue: handleDataService },
         {
           provide: Store, useValue: {
             // tslint:disable-next-line:no-empty
@@ -70,16 +71,17 @@ describe('NewHandlePageComponent', () => {
   });
 
   it('should send request after click on Submit', () => {
-    expect(component).toBeTruthy();
     component.onClickSubmit('new handle');
 
-    expect((component as any).requestService.send).toHaveBeenCalled();
+    expect((component as any).handleService.create).toHaveBeenCalled();
   });
 
   it('should notify after successful request', () => {
     component.onClickSubmit('new handle');
 
-    expect((component as any).notificationsService.success).toHaveBeenCalled();
-    expect((component as any).notificationsService.error).not.toHaveBeenCalled();
+    fixture.whenStable().then(() => {
+      expect((component as any).notificationsService.success).toHaveBeenCalled();
+      expect((component as any).notificationsService.error).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/shared/mocks/handle-mock.ts
+++ b/src/app/shared/mocks/handle-mock.ts
@@ -1,0 +1,30 @@
+import { Handle } from '../../core/handle/handle.model';
+import { createSuccessfulRemoteDataObject$ } from '../remote-data.utils';
+import { buildPaginatedList } from '../../core/data/paginated-list.model';
+import { PageInfo } from '../../core/shared/page-info.model';
+
+/**
+ * The Handle mock for testing.
+ */
+
+export const selectedHandleId = 1;
+
+export const successfulResponse = {
+  response: {
+    statusCode: 200
+  }};
+
+export const mockHandle = Object.assign(new Handle(), {
+  id: selectedHandleId,
+  handle: '123456',
+  resourceTypeID: 0,
+  url: 'handle.url',
+  _links: {
+    self: {
+      href: 'url.123456'
+    }
+  }
+});
+
+export const mockHandleRD$ = createSuccessfulRemoteDataObject$(buildPaginatedList(new PageInfo(), [mockHandle]));
+export const mockCreatedHandleRD$ = createSuccessfulRemoteDataObject$(mockHandle);


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  3  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
The admin cannot create a new Handle because the server throws Unknown Error. Reason: the server url was hardcoded in the CreateRequest.
**Solution**: instead of creating the CreateRequest is used the handleService.create method.
