### PR TITLE
different-required-field-when-download-hamledt

### DIFF
--- a/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
+++ b/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
@@ -312,6 +312,8 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
     let shouldSee = false;
     this.requiredInfo$?.value?.forEach(requiredInfo => {
       if (requiredInfo?.name === 'SEND_TOKEN') {
+        // We don't want to display SEND_TOKEN as an input field
+        this.requiredInfo$.next(this.requiredInfo$.value?.filter(item => item.name !== 'SEND_TOKEN'));
         shouldSee = true;
       }
     });


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  5  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
In the required info, there are SEND_TOKEN and EXTRA_EMAIL. In version 5, when SEND_TOKEN is required, the system sends information to the address in the EXTRA_EMAIL field. We require two addresses from the user and will send an email to the address in the SEND_TOKEN field when SEND_TOKEN is required.
## Solution
Do not require SEND_TOKEN as an input field. Instead, send the email to the EXTRA_EMAIL address when SEND_TOKEN is required.

