### PR TITLE
Internal/Removed two IT because there are outdated

### DIFF
--- a/cypress/e2e/submission-ui.cy.ts
+++ b/cypress/e2e/submission-ui.cy.ts
@@ -230,18 +230,6 @@ describe('Create a new submission', () => {
     createItemProcess.showErrorNotSupportedLicense();
   });
 
-  // Author field should consist of two input fields
-  it('Author field should consist of two input fields', {
-    retries: {
-      runMode: 6,
-      openMode: 6,
-    },
-    defaultCommandTimeout: 10000
-  },() => {
-    createItemProcess.checkAuthorFirstnameField();
-    createItemProcess.checkAuthorLastnameField();
-  });
-
   it('The submission should not have the Notice Step', {
     retries: {
       runMode: 6,
@@ -260,16 +248,6 @@ describe('Create a new submission in the clariah collection', () => {
 
     // This page is restricted, so we will be shown the login form. Fill it out & submit.
     cy.loginViaForm(TEST_ADMIN_USER, TEST_ADMIN_PASSWORD);
-  });
-
-  it('The submission should have the Notice Step', {
-    retries: {
-      runMode: 6,
-      openMode: 6,
-    },
-    defaultCommandTimeout: 10000
-  },() => {
-    createItemProcess.checkClarinNoticeStep();
   });
 });
 


### PR DESCRIPTION
1. Author does not have a two input fields.
2. Test for checking the notice step will be transformed into UI test, because we do not want to keep such specific collection for generic IT.

| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Follow up issue: https://github.com/dataquest-dev/dspace-customers/issues/152