### PR TITLE
UFAL/Temporary fix for the type-bind. The form automatically refreshes after the type is changed.

### DIFF
--- a/src/app/shared/form/builder/form-builder.service.ts
+++ b/src/app/shared/form/builder/form-builder.service.ts
@@ -94,7 +94,7 @@ export class FormBuilderService extends DynamicFormService {
     this.typeFields.set(TYPE_BIND_DEFAULT_KEY, 'dc_type');
     // If optional config service was passed, perform an initial set of type field (default dc_type) for type binds
     if (hasValue(this.configService)) {
-      this.setTypeBindFieldFromConfig();
+      this.setTypeBindFieldFromConfig(this.typeFields);
     }
 
 
@@ -560,7 +560,7 @@ export class FormBuilderService extends DynamicFormService {
   /**
    * Get the type bind field from config
    */
-  setTypeBindFieldFromConfig(metadataField: string = null): void {
+  setTypeBindFieldFromConfig(typeBindFields: Map<string, string>, metadataField: string = null): void {
     this.configService.findByPropertyName('submit.type-bind.field').pipe(
       getFirstCompletedRemoteData(),
     ).subscribe((remoteData: any) => {
@@ -584,7 +584,7 @@ export class FormBuilderService extends DynamicFormService {
             const normalizedValuePart = valuePart.replace(/\./g, '_');
 
             // Set the value in the typeFields map
-            this.typeFields.set(metadataFieldConfigPart, normalizedValuePart);
+            typeBindFields.set(metadataFieldConfigPart, normalizedValuePart);
 
             if (metadataFieldConfigPart === metadataField) {
               typeFieldConfigValue = valuePart;
@@ -596,7 +596,7 @@ export class FormBuilderService extends DynamicFormService {
         }
 
         // Always update the typeFields map with the default value, normalized
-        this.typeFields.set(TYPE_BIND_DEFAULT_KEY, typeFieldConfigValue.replace(/\./g, '_'));
+        typeBindFields.set(TYPE_BIND_DEFAULT_KEY, typeFieldConfigValue.replace(/\./g, '_'));
       });
     });
   }
@@ -607,7 +607,7 @@ export class FormBuilderService extends DynamicFormService {
    */
   getTypeField(metadataField: string): string {
     if (hasValue(this.configService) && isEmpty(this.typeFields.values())) {
-      this.setTypeBindFieldFromConfig(metadataField);
+      this.setTypeBindFieldFromConfig(this.typeFields, metadataField);
     } else if (hasNoValue(this.typeFields.get(TYPE_BIND_DEFAULT_KEY))) {
       this.typeFields.set(TYPE_BIND_DEFAULT_KEY, 'dc_type');
     }

--- a/src/app/shared/mocks/form-builder-service.mock.ts
+++ b/src/app/shared/mocks/form-builder-service.mock.ts
@@ -39,7 +39,8 @@ export function getMockFormBuilderService(): FormBuilderService {
           {match: 'VISIBLE', operator: 'OR', when: [{id: 'dc.type', value: 'boundType'}]}
         ]
       }
-    )
+    ),
+    setTypeBindFieldFromConfig: {},
   });
 
 }

--- a/src/app/submission/sections/form/section-form.component.ts
+++ b/src/app/submission/sections/form/section-form.component.ts
@@ -436,22 +436,22 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
     // The values in the `typeFields` are in the format `dc_type` or `edm_type`, so we need to replace `_` with `.`
     [...this.typeFields.values()].some(typeValue => {
       if (typeValue.replace('_', '.') === metadata) {
-        this.handleFormSave(typeValue, value);
+        this.dispatchFormSaveAndReinitialize(typeValue, value);
         return true;
       }
     });
 
     if ([SPONSOR_METADATA_NAME, AUTHOR_METADATA_FIELD_NAME].includes(metadata)) {
-      this.handleFormSave(metadata, value);
+      this.dispatchFormSaveAndReinitialize(metadata, value);
     }
   }
 
   /**
-   * Handle form save and reinitialization
+   * Dispatch form save and reinitialize form
    * @param metadata
    * @param value
    */
-  handleFormSave(metadata, value) {
+  dispatchFormSaveAndReinitialize(metadata, value) {
     this.submissionService.dispatchSaveSection(this.submissionId, this.sectionData.id);
     this.reinitializeForm(metadata, value);
   }

--- a/src/app/submission/sections/form/section-form.component.ts
+++ b/src/app/submission/sections/form/section-form.component.ts
@@ -136,6 +136,11 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
   public sponsorRefreshTimeout = 20;
 
   /**
+   * The map of type bind fields. We need to have this map to check if the type field is updated.
+   */
+  private typeFields: Map<string, string>;
+
+  /**
    * The FormComponent reference
    */
   @ViewChild('formRef') private formRef: FormComponent;
@@ -175,6 +180,7 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
               @Inject('sectionDataProvider') public injectedSectionData: SectionDataObject,
               @Inject('submissionIdProvider') public injectedSubmissionId: string) {
     super(injectedCollectionId, injectedSectionData, injectedSubmissionId);
+    this.typeFields = new Map();
   }
 
   /**
@@ -209,6 +215,7 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
           this.cdr.detectChanges();
         }
       });
+    this.formBuilderService.setTypeBindFieldFromConfig(this.typeFields);
   }
 
   /**
@@ -424,15 +431,29 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
       this.submissionService.dispatchSave(this.submissionId);
     }
 
-    if (metadata === SPONSOR_METADATA_NAME) {
-      this.submissionService.dispatchSaveSection(this.submissionId, this.sectionData.id);
-      this.reinitializeForm(SPONSOR_METADATA_NAME, value);
-    }
+    // Check if the type field is updated it could be e.g. `dc.type` or `edm.type` metadata field
+    // `.some()` method is used to break the loop when the type field is found.
+    // The values in the `typeFields` are in the format `dc_type` or `edm_type`, so we need to replace `_` with `.`
+    [...this.typeFields.values()].some(typeValue => {
+      if (typeValue.replace('_', '.') === metadata) {
+        this.handleFormSave(typeValue, value);
+        return true;
+      }
+    });
 
-    if (metadata === AUTHOR_METADATA_FIELD_NAME) {
-      this.submissionService.dispatchSaveSection(this.submissionId, this.sectionData.id);
-      this.reinitializeForm(AUTHOR_METADATA_FIELD_NAME, value);
+    if ([SPONSOR_METADATA_NAME, AUTHOR_METADATA_FIELD_NAME].includes(metadata)) {
+      this.handleFormSave(metadata, value);
     }
+  }
+
+  /**
+   * Handle form save and reinitialization
+   * @param metadata
+   * @param value
+   */
+  handleFormSave(metadata, value) {
+    this.submissionService.dispatchSaveSection(this.submissionId, this.sectionData.id);
+    this.reinitializeForm(metadata, value);
   }
 
   /**


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
