### PR TITLE
#808 - Redirect fix - switched href to routerLink

### DIFF
--- a/src/app/item-page/edit-item-page/item-license-mapper/item-license-mapper.component.html
+++ b/src/app/item-page/edit-item-page/item-license-mapper/item-license-mapper.component.html
@@ -26,7 +26,7 @@
     </div>
   </div>
   <div>
-    <a class="text-info" [href]="getLicensesModulePath() + getLicensesManageTablePath()">
+    <a class="text-info" [routerLink]="getLicensesModulePath() + getLicensesManageTablePath()">
       {{'item.edit.license.define.license.message' | translate}}
     </a>
   </div>


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |

### Testing
To test changes on localhost, it is helpful to add [these lines from config.example.yml](https://github.com/dataquest-dev/dspace-angular/blob/c73814a4ee07622a1d1cdc0babedc69ef4324d1c/config/config.example.yml#L7-L18) with nameSpace: /repository to [config.yml](https://github.com/dataquest-dev/dspace-angular/blob/c73814a4ee07622a1d1cdc0babedc69ef4324d1c/config/config.yml#L2)