### PR TITLE
TUL/language-icon-not-working

### DIFF
--- a/src/app/shared/lang-switch/lang-switch.component.html
+++ b/src/app/shared/lang-switch/lang-switch.component.html
@@ -2,7 +2,7 @@
   <a href="javascript:void(0);" role="button"
      [attr.aria-label]="'nav.language' |translate"
      [title]="'nav.language' | translate" class="px-1"
-     (click)="$event.preventDefault()" data-toggle="dropdown" ngbDropdownToggle
+     (click)="$event.preventDefault()" ngbDropdownToggle
      tabindex="0">
     <i class="fas fa-globe-asia fa-lg fa-fw"></i>
   </a>


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0.1 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Fixed by following this thread: https://stackoverflow.com/questions/24218663/avoid-having-to-double-click-to-toggle-bootstrap-dropdown