### PR TITLE
fix link for bitstream downloading

### DIFF
--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
@@ -107,7 +107,7 @@ export class ClarinFilesSectionComponent implements OnInit {
       return file.name;
     });
 
-    this.command = `curl --remote-name-all ` + this.halService.getRootHref() + `/core/items/${this.item.id}/allzip?handleId=${this.itemHandle}`;
+    this.command = `curl -o allzip.zip ` + this.halService.getRootHref() + `/core/items/${this.item.id}/allzip?handleId=${this.itemHandle}`;
   }
 
   loadDownloadZipConfigProperties() {


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  1  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |

### Problem description
When files are downloaded using a command-line instruction, they are missing a file extension, making them unopenable.

### Fix
Set a default name for the downloaded file, including the appropriate file extension.

**New download instruction:** curl -o allzip.zip [link]
