### PR TITLE
change entrypoint so that containers has less logs and restarts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN yarn install --network-timeout 300000
 RUN apk add tzdata
 RUN yarn build:prod
 RUN npm install pm2 -g
-CMD /bin/sh -c "pm2 start dspace-ui.json && pm2 logs"
+CMD /bin/sh -c "pm2-runtime start dspace-ui.json > /dev/null 2> /dev/null"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       dockerfile: Dockerfile
     networks:
       dspacenet:
-    entrypoint: ${FE_CMD:-/bin/sh -c "pm2 start dspace-ui.json && pm2 logs"}
+    entrypoint: ${FE_CMD:-/bin/sh -c "pm2-runtime start dspace-ui.json > /dev/null 2> /dev/null"}
     ports:
     - published: 400${INSTANCE}
       target: 4000


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description

Entrypoint was wrong -> too many logs and not 
restarting if pm2 crashed. Now it restarts and
logs are eliminated
