### PR TITLE
66-FE/clickable-metadata-item-view

### DIFF
--- a/cypress/integration/submission-ui.spec.ts
+++ b/cypress/integration/submission-ui.spec.ts
@@ -416,52 +416,6 @@ describe('Create a new submission', () => {
     createItemProcess.checkAuthorLastnameField();
   });
 
-  it('should show warning messages if was selected non-supported license', {
-    retries: {
-      runMode: 6,
-      openMode: 6,
-    },
-    defaultCommandTimeout: 10000
-  },() => {
-    createItemProcess.checkLicenseResourceStep();
-    // check default value in the license dropdown selection
-    createItemProcess.checkLicenseSelectionValue('Select a License ...');
-    // check step status - it should be as warning
-    createItemProcess.checkResourceLicenseStatus('Warnings');
-    // select `Select a License ...` from the selection - this license is not supported
-    createItemProcess.selectValueFromLicenseSelection('Select a License ...');
-    // selected value should be seen as selected value in the selection
-    createItemProcess.checkLicenseSelectionValue('Select a License ...');
-    // check step status - it should an error
-    createItemProcess.checkResourceLicenseStatus('Errors');
-    // error messages should be popped up
-    createItemProcess.showErrorMustChooseLicense();
-    createItemProcess.showErrorNotSupportedLicense();
-  });
-
-  it('the submission should have the Notice Step', {
-    retries: {
-      runMode: 6,
-      openMode: 6,
-    },
-    defaultCommandTimeout: 10000
-  },() => {
-    createItemProcess.checkLicenseResourceStep();
-    // check default value in the license dropdown selection
-    createItemProcess.checkLicenseSelectionValue('Select a License ...');
-    // check step status - it should be as warning
-    createItemProcess.checkResourceLicenseStatus('Warnings');
-    // select `Select a License ...` from the selection - this license is not supported
-    createItemProcess.selectValueFromLicenseSelection('Select a License ...');
-    // selected value should be seen as selected value in the selection
-    createItemProcess.checkLicenseSelectionValue('Select a License ...');
-    // check step status - it should an error
-    createItemProcess.checkResourceLicenseStatus('Errors');
-    // error messages should be popped up
-    createItemProcess.showErrorMustChooseLicense();
-    createItemProcess.showErrorNotSupportedLicense();
-  });
-
   it('The submission should not have the Notice Step', {
     retries: {
       runMode: 6,

--- a/src/app/item-page/simple/field-components/clarin-collections-item-field/clarin-collections-item-field.component.html
+++ b/src/app/item-page/simple/field-components/clarin-collections-item-field/clarin-collections-item-field.component.html
@@ -1,9 +1,9 @@
 <div class="row clarin-item-page-field">
-  <div class="col-md-2 d-flex">
+  <div class="col-lg-2 d-flex">
     <div><i [class]="'fas ' + iconName + ' fa-xs'"></i></div>
     <div class="pl-1"><b>{{'item.page.collections' | translate}}</b></div>
   </div>
-  <div class="col-md-10">
+  <div class="col-lg-10">
     <div class="collections">
       <a *ngFor="let collection of (this.collections$ | async); let last=last;" [routerLink]="['/collections', collection.id]">
         <span>{{collection?.name}}</span><span *ngIf="!last" [innerHTML]="separator"></span>

--- a/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.html
+++ b/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.html
@@ -1,9 +1,9 @@
 <div class="row clarin-item-page-field" *ngIf="hasMetadataValue()">
-  <div class="col-md-2 d-flex">
+  <div class="col-lg-2 d-flex">
     <div><i [class]="'fas ' + iconName + ' fa-xs'"></i></div>
     <div class="pl-1"><b>{{label | translate}}</b></div>
   </div>
-  <div class="col-md-10">
+  <div class="col-lg-10">
     <div>
       <div *ngIf="type === 'author'" class="d-inline">
         <ds-clarin-item-author-preview [item]="item"></ds-clarin-item-author-preview>

--- a/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.html
+++ b/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.html
@@ -5,7 +5,10 @@
   </div>
   <div class="col-md-10">
     <div>
-      <span class="dont-break-out" *ngFor="let mdValue of item?.allMetadata(fields); let last=last; let i = index">
+      <div *ngIf="type === 'author'" class="d-inline">
+        <ds-clarin-item-author-preview [item]="item"></ds-clarin-item-author-preview>
+      </div>
+      <div class="dont-break-out d-inline" *ngFor="let mdValue of item?.allMetadata(fields); let last=last; let i = index">
         <a *ngIf="type === 'hyperlink'" [href]="mdValue.value">{{mdValue.value}}</a>
         <a *ngIf="type === 'search'" [href]="getLinkToSearch(i)">{{mdValue.value}}</a>
         <span *ngIf="type === 'subject'">
@@ -18,7 +21,7 @@
         <span *ngIf="type == null">
           {{mdValue.value}}<span *ngIf="!last" [innerHTML]="separator"></span>
         </span>
-      </span>
+      </div>
     </div>
   </div>
 </div>

--- a/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.html
+++ b/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.html
@@ -5,8 +5,9 @@
   </div>
   <div class="col-md-10">
     <div>
-      <span class="dont-break-out" *ngFor="let mdValue of item?.allMetadata(fields); let last=last;">
+      <span class="dont-break-out" *ngFor="let mdValue of item?.allMetadata(fields); let last=last; let i = index">
         <a *ngIf="type === 'hyperlink'" [href]="mdValue.value">{{mdValue.value}}</a>
+        <a *ngIf="type === 'search'" [href]="getLinkToSearch(i)">{{mdValue.value}}</a>
         <span *ngIf="type == null">
           {{mdValue.value}}<span *ngIf="!last" [innerHTML]="separator"></span>
         </span>

--- a/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.html
+++ b/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.html
@@ -8,6 +8,13 @@
       <span class="dont-break-out" *ngFor="let mdValue of item?.allMetadata(fields); let last=last; let i = index">
         <a *ngIf="type === 'hyperlink'" [href]="mdValue.value">{{mdValue.value}}</a>
         <a *ngIf="type === 'search'" [href]="getLinkToSearch(i)">{{mdValue.value}}</a>
+        <span *ngIf="type === 'subject'">
+          <a class="badge badge-info text-white cursor-pointer"
+             *ngFor="let subject of mdValue.value.split(separator);"
+             [href]="getLinkToSearch(-1, subject)">
+            {{subject}}
+          </a>
+        </span>
         <span *ngIf="type == null">
           {{mdValue.value}}<span *ngIf="!last" [innerHTML]="separator"></span>
         </span>

--- a/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.ts
+++ b/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.ts
@@ -5,7 +5,6 @@ import {ConfigurationProperty} from '../../../../core/shared/configuration-prope
 import {DSONameService} from '../../../../core/breadcrumbs/dso-name.service';
 import {convertMetadataFieldIntoSearchType, getBaseUrl} from '../../../../shared/clarin-shared-util';
 import {ConfigurationDataService} from '../../../../core/data/configuration-data.service';
-import {MetadataValue} from '../../../../core/shared/metadata.models';
 
 @Component({
   selector: 'ds-clarin-generic-item-field',
@@ -55,8 +54,8 @@ export class ClarinGenericItemFieldComponent implements OnInit {
               protected configurationService: ConfigurationDataService) { }
 
   // tslint:disable-next-line:no-empty
-  ngOnInit(): void {
-    this.assignBaseUrl();
+  async ngOnInit(): Promise<void> {
+    await this.assignBaseUrl();
   }
 
   public hasMetadataValue() {

--- a/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.ts
+++ b/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Item } from '../../../../core/shared/item.model';
-import { isNotUndefined } from '../../../../shared/empty.util';
+import {isEmpty, isNotUndefined} from '../../../../shared/empty.util';
 import {ConfigurationProperty} from '../../../../core/shared/configuration-property.model';
 import {DSONameService} from '../../../../core/breadcrumbs/dso-name.service';
 import {convertMetadataFieldIntoSearchType, getBaseUrl} from '../../../../shared/clarin-shared-util';
@@ -68,8 +68,22 @@ export class ClarinGenericItemFieldComponent implements OnInit {
    * field has only one metadata value - index is 0, but sometimes it has more values e.g. `Author`.
    * @param index
    */
-  public getLinkToSearch(index) {
+  public getLinkToSearch(index, value = '') {
     let metadataValue = 'Error: value is empty';
+    if (isEmpty(value)) {
+      // Get metadata value from the Item's metadata field
+      metadataValue = this.getMetadataValue(index);
+    } else {
+      // The metadata value is passed from the parameter.
+      metadataValue = value;
+    }
+
+    const searchType = convertMetadataFieldIntoSearchType(this.fields);
+    return this.baseUrl + '/search/objects?f.' + searchType + '=' + metadataValue + ',equals';
+  }
+
+  public getMetadataValue(index) {
+    let metadataValue = '';
     if (index === 0) {
       // Return first metadata value.
       metadataValue = this.item.firstMetadataValue(this.fields);
@@ -82,9 +96,7 @@ export class ClarinGenericItemFieldComponent implements OnInit {
         metadataValue = metadataValueArray;
       });
     }
-
-    const searchType = convertMetadataFieldIntoSearchType(this.fields);
-    return this.baseUrl + '/search/objects?f.' + searchType + '=' + metadataValue + ',equals';
+    return metadataValue;
   }
 
   async assignBaseUrl() {
@@ -93,5 +105,7 @@ export class ClarinGenericItemFieldComponent implements OnInit {
         return baseUrlResponse?.values?.[0];
       });
   }
+
+
 
 }

--- a/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.ts
+++ b/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.ts
@@ -92,16 +92,15 @@ export class ClarinGenericItemFieldComponent implements OnInit {
     let metadataValue = '';
     if (index === 0) {
       // Return first metadata value.
-      metadataValue = this.item.firstMetadataValue(this.fields);
-    } else {
-      // The metadata field has more metadata values - get the actual one
-      this.item.allMetadataValues(this.fields)?.forEach((metadataValueArray, arrayIndex) => {
-        if (index !== arrayIndex) {
-          return;
-        }
-        metadataValue = metadataValueArray;
-      });
+      return this.item.firstMetadataValue(this.fields);
     }
+    // The metadata field has more metadata values - get the actual one
+    this.item.allMetadataValues(this.fields)?.forEach((metadataValueArray, arrayIndex) => {
+      if (index !== arrayIndex) {
+        return metadataValue;
+      }
+      metadataValue = metadataValueArray;
+    });
     return metadataValue;
   }
 

--- a/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.ts
+++ b/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.ts
@@ -3,7 +3,7 @@ import { Item } from '../../../../core/shared/item.model';
 import { isNotUndefined } from '../../../../shared/empty.util';
 import {ConfigurationProperty} from '../../../../core/shared/configuration-property.model';
 import {DSONameService} from '../../../../core/breadcrumbs/dso-name.service';
-import {getBaseUrl} from '../../../../shared/clarin-shared-util';
+import {convertMetadataFieldIntoSearchType, getBaseUrl} from '../../../../shared/clarin-shared-util';
 import {ConfigurationDataService} from '../../../../core/data/configuration-data.service';
 import {MetadataValue} from '../../../../core/shared/metadata.models';
 
@@ -82,7 +82,9 @@ export class ClarinGenericItemFieldComponent implements OnInit {
         metadataValue = metadataValueArray;
       });
     }
-    return this.baseUrl + '/search/objects?f.author=' + metadataValue + ',equals';
+
+    const searchType = convertMetadataFieldIntoSearchType(this.fields);
+    return this.baseUrl + '/search/objects?f.' + searchType + '=' + metadataValue + ',equals';
   }
 
   async assignBaseUrl() {

--- a/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.ts
+++ b/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.ts
@@ -1,6 +1,11 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Item } from '../../../../core/shared/item.model';
 import { isNotUndefined } from '../../../../shared/empty.util';
+import {ConfigurationProperty} from '../../../../core/shared/configuration-property.model';
+import {DSONameService} from '../../../../core/breadcrumbs/dso-name.service';
+import {getBaseUrl} from '../../../../shared/clarin-shared-util';
+import {ConfigurationDataService} from '../../../../core/data/configuration-data.service';
+import {MetadataValue} from '../../../../core/shared/metadata.models';
 
 @Component({
   selector: 'ds-clarin-generic-item-field',
@@ -40,15 +45,51 @@ export class ClarinGenericItemFieldComponent implements OnInit {
    */
   @Input() label: string;
 
+  /**
+   * UI URL loaded from the server.
+   */
+  baseUrl = '';
+
   // tslint:disable-next-line:no-empty
-  constructor() { }
+  constructor(protected dsoNameService: DSONameService,
+              protected configurationService: ConfigurationDataService) { }
 
   // tslint:disable-next-line:no-empty
   ngOnInit(): void {
+    this.assignBaseUrl();
   }
 
   public hasMetadataValue() {
     return isNotUndefined(this.item.firstMetadataValue(this.fields));
+  }
+
+  /**
+   * Return current metadata value. The metadata field could have more metadata values, the more often the metadata
+   * field has only one metadata value - index is 0, but sometimes it has more values e.g. `Author`.
+   * @param index
+   */
+  public getLinkToSearch(index) {
+    let metadataValue = 'Error: value is empty';
+    if (index === 0) {
+      // Return first metadata value.
+      metadataValue = this.item.firstMetadataValue(this.fields);
+    } else {
+      // The metadata field has more metadata values - get the actual one
+      this.item.allMetadataValues(this.fields)?.forEach((metadataValueArray, arrayIndex) => {
+        if (index !== arrayIndex) {
+          return;
+        }
+        metadataValue = metadataValueArray;
+      });
+    }
+    return this.baseUrl + '/search/objects?f.author=' + metadataValue + ',equals';
+  }
+
+  async assignBaseUrl() {
+    this.baseUrl = await getBaseUrl(this.configurationService)
+      .then((baseUrlResponse: ConfigurationProperty) => {
+        return baseUrlResponse?.values?.[0];
+      });
   }
 
 }

--- a/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.ts
+++ b/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.ts
@@ -1,10 +1,10 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Item } from '../../../../core/shared/item.model';
-import {isEmpty, isNotUndefined} from '../../../../shared/empty.util';
-import {ConfigurationProperty} from '../../../../core/shared/configuration-property.model';
-import {DSONameService} from '../../../../core/breadcrumbs/dso-name.service';
-import {convertMetadataFieldIntoSearchType, getBaseUrl} from '../../../../shared/clarin-shared-util';
-import {ConfigurationDataService} from '../../../../core/data/configuration-data.service';
+import { isEmpty, isNotUndefined } from '../../../../shared/empty.util';
+import { ConfigurationProperty } from '../../../../core/shared/configuration-property.model';
+import { DSONameService } from '../../../../core/breadcrumbs/dso-name.service';
+import { convertMetadataFieldIntoSearchType, getBaseUrl } from '../../../../shared/clarin-shared-util';
+import { ConfigurationDataService } from '../../../../core/data/configuration-data.service';
 
 @Component({
   selector: 'ds-clarin-generic-item-field',
@@ -58,12 +58,15 @@ export class ClarinGenericItemFieldComponent implements OnInit {
     await this.assignBaseUrl();
   }
 
+  /**
+   * If the metadata fields has some metadata value - show nothing if the field do not have any value.
+   */
   public hasMetadataValue() {
     return isNotUndefined(this.item.firstMetadataValue(this.fields));
   }
 
   /**
-   * Return current metadata value. The metadata field could have more metadata values, the more often the metadata
+   * Return current metadata value. The metadata field could have more metadata values, often the metadata
    * field has only one metadata value - index is 0, but sometimes it has more values e.g. `Author`.
    * @param index
    */
@@ -81,6 +84,10 @@ export class ClarinGenericItemFieldComponent implements OnInit {
     return this.baseUrl + '/search/objects?f.' + searchType + '=' + metadataValue + ',equals';
   }
 
+  /**
+   * If the metadata field has more than 1 value return the value based on the index.
+   * @param index of the metadata value
+   */
   public getMetadataValue(index) {
     let metadataValue = '';
     if (index === 0) {
@@ -98,13 +105,13 @@ export class ClarinGenericItemFieldComponent implements OnInit {
     return metadataValue;
   }
 
+  /**
+   * Load base url from the configuration from the BE.
+   */
   async assignBaseUrl() {
     this.baseUrl = await getBaseUrl(this.configurationService)
       .then((baseUrlResponse: ConfigurationProperty) => {
         return baseUrlResponse?.values?.[0];
       });
   }
-
-
-
 }

--- a/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -29,7 +29,8 @@
                                   [fields]="['dc.contributor.author', 'dc.creator']"
                                   [label]="'relationships.isAuthorOf'"
                                   [iconName]="'fa-pen'"
-                                  [separator]="','">
+                                  [separator]="','"
+                                  [type]="'search'">
     </ds-clarin-generic-item-field>
     <ds-clarin-generic-item-field [item]="object"
                                   [fields]="['dc.identifier.uri']"

--- a/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -30,7 +30,7 @@
                                   [label]="'relationships.isAuthorOf'"
                                   [iconName]="'fa-pen'"
                                   [separator]="','"
-                                  [type]="'search'">
+                                  [type]="'author'">
     </ds-clarin-generic-item-field>
     <ds-clarin-generic-item-field [item]="object"
                                   [fields]="['dc.identifier.uri']"

--- a/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -56,7 +56,8 @@
     <ds-clarin-generic-item-field [item]="object"
                                   [fields]="['dc.type']"
                                   [label]="'item.page.type'"
-                                  [iconName]="'fa-tag'">
+                                  [iconName]="'fa-tag'"
+                                  [type]="'search'">
     </ds-clarin-generic-item-field>
     <ds-clarin-generic-item-field [item]="object"
                                   [fields]="['local.size.info']"
@@ -67,7 +68,8 @@
                                   [fields]="['dc.language.iso']"
                                   [label]="'item.page.language'"
                                   [iconName]="'fa-flag'"
-                                  [separator]="','">
+                                  [separator]="','"
+                                  [type]="'search'">
     </ds-clarin-generic-item-field>
     <ds-clarin-generic-item-field [item]="object"
                                   [fields]="['dc.description']"
@@ -75,9 +77,10 @@
                                   [iconName]="'fa-file-alt'">
     </ds-clarin-generic-item-field>
     <ds-clarin-generic-item-field [item]="object"
-                                  [fields]="['dc.publisher']"
+                                  [fields]="['dc.publisher', 'creativework.publisher']"
                                   [label]="'item.page.publisher'"
-                                  [iconName]="'fa-copy'">
+                                  [iconName]="'fa-copy'"
+                                  [type]="'search'">
     </ds-clarin-generic-item-field>
     <ds-clarin-generic-item-field [item]="object"
                                   [fields]="['local.sponsor']"

--- a/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -91,7 +91,8 @@
                                   [fields]="['dc.subject']"
                                   [label]="'item.page.subject'"
                                   [iconName]="'fa-tags'"
-                                  [separator]="','">
+                                  [separator]="','"
+                                  [type]="'subject'">
     </ds-clarin-generic-item-field>
     <ds-clarin-collections-item-field
                                   [item]="object"

--- a/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -41,7 +41,8 @@
     <ds-clarin-generic-item-field [item]="object"
                                   [fields]="['dc.source.uri']"
                                   [label]="'item.page.project-url'"
-                                  [iconName]="'fa-link'">
+                                  [iconName]="'fa-link'"
+                                  [type]="'hyperlink'">
     </ds-clarin-generic-item-field>
     <ds-clarin-generic-item-field [item]="object"
                                   [fields]="['dc.relation.isreferencedby']"

--- a/src/app/shared/clarin-item-author-preview/clarin-item-author-preview.component.html
+++ b/src/app/shared/clarin-item-author-preview/clarin-item-author-preview.component.html
@@ -1,0 +1,29 @@
+<div>
+  <div *ngIf="itemAuthors.value.length <= 5" class="item-author-wrapper pb-1">
+            <span *ngFor="let author of (itemAuthors | async); let i = index">
+              <span *ngIf="i > 0 && i < itemAuthors.value.length -1"> ; </span>
+              <span *ngIf="i == itemAuthors.value.length -1 && itemAuthors.value.length > 1"> and </span>
+              <a [href]="author.url" class="item-author">{{ author.name }}</a>
+            </span>
+  </div>
+  <div *ngIf="itemAuthors.value.length > 5">
+    <div *ngFor="let author of (itemAuthors | async); let i = index">
+      <span *ngIf="i == 0" ><a [href]="author.url" class="item-author">{{ author.name }}</a> ; et al.</span>
+    </div>
+    <div class="item-author-wrapper">
+              <span (click)="toggleShowEveryAuthor()" class="clarin-font-size">
+                <i [hidden]="showEveryAuthor | async" class="fas fa-caret-right"></i>
+                <i [hidden]="!(showEveryAuthor | async)" class="fas fa-caret-down"></i>
+                Show everyone
+              </span>
+
+      <div [hidden]="!(showEveryAuthor | async)">
+                <span *ngFor="let author of (itemAuthors | async); let i = index">
+                  <span *ngIf="i > 1 && i < itemAuthors.value.length -1"> ; </span>
+                  <span *ngIf="i == itemAuthors.value.length -1"> and </span>
+                  <a *ngIf="i > 0" [href]="author.url" class="item-author">{{author.name}}</a>
+                </span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/shared/clarin-item-author-preview/clarin-item-author-preview.component.scss
+++ b/src/app/shared/clarin-item-author-preview/clarin-item-author-preview.component.scss
@@ -1,0 +1,3 @@
+/**
+This is a styling file for the clarin-item-author-preview component.
+ */

--- a/src/app/shared/clarin-item-author-preview/clarin-item-author-preview.component.spec.ts
+++ b/src/app/shared/clarin-item-author-preview/clarin-item-author-preview.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ClarinItemAuthorPreviewComponent } from './clarin-item-author-preview.component';
+
+describe('ClarinItemAuthorPreviewComponent', () => {
+  let component: ClarinItemAuthorPreviewComponent;
+  let fixture: ComponentFixture<ClarinItemAuthorPreviewComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ClarinItemAuthorPreviewComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ClarinItemAuthorPreviewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/clarin-item-author-preview/clarin-item-author-preview.component.spec.ts
+++ b/src/app/shared/clarin-item-author-preview/clarin-item-author-preview.component.spec.ts
@@ -1,14 +1,23 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ClarinItemAuthorPreviewComponent } from './clarin-item-author-preview.component';
+import {of} from 'rxjs';
+import {ConfigurationDataService} from '../../core/data/configuration-data.service';
 
 describe('ClarinItemAuthorPreviewComponent', () => {
   let component: ClarinItemAuthorPreviewComponent;
   let fixture: ComponentFixture<ClarinItemAuthorPreviewComponent>;
 
+  const configurationServiceSpy = jasmine.createSpyObj('configurationService', {
+    findByPropertyName: of(true),
+  });
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ ClarinItemAuthorPreviewComponent ]
+      declarations: [ ClarinItemAuthorPreviewComponent ],
+      providers: [
+        { provide: ConfigurationDataService, useValue: configurationServiceSpy }
+      ]
     })
     .compileComponents();
   });

--- a/src/app/shared/clarin-item-author-preview/clarin-item-author-preview.component.ts
+++ b/src/app/shared/clarin-item-author-preview/clarin-item-author-preview.component.ts
@@ -40,6 +40,9 @@ export class ClarinItemAuthorPreviewComponent implements OnInit {
     this.showEveryAuthor.next(!this.showEveryAuthor.value);
   }
 
+  /**
+   * Load base url from the configuration from the BE.
+   */
   async assignBaseUrl() {
     this.baseUrl = await getBaseUrl(this.configurationService)
       .then((baseUrlResponse: ConfigurationProperty) => {

--- a/src/app/shared/clarin-item-author-preview/clarin-item-author-preview.component.ts
+++ b/src/app/shared/clarin-item-author-preview/clarin-item-author-preview.component.ts
@@ -1,0 +1,49 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { AuthorNameLink } from '../clarin-item-box-view/clarin-item-box-view.component';
+import { getBaseUrl, loadItemAuthors } from '../clarin-shared-util';
+import { Item } from '../../core/shared/item.model';
+import { ConfigurationProperty } from '../../core/shared/configuration-property.model';
+import { ConfigurationDataService } from '../../core/data/configuration-data.service';
+
+@Component({
+  selector: 'ds-clarin-item-author-preview',
+  templateUrl: './clarin-item-author-preview.component.html',
+  styleUrls: ['./clarin-item-author-preview.component.scss']
+})
+export class ClarinItemAuthorPreviewComponent implements OnInit {
+
+  @Input() item: Item;
+
+  /**
+   * Authors of the Item.
+   */
+  itemAuthors: BehaviorSubject<AuthorNameLink[]> = new BehaviorSubject<AuthorNameLink[]>([]);
+
+  /**
+   * If the Item have a lot of authors do not show them all.
+   */
+  showEveryAuthor: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+
+  /**
+   * UI URL loaded from the server.
+   */
+  baseUrl = '';
+
+  constructor(protected configurationService: ConfigurationDataService) { }
+
+  async ngOnInit(): Promise<void> {
+    await this.assignBaseUrl();
+    loadItemAuthors(this.item, this.itemAuthors, this.baseUrl);
+  }
+  toggleShowEveryAuthor() {
+    this.showEveryAuthor.next(!this.showEveryAuthor.value);
+  }
+
+  async assignBaseUrl() {
+    this.baseUrl = await getBaseUrl(this.configurationService)
+      .then((baseUrlResponse: ConfigurationProperty) => {
+        return baseUrlResponse?.values?.[0];
+      });
+  }
+}

--- a/src/app/shared/clarin-item-box-view/clarin-item-box-view.component.html
+++ b/src/app/shared/clarin-item-box-view/clarin-item-box-view.component.html
@@ -16,33 +16,7 @@
           </div>
         </div>
         <div class="row">
-          <div *ngIf="itemAuthors.value.length <= 5" class="item-author-wrapper pb-1">
-            <span *ngFor="let author of (itemAuthors | async); let i = index">
-              <span *ngIf="i > 0 && i < itemAuthors.value.length -1"> ; </span>
-              <span *ngIf="i == itemAuthors.value.length -1 && itemAuthors.value.length > 1"> and </span>
-              <a [href]="author.url" class="item-author">{{ author.name }}</a>
-            </span>
-          </div>
-          <div *ngIf="itemAuthors.value.length > 5">
-            <div *ngFor="let author of (itemAuthors | async); let i = index">
-              <span *ngIf="i == 0" ><a [href]="author.url" class="item-author">{{ author.name }}</a> ; et al.</span>
-            </div>
-            <div class="item-author-wrapper">
-              <span (click)="toggleShowEveryAuthor()" class="clarin-font-size">
-                <i [hidden]="showEveryAuthor | async" class="fas fa-caret-right"></i>
-                <i [hidden]="!(showEveryAuthor | async)" class="fas fa-caret-down"></i>
-                Show everyone
-              </span>
-
-              <div [hidden]="!(showEveryAuthor | async)">
-                <span *ngFor="let author of (itemAuthors | async); let i = index">
-                  <span *ngIf="i > 1 && i < itemAuthors.value.length -1"> ; </span>
-                  <span *ngIf="i == itemAuthors.value.length -1"> and </span>
-                  <a *ngIf="i > 0" [href]="author.url" class="item-author">{{author.name}}</a>
-                </span>
-              </div>
-            </div>
-          </div>
+          <ds-clarin-item-author-preview [item]="item"></ds-clarin-item-author-preview>
         </div>
         <div class="row d-block pt-1">
           <div><strong>Description:</strong></div>

--- a/src/app/shared/clarin-item-box-view/clarin-item-box-view.component.ts
+++ b/src/app/shared/clarin-item-box-view/clarin-item-box-view.component.ts
@@ -19,7 +19,7 @@ import { RemoteData } from '../../core/data/remote-data';
 import { PaginatedList } from '../../core/data/paginated-list.model';
 import { ClarinLicense } from '../../core/shared/clarin/clarin-license.model';
 import { ClarinLicenseDataService } from '../../core/data/clarin/clarin-license-data.service';
-import { secureImageData } from '../clarin-shared-util';
+import {getBaseUrl, secureImageData} from '../clarin-shared-util';
 import { DomSanitizer } from '@angular/platform-browser';
 import { BundleDataService } from '../../core/data/bundle-data.service';
 import { Bundle } from '../../core/shared/bundle.model';
@@ -197,15 +197,8 @@ export class ClarinItemBoxViewComponent implements OnInit {
           });
       });
   }
-
-  async getBaseUrl(): Promise<any> {
-    return this.configurationService.findByPropertyName('dspace.ui.url')
-      .pipe(getFirstSucceededRemoteDataPayload())
-      .toPromise();
-  }
-
   async assignBaseUrl() {
-    this.baseUrl = await this.getBaseUrl()
+    this.baseUrl = await getBaseUrl(this.configurationService)
       .then((baseUrlResponse: ConfigurationProperty) => {
         return baseUrlResponse?.values?.[0];
       });

--- a/src/app/shared/clarin-item-box-view/clarin-item-box-view.component.ts
+++ b/src/app/shared/clarin-item-box-view/clarin-item-box-view.component.ts
@@ -19,7 +19,7 @@ import { RemoteData } from '../../core/data/remote-data';
 import { PaginatedList } from '../../core/data/paginated-list.model';
 import { ClarinLicense } from '../../core/shared/clarin/clarin-license.model';
 import { ClarinLicenseDataService } from '../../core/data/clarin/clarin-license-data.service';
-import {getBaseUrl, secureImageData} from '../clarin-shared-util';
+import { getBaseUrl, secureImageData } from '../clarin-shared-util';
 import { DomSanitizer } from '@angular/platform-browser';
 import { BundleDataService } from '../../core/data/bundle-data.service';
 import { Bundle } from '../../core/shared/bundle.model';
@@ -81,14 +81,7 @@ export class ClarinItemBoxViewComponent implements OnInit {
    * How many files the Item has.
    */
   itemCountOfFiles: BehaviorSubject<number> = new BehaviorSubject<number>(-1);
-  /**
-   * Authors of the Item.
-   */
-  itemAuthors: BehaviorSubject<AuthorNameLink[]> = new BehaviorSubject<AuthorNameLink[]>([]);
-  /**
-   * If the Item have a lot of authors do not show them all.
-   */
-  showEveryAuthor: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+
   /**
    * Current License Label e.g. `PUB`
    */
@@ -132,33 +125,6 @@ export class ClarinItemBoxViewComponent implements OnInit {
     this.getItemCommunity();
     this.loadItemLicense();
     this.getItemFilesSize();
-    this.loadItemAuthors();
-  }
-
-  private loadItemAuthors() {
-    if (isNull(this.item)) {
-      return;
-    }
-
-    let authorsMV: MetadataValue[] = this.item?.metadata?.['dc.contributor.author'];
-    // Harvested Items has authors in the metadata field `dc.creator`.
-    if (isUndefined(authorsMV)) {
-      authorsMV = this.item?.metadata?.['dc.creator'];
-    }
-
-    if (isUndefined(authorsMV)) {
-      return null;
-    }
-    const itemAuthorsLocal = [];
-    authorsMV.forEach((authorMV: MetadataValue) => {
-      const authorSearchLink = this.baseUrl + '/search/objects?f.author=' + authorMV.value + ',equals';
-      const authorNameLink = Object.assign(new AuthorNameLink(), {
-        name: authorMV.value,
-        url: authorSearchLink
-      });
-      itemAuthorsLocal.push(authorNameLink);
-    });
-    this.itemAuthors.next(itemAuthorsLocal);
   }
 
   private getItemFilesSize() {
@@ -244,17 +210,13 @@ export class ClarinItemBoxViewComponent implements OnInit {
   secureImageData(imageByteArray) {
     return secureImageData(this.sanitizer, imageByteArray);
   }
-
-  toggleShowEveryAuthor() {
-    this.showEveryAuthor.next(!this.showEveryAuthor.value);
-  }
 }
 
 /**
  * Redirect the user after clicking on the `Author`.
  */
 // tslint:disable-next-line:max-classes-per-file
-class AuthorNameLink {
+export class AuthorNameLink {
   name: string;
   url: string;
 }

--- a/src/app/shared/clarin-shared-util.ts
+++ b/src/app/shared/clarin-shared-util.ts
@@ -25,6 +25,10 @@ export function convertMetadataFieldIntoSearchType(field: string[]) {
       return 'itemtype';
     case field.includes('dc.publisher') || field.includes('creativework.publisher'):
       return 'publisher';
+    case field.includes('dc.language.iso'):
+      return 'language';
+    case field.includes('dc.subject'):
+      return 'subject';
     default:
       return '';
   }

--- a/src/app/shared/clarin-shared-util.ts
+++ b/src/app/shared/clarin-shared-util.ts
@@ -1,4 +1,6 @@
 import { DomSanitizer } from '@angular/platform-browser';
+import {getFirstSucceededRemoteDataPayload} from '../core/shared/operators';
+import {ConfigurationDataService} from '../core/data/configuration-data.service';
 
 /**
  * Convert raw byte array to the image is not secure - this function make it secure
@@ -7,4 +9,10 @@ import { DomSanitizer } from '@angular/platform-browser';
 export function secureImageData(sanitizer: DomSanitizer,imageByteArray) {
   const objectURL = 'data:image/png;base64,' + imageByteArray;
   return sanitizer.bypassSecurityTrustUrl(objectURL);
+}
+
+export function getBaseUrl(configurationService: ConfigurationDataService): Promise<any> {
+  return configurationService.findByPropertyName('dspace.ui.url')
+    .pipe(getFirstSucceededRemoteDataPayload())
+    .toPromise();
 }

--- a/src/app/shared/clarin-shared-util.ts
+++ b/src/app/shared/clarin-shared-util.ts
@@ -1,6 +1,9 @@
 import { DomSanitizer } from '@angular/platform-browser';
-import {getFirstSucceededRemoteDataPayload} from '../core/shared/operators';
-import {ConfigurationDataService} from '../core/data/configuration-data.service';
+import { getFirstSucceededRemoteDataPayload } from '../core/shared/operators';
+import { ConfigurationDataService } from '../core/data/configuration-data.service';
+import { isNull, isUndefined } from './empty.util';
+import { MetadataValue } from '../core/shared/metadata.models';
+import { AuthorNameLink } from './clarin-item-box-view/clarin-item-box-view.component';
 
 /**
  * Convert raw byte array to the image is not secure - this function make it secure
@@ -17,6 +20,12 @@ export function getBaseUrl(configurationService: ConfigurationDataService): Prom
     .toPromise();
 }
 
+/**
+ * Some metadata values in the Item View has links to redirect for search, this method decides what is the search field
+ * based on the metadata field.
+ *
+ * @param field metadata field
+ */
 export function convertMetadataFieldIntoSearchType(field: string[]) {
   switch (true) {
     case field.includes('dc.contributor.author') || field.includes('dc.creator'):
@@ -32,4 +41,38 @@ export function convertMetadataFieldIntoSearchType(field: string[]) {
     default:
       return '';
   }
+}
+
+/**
+ * Load Authors of the current item into BehaviourSubject - ItemAuthors. This method also compose
+ * search link for every Author.
+ *
+ * @param item current Item
+ * @param itemAuthors BehaviourSubject (async) of Authors with search links
+ * @param baseUrl e.g. localhost:8080
+ */
+export function loadItemAuthors(item, itemAuthors, baseUrl) {
+  if (isNull(item) || isNull(itemAuthors) || isNull(baseUrl)) {
+    return;
+  }
+
+  let authorsMV: MetadataValue[] = item?.metadata?.['dc.contributor.author'];
+  // Harvested Items has authors in the metadata field `dc.creator`.
+  if (isUndefined(authorsMV)) {
+    authorsMV = item?.metadata?.['dc.creator'];
+  }
+
+  if (isUndefined(authorsMV)) {
+    return null;
+  }
+  const itemAuthorsLocal = [];
+  authorsMV.forEach((authorMV: MetadataValue) => {
+    const authorSearchLink = baseUrl + '/search/objects?f.author=' + authorMV.value + ',equals';
+    const authorNameLink = Object.assign(new AuthorNameLink(), {
+      name: authorMV.value,
+      url: authorSearchLink
+    });
+    itemAuthorsLocal.push(authorNameLink);
+  });
+  itemAuthors.next(itemAuthorsLocal);
 }

--- a/src/app/shared/clarin-shared-util.ts
+++ b/src/app/shared/clarin-shared-util.ts
@@ -16,3 +16,16 @@ export function getBaseUrl(configurationService: ConfigurationDataService): Prom
     .pipe(getFirstSucceededRemoteDataPayload())
     .toPromise();
 }
+
+export function convertMetadataFieldIntoSearchType(field: string[]) {
+  switch (true) {
+    case field.includes('dc.contributor.author') || field.includes('dc.creator'):
+      return 'author';
+    case field.includes('dc.type'):
+      return 'itemtype';
+    case field.includes('dc.publisher') || field.includes('creativework.publisher'):
+      return 'publisher';
+    default:
+      return '';
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -183,6 +183,7 @@ import { ClarinLicenseLabelRadioValuePipe } from './utils/clarin-license-label-r
 import { CharToEndPipe } from './utils/char-to-end.pipe';
 import { ClarinLicenseRequiredInfoPipe } from './utils/clarin-license-required-info.pipe';
 import { ClarinItemBoxViewComponent } from './clarin-item-box-view/clarin-item-box-view.component';
+import { ClarinItemAuthorPreviewComponent } from './clarin-item-author-preview/clarin-item-author-preview.component';
 
 const MODULES = [
   // Do NOT include UniversalModule, HttpModule, or JsonpModule here
@@ -357,7 +358,8 @@ const COMPONENTS = [
   CommunitySidebarSearchListElementComponent,
   SearchNavbarComponent,
   ScopeSelectorModalComponent,
-  ClarinItemBoxViewComponent
+  ClarinItemBoxViewComponent,
+  ClarinItemAuthorPreviewComponent
 ];
 
 const ENTRY_COMPONENTS = [

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3612,6 +3612,8 @@
 
   "search.filters.applied.f.items_owning_community": "Community",
 
+  "search.filters.applied.f.publisher": "Publisher",
+
 
 
   "search.filters.filter.author.head": "Author",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -2354,6 +2354,10 @@
 
   "item.preview.oaire.fundingStream": "Funding Stream:",
 
+  "item.preview.authors.show.everyone": "Show everyone",
+
+  "item.preview.authors.et.al": " ; et al.",
+
 
   "item.refbox.modal.copy.instruction": ["Press", "ctrl + c", "to copy"],
 

--- a/src/styles/_clarin-styles.scss
+++ b/src/styles/_clarin-styles.scss
@@ -9,3 +9,7 @@
 .label-RES {
   background-color: #c62d1f;
 }
+
+.cursor-pointer {
+  cursor: pointer;
+}


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  4.8  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  4.3 + 3  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
- Updated `clarin-generic-item-field` to redirect the user to the `browse` page based on the metadata value.
- Created `clarin-item-author-preview` component to wrap the author preview functionality into one component because it is used in more places.

## Problems
- Browse configuration for some metadata fields was missing so I configured it here: https://github.com/dataquest-dev/DSpace/pull/252/files#diff-39220e4ec26d2bc963fa3162bda3fbe3a9076354cb73efc5525c89f57033a1f6R1070-R1073