### PR TITLE
Add custom dimension (handle) to pageTrack of matomo

### DIFF
--- a/src/app/statistics/angulartics/dspace/view-tracker.component.ts
+++ b/src/app/statistics/angulartics/dspace/view-tracker.component.ts
@@ -36,7 +36,7 @@ export class ViewTrackerComponent implements OnInit, OnDestroy {
     this.sub = this.referrerService.getReferrer()
       .pipe(take(1))
       .subscribe((referrer: string) => {
-        let dc_identifier  = this.object.firstMetadataValue("dc.identifier.uri");
+        let dc_identifier  = this.object?.firstMetadataValue('dc.identifier.uri');
         this.angulartics2.eventTrack.next({
           action: 'page_view',
           properties: {

--- a/src/app/statistics/angulartics/dspace/view-tracker.component.ts
+++ b/src/app/statistics/angulartics/dspace/view-tracker.component.ts
@@ -36,12 +36,14 @@ export class ViewTrackerComponent implements OnInit, OnDestroy {
     this.sub = this.referrerService.getReferrer()
       .pipe(take(1))
       .subscribe((referrer: string) => {
+        let dc_identifier  = this.object.firstMetadataValue("dc.identifier.uri");
         this.angulartics2.eventTrack.next({
           action: 'page_view',
           properties: {
             object: this.object,
             referrer,
             category: 'page_view',
+            dc_identifier: dc_identifier
           },
         });
       });

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -433,6 +433,7 @@ export class DefaultAppConfig implements AppConfig {
   // Matomo configuration
   matomo: MatomoConfig = {
     hostUrl: 'http://localhost:8135/',
-    siteId: '1'
+    siteId: '1',
+    dimensionId: 1
   };
 }

--- a/src/config/matomo-config.ts
+++ b/src/config/matomo-config.ts
@@ -8,4 +8,6 @@ export class MatomoConfig implements Config {
   public hostUrl: string;
 
   public siteId: string;
+
+  public dimensionId: Number;
 }

--- a/src/config/matomo-config.ts
+++ b/src/config/matomo-config.ts
@@ -9,5 +9,5 @@ export class MatomoConfig implements Config {
 
   public siteId: string;
 
-  public dimensionId: Number;
+  public dimensionId: number;
 }

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -320,5 +320,6 @@ export const environment: BuildConfig = {
   matomo: {
     hostUrl: 'http://localhost:8135/',
     siteId: '1',
+    dimensionId: 1
   }
 };

--- a/src/modules/app/browser-init.service.ts
+++ b/src/modules/app/browser-init.service.ts
@@ -105,7 +105,7 @@ export class BrowserInitService extends InitService {
       // ideally we'd add the custom dimension to the 'trackPageView' action only, but don't have that information
       // in pageTrack context. So we add it to page_view events, and remove it after the page view.
       // page_view events are fired via view-track.component, and exposes dc.identifier.uri via properties
-      this.angulartics2Matomo.eventTrack = function (action, properties? : any) {
+      this.angulartics2Matomo.eventTrack = function (action: string, properties?: any) {
         if (action === 'page_view') {
           if (properties.dc_identifier) {
             (window as any)._paq.push(['setCustomDimension', environment.matomo.dimensionId, properties.dc_identifier]);

--- a/src/modules/app/browser-init.service.ts
+++ b/src/modules/app/browser-init.service.ts
@@ -102,6 +102,21 @@ export class BrowserInitService extends InitService {
       this.initRouteListeners();
       this.themeService.listenForThemeChanges(true);
       this.trackAuthTokenExpiration();
+      // ideally we'd add the custom dimension to the 'trackPageView' action only, but don't have that information
+      // in pageTrack context. So we add it to page_view events, and remove it after the page view.
+      // page_view events are fired via view-track.component, and exposes dc.identifier.uri via properties
+      this.angulartics2Matomo.eventTrack = function (action, properties? : any) {
+        if (action === 'page_view') {
+          if (properties.dc_identifier) {
+            (window as any)._paq.push(['setCustomDimension', environment.matomo.dimensionId, properties.dc_identifier]);
+          }
+        }
+      };
+      let pageTrack = this.angulartics2Matomo.pageTrack;
+      this.angulartics2Matomo.pageTrack = function (path: string) {
+        pageTrack.call(this, path);
+        (window as any)._paq.push(['deleteCustomDimension', environment.matomo.dimensionId]);
+      };
       this.angulartics2Matomo.startTracking();
 
       this.initKlaro();


### PR DESCRIPTION
This extends/overrides the pageTrack/eventTrack methods of angulartics matomo plugin and hooks into the event tracking (view-tracker.component) that's there for DSpace internal statistics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced event tracking with an additional identifier that captures unique content data during views.
  - Expanded analytics configuration to support an extra custom dimension for more detailed insights.
  - Introduced logic to attach and then remove the custom tracking property after a page view, ensuring precise data collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->