### PR TITLE
removed IP metadatakey from request

### DIFF
--- a/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
+++ b/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
@@ -165,15 +165,17 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
       CLARIN_USER_METADATA_MANAGE;
     url += this.isDownloadingZIP() ? '/zip?itemUUID=' + this.item$.value.uuid : '?bitstreamUUID=' +
       this.getBitstreamUUID();
-    const postRequest = new PostRequest(requestId, url, this.userMetadata$.value?.page, requestOptions);
-
+    if (this.userMetadata$.value?.page) {
+      // Filter the page array to exclude items with metadataKey "IP"
+      this.userMetadata$.value.page = this.userMetadata$.value.page.filter(item => item.metadataKey !== "IP");
+    }
     // Add IP address into request. Every restricted download must have stored IP address in the `user_metadata` table.
     this.userMetadata$.value?.page.push(Object.assign(new ClarinUserMetadata(), {
       type: ClarinUserMetadata.type,
       metadataKey: 'IP',
       metadataValue: this.ipAddress$.value
     }));
-
+    const postRequest = new PostRequest(requestId, url, this.userMetadata$.value?.page, requestOptions);
     // Send POST request
     this.requestService.send(postRequest);
     // Get response

--- a/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
+++ b/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
@@ -167,7 +167,8 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
       this.getBitstreamUUID();
     if (this.userMetadata$.value?.page) {
       // Filter the page array to exclude items with metadataKey "IP"
-      this.userMetadata$.value.page = this.userMetadata$.value.page.filter(item => item.metadataKey !== "IP");
+      this.userMetadata$.value.page =
+        this.userMetadata$.value.page.filter(item => item.metadataKey !== 'IP');
     }
     // Add IP address into request. Every restricted download must have stored IP address in the `user_metadata` table.
     this.userMetadata$.value?.page.push(Object.assign(new ClarinUserMetadata(), {


### PR DESCRIPTION
Data are stored in the database multiple times because the request contains all stored data in user_metadata. We removed entries from the request where metadataKey is "IP" and added only the new IP address.