### PR TITLE
UFAL/Shibboleth - cannot log in after verification token

### DIFF
--- a/src/app/login-page/autoregistration/autoregistration.component.ts
+++ b/src/app/login-page/autoregistration/autoregistration.component.ts
@@ -22,7 +22,6 @@ import { HttpHeaders } from '@angular/common/http';
 import { AuthTokenInfo } from '../../core/auth/models/auth-token-info.model';
 import { isEmpty } from '../../shared/empty.util';
 import { CoreState } from 'src/app/core/core-state.model';
-import { hasSucceeded } from 'src/app/core/data/request-entry-state.model';
 import { FindListOptions } from '../../core/data/find-list-options.model';
 import { getBaseUrl } from '../../shared/clarin-shared-util';
 import { ConfigurationProperty } from '../../core/shared/configuration-property.model';
@@ -99,7 +98,7 @@ export class AutoregistrationComponent implements OnInit {
     });
 
     if (this.showAttributes.value === false) {
-      this.sendAutoLoginRequest();
+      this.autologin();
     }
   }
 
@@ -119,11 +118,9 @@ export class AutoregistrationComponent implements OnInit {
     const response = this.rdbService.buildFromRequestUUID(requestId);
     // Process response
     response
-      .pipe(getFirstCompletedRemoteData())
+      .pipe(getFirstSucceededRemoteData())
       .subscribe(responseRD$ => {
-        if (hasSucceeded(responseRD$.state)) {
-          // Show successful message
-          this.notificationService.success(this.translateService.instant('clarin.autoregistration.successful.message'));
+        if (responseRD$.hasSucceeded) {
           // Call autologin
           this.sendAutoLoginRequest();
         } else {


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
I refactored the code here: https://github.com/dataquest-dev/dspace-angular/commit/d1fbc1be6cc775ac2ca64df33890b6f626c5b0f0#diff-e1768152d3d1c4e6fb6c823c02822d7059c626f9ec14c234fdd132b6e09e78bbR69 and I did a mistake.

Before the "fix" the user had to click on the Login button which calls the autoLogin method, but after the fix another method is called on the component Init. https://github.com/dataquest-dev/dspace-angular/blob/dtq-dev/src/app/login-page/autoregistration/autoregistration.component.html#L32C67-L32C68

I fixed it by using autoLogin method.
