### PR TITLE
Use only 4000, not the {UI_PORT} from the .env in the docker-compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,8 @@ services:
       TZ: ${TIMEZONE:-Europe/Bratislava}
       DSPACE_UI_SSL: 'false'
       DSPACE_UI_HOST: dspace-angular
-      DSPACE_UI_PORT: ${UI_PORT:-4000}
+      # Use only 4000, not the {UI_PORT} from the .env because in the container it is always 4000
+      DSPACE_UI_PORT: 4000
       DSPACE_UI_NAMESPACE: ${DSPACE_UI_NAMESPACE:-/}
       DSPACE_REST_SSL: ${DSPACE_SSL:-false}
       DSPACE_REST_HOST: ${DSPACE_HOST:-localhost}


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
The container in wasn't listening on the port 4000 because it was overridden by the UI_PORT from the .env 
