### PR TITLE
UFAL/Enhanced type-bind error

### DIFF
--- a/src/app/shared/form/builder/models/form-field.model.ts
+++ b/src/app/shared/form/builder/models/form-field.model.ts
@@ -137,4 +137,7 @@ export class FormFieldModel {
 
   @autoserialize
   autocompleteCustom: string;
+
+  @autoserialize
+  typeBindField: string;
 }

--- a/src/app/shared/form/builder/parsers/field-parser.ts
+++ b/src/app/shared/form/builder/parsers/field-parser.ts
@@ -330,6 +330,9 @@ export abstract class FieldParser {
         this.parserOptions.typeField);
     }
 
+    if (isNotEmpty(this.configData.typeBindField)) {
+      controlModel.typeBindField = this.configData.typeBindField;
+    }
     return controlModel;
   }
 


### PR DESCRIPTION
BE: https://github.com/dataquest-dev/DSpace/pull/822
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
The type-binded input fields wasn't working properly. They were still displayed.
