### PR TITLE
feature/laf-4-item-new-version

### DIFF
--- a/src/app/shared/item/item-versions/item-versions.component.html
+++ b/src/app/shared/item/item-versions/item-versions.component.html
@@ -17,7 +17,7 @@
           <thead>
           <tr>
             <th scope="col">{{"item.version.history.table.version" | translate}}</th>
-            <th scope="col" *ngIf="(showSubmitter() | async)">{{"item.version.history.table.editor" | translate}}</th>
+            <th scope="col" *ngIf="(showSubmitter$ | async)">{{"item.version.history.table.editor" | translate}}</th>
             <th scope="col">{{"item.version.history.table.date" | translate}}</th>
             <th scope="col">{{"item.version.history.table.summary" | translate}}</th>
           </tr>
@@ -87,7 +87,7 @@
                 </ng-container>
               </ng-container>
             </td>
-            <td class="version-row-element-editor" *ngIf="(showSubmitter() | async)">
+            <td class="version-row-element-editor" *ngIf="(showSubmitter$ | async)">
               {{version?.submitterName}}
             </td>
             <td class="version-row-element-date">

--- a/src/app/shared/item/item-versions/item-versions.component.ts
+++ b/src/app/shared/item/item-versions/item-versions.component.ts
@@ -379,7 +379,6 @@ export class ItemVersionsComponent implements OnInit {
    * Show submitter in version history table
    */
   showSubmitter() {
-    console.log('method is called')
     const includeSubmitter$ = this.configurationService.findByPropertyName('versioning.item.history.include.submitter').pipe(
       getFirstSucceededRemoteDataPayload(),
       map((configurationProperty) => configurationProperty.values[0]),

--- a/src/app/shared/item/item-versions/item-versions.component.ts
+++ b/src/app/shared/item/item-versions/item-versions.component.ts
@@ -2,13 +2,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import { Item } from '../../../core/shared/item.model';
 import { Version } from '../../../core/shared/version.model';
 import { RemoteData } from '../../../core/data/remote-data';
-import {
-  BehaviorSubject,
-  combineLatest,
-  Observable,
-  of,
-  Subscription,
-} from 'rxjs';
+import { BehaviorSubject, combineLatest, Observable, of, Subscription } from 'rxjs';
 import { VersionHistory } from '../../../core/shared/version-history.model';
 import {
   getAllSucceededRemoteData,
@@ -25,7 +19,7 @@ import { VersionHistoryDataService } from '../../../core/data/version-history-da
 import { PaginatedSearchOptions } from '../../search/models/paginated-search-options.model';
 import { AlertType } from '../../alert/aletr-type';
 import { followLink } from '../../utils/follow-link-config.model';
-import { hasValue, hasValueOperator } from '../../empty.util';
+import { hasValue, hasValueOperator, isNotNull } from '../../empty.util';
 import { PaginationService } from '../../../core/pagination/pagination.service';
 import {
   getItemEditVersionhistoryRoute,
@@ -166,6 +160,11 @@ export class ItemVersionsComponent implements OnInit {
 
   canCreateVersion$: Observable<boolean>;
   createVersionTitle$: Observable<string>;
+
+  /**
+   * Show `Editor` column in the table.
+   */
+  showSubmitter$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(null);
 
   constructor(private versionHistoryService: VersionHistoryDataService,
               private versionService: VersionDataService,
@@ -380,7 +379,7 @@ export class ItemVersionsComponent implements OnInit {
    * Show submitter in version history table
    */
   showSubmitter() {
-
+    console.log('method is called')
     const includeSubmitter$ = this.configurationService.findByPropertyName('versioning.item.history.include.submitter').pipe(
       getFirstSucceededRemoteDataPayload(),
       map((configurationProperty) => configurationProperty.values[0]),
@@ -398,12 +397,19 @@ export class ItemVersionsComponent implements OnInit {
       take(1),
     );
 
-    return combineLatest([includeSubmitter$, isAdmin$]).pipe(
+    const result$ = combineLatest([includeSubmitter$, isAdmin$]).pipe(
       map(([includeSubmitter, isAdmin]) => {
         return includeSubmitter && isAdmin;
       })
     );
 
+    if (isNotNull(this.showSubmitter$.value)) {
+      return;
+    }
+
+    result$.subscribe(res => {
+      this.showSubmitter$.next(res);
+    });
   }
 
   /**
@@ -524,6 +530,8 @@ export class ItemVersionsComponent implements OnInit {
           return itemPageRoutes;
         })
       );
+
+      this.showSubmitter();
     }
   }
 


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
There is bug in the versions table: the table is still reloading so the user has a problem to redirect for the another version.
Problem: The method `showSubmitter` was still called.
Solution: The method is called only once and the return value is stored into the variable `showSubmitter$`