### PR TITLE
Updated text color to white in the /licenses page

### DIFF
--- a/src/app/clarin-licenses/clarin-all-licenses-page/clarin-all-licenses-page.component.scss
+++ b/src/app/clarin-licenses/clarin-all-licenses-page/clarin-all-licenses-page.component.scss
@@ -15,6 +15,7 @@
 
 .label-default {
   background-color: #999 !important;
+  color: white !important;
 }
 
 .license-card-border {


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |

