### PR TITLE
Translations + orcid in UI

### DIFF
--- a/src/app/shared/clarin-item-author-preview/clarin-item-author-preview.component.html
+++ b/src/app/shared/clarin-item-author-preview/clarin-item-author-preview.component.html
@@ -5,12 +5,14 @@
               <span *ngIf="i == (itemAuthors | async).length -1 && (itemAuthors | async).length > 1">
                 {{'item.view.box.author.preview.and' | translate}}
               </span>
-              <a [href]="author.url" class="item-author">{{ author.name }}</a>
+              <a [href]="author.url" class="item-author">{{ author.name }}
+                <i *ngIf="author.isAuthority" class="fa-brands fa-orcid"> &nbsp;</i></a>
             </span>
   </div>
   <div *ngIf="(itemAuthors | async).length > 5">
     <div *ngFor="let author of (itemAuthors | async); let i = index">
-      <span *ngIf="i == 0" ><a [href]="author.url" class="item-author">{{ author.name }}</a>; et al.</span>
+      <span *ngIf="i == 0" ><a [href]="author.url" class="item-author">{{ author.name }}
+        <i *ngIf="author.isAuthority" class="fa-brands fa-orcid"> &nbsp;</i></a>; et al.</span>
     </div>
     <div class="item-author-wrapper">
               <span (click)="toggleShowEveryAuthor()" class="clarin-font-size cursor-pointer">
@@ -25,7 +27,8 @@
                   <span *ngIf="i == (itemAuthors | async).length -1">
                     {{'item.view.box.author.preview.and' | translate}}
                   </span>
-                  <a *ngIf="i > 0" [href]="author.url" class="item-author">{{author.name}}</a>
+                  <a *ngIf="i > 0" [href]="author.url" class="item-author">{{author.name}}
+                    <i *ngIf="author.isAuthority" class="fa-brands fa-orcid"> &nbsp;</i></a>
                 </span>
       </div>
     </div>

--- a/src/app/shared/clarin-item-box-view/clarin-author-name-link.model.ts
+++ b/src/app/shared/clarin-item-box-view/clarin-author-name-link.model.ts
@@ -5,4 +5,5 @@
 export class AuthorNameLink {
   name: string;
   url: string;
+  isAuthority: boolean;
 }

--- a/src/app/shared/clarin-shared-util.ts
+++ b/src/app/shared/clarin-shared-util.ts
@@ -63,10 +63,19 @@ export function loadItemAuthors(item, itemAuthors, baseUrl, fields) {
   }
   const itemAuthorsLocal = [];
   authorsMV.forEach((authorMV: MetadataValue) => {
-    const authorSearchLink = baseUrl + '/search?f.author=' + authorMV.value + ',equals';
+    let value: string, operator: string;
+    if (authorMV.authority) {
+      value = encodeURIComponent(authorMV.authority);
+      operator = 'authority';
+    } else {
+      value = encodeURIComponent(authorMV.value);
+      operator = 'equals';
+    }
+    const authorSearchLink = baseUrl + '/search?f.author=' + value + ',' + operator;
     const authorNameLink = Object.assign(new AuthorNameLink(), {
       name: authorMV.value,
-      url: authorSearchLink
+      url: authorSearchLink,
+      isAuthority: !!authorMV.authority
     });
     itemAuthorsLocal.push(authorNameLink);
   });

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -1721,8 +1721,31 @@
   "form.no-results": "Nebyli nalezeny žádné výsledky",
   // "form.no-value": "No value entered",
   "form.no-value": "Nebyla zadána hodnota",
-  // "form.other-information": {},
-  "form.other-information": {},
+
+  // "form.other-information.email": "Email",
+  "form.other-information.email": "Email",
+
+  // "form.other-information.first-name": "First Name",
+  "form.other-information.first-name": "Křestní jméno",
+
+  // "form.other-information.insolr": "In Solr Index",
+  "form.other-information.insolr": "V SOLR indexu",
+
+  // "form.other-information.institution": "Institution",
+  "form.other-information.institution": "Organizace",
+
+  // "form.other-information.last-name": "Last Name",
+  "form.other-information.last-name": "Příjmení",
+
+  // "form.other-information.orcid": "ORCID",
+  "form.other-information.orcid": "ORCID",
+
+  // "form.other-information.credit-name": "Credit Name",
+  "form.other-information.credit-name": "Preferované jméno",
+
+  // "form.other-information.other-names": "Other Names",
+  "form.other-information.other-names": "Další jména",
+
   // "form.remove": "Remove",
   "form.remove": "Smazat",
   // "form.save": "Save",
@@ -4789,6 +4812,16 @@
   "submission.sections.submit.progressbar.describe.stepone": "Popis",
   // "submission.sections.submit.progressbar.describe.steptwo": "Describe",
   "submission.sections.submit.progressbar.describe.steptwo": "Popis",
+
+  // "submission.sections.submit.progressbar.describe.dataciterequired": "Required Properties",
+  "submission.sections.submit.progressbar.describe.dataciterequired": "Minimální popis (povinné)",
+
+  // "submission.sections.submit.progressbar.describe.dataciterecommended": "Recommended Properties",
+  "submission.sections.submit.progressbar.describe.dataciterecommended": "Rozšířený popis (doporučené)",
+
+  // "submission.sections.submit.progressbar.describe.dataciteoptional": "Optional Properties",
+  "submission.sections.submit.progressbar.describe.dataciteoptional": "Rozšířený popis (volitelné)",
+
   // "submission.sections.submit.progressbar.detect-duplicate": "Potential duplicates",
   "submission.sections.submit.progressbar.detect-duplicate": "Potenciální duplicity",
   // "submission.sections.submit.progressbar.identifiers": "Identifiers",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1798,6 +1798,10 @@
 
   "form.other-information.orcid": "ORCID",
 
+  "form.other-information.credit-name": "Credit Name",
+
+  "form.other-information.other-names": "Other Names",
+
   "form.remove": "Remove",
 
   "form.save": "Save",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -4937,6 +4937,12 @@
 
   "submission.sections.submit.progressbar.describe.steptwo": "Describe",
 
+  "submission.sections.submit.progressbar.describe.dataciterequired": "Required Properties",
+
+  "submission.sections.submit.progressbar.describe.dataciterecommended": "Recommended Properties",
+
+  "submission.sections.submit.progressbar.describe.dataciteoptional": "Optional Properties",
+
   "submission.sections.submit.progressbar.detect-duplicate": "Potential duplicates",
 
   "submission.sections.submit.progressbar.identifiers": "Identifiers",


### PR DESCRIPTION
@milanmajchrak feel free to change the base branch

- `en.json5` 
  - english translations for datacite submission section headings
  - english translations for orcid lookup (other/extra info)

- if author md field has authority value, assume it's orcid
  - add `fa-brands fa-orcid` next to the name 
![image](https://github.com/dataquest-dev/dspace-angular/assets/1842385/0e1d47e2-928c-47a4-b80b-71d4811f1089)
  -  when linking to search use the authority value (instead of text value), also use the authority operator
