### PR TITLE
ufal/cannot-load-user-metadata

### DIFF
--- a/src/app/core/data/item-data.service.ts
+++ b/src/app/core/data/item-data.service.ts
@@ -46,8 +46,8 @@ import { RestRequestMethod } from './rest-request-method';
 import { CreateData, CreateDataImpl } from './base/create-data';
 import { RequestParam } from '../cache/models/request-param.model';
 import { dataService } from './base/data-service.decorator';
-import {SearchData} from './base/search-data';
-import {FollowLinkConfig} from '../../shared/utils/follow-link-config.model';
+import { SearchData, SearchDataImpl } from './base/search-data';
+import { FollowLinkConfig } from '../../shared/utils/follow-link-config.model';
 
 /**
  * An abstract service for CRUD operations on Items
@@ -420,6 +420,7 @@ export class ItemDataService extends BaseItemDataService {
     protected bundleService: BundleDataService,
   ) {
     super('items', requestService, rdbService, objectCache, halService, notificationsService, comparator, browseService, bundleService);
+    this.searchData = new SearchDataImpl(this.linkPath, requestService, rdbService, objectCache, halService, this.responseMsToLive);
   }
 
   searchBy(searchMethod: string, options?: FindListOptions, useCachedVersionIfAvailable?: boolean, reRequestOnStale?: boolean, ...linksToFollow: FollowLinkConfig<Item>[]): Observable<RemoteData<PaginatedList<Item>>> {


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  1  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
After the upgrade to CLARIN-DSpace7.6.1. suddenly the user metadata wasn't loaded: 
![image](https://github.com/dataquest-dev/dspace-angular/assets/90026355/1a0b3b93-c39f-47eb-8fb1-54d05c885846)

It was because of mistake in the `item-data.service.ts`.
