### PR TITLE
UFAL/Redirect to `/lindat` after clicking on the Lindat icon in the home page

### DIFF
--- a/src/app/home-page/home-page.component.html
+++ b/src/app/home-page/home-page.component.html
@@ -32,7 +32,7 @@
       </div>
       <div class="col-md-4 d-none d-lg-block">
         <div class="row">
-          <a routerLink="home" class="col-md-7" style="height: 160px; position: relative;">
+          <a href="lindat" class="col-md-7" style="height: 160px; position: relative;">
             <img alt="LINDAT/CLARIAH-CZ logo" class="logo" style="position: absolute; height: 50%; top: 0px; bottom: 0px; margin: auto;" src="assets/images/lindat-logo-new-sm.png">
           </a>
           <a class="col-md-5" style="height: 160px; position: relative;" href="http://www.clarin.eu/">

--- a/src/app/home-page/home-page.component.html
+++ b/src/app/home-page/home-page.component.html
@@ -32,7 +32,7 @@
       </div>
       <div class="col-md-4 d-none d-lg-block">
         <div class="row">
-          <a href="lindat" class="col-md-7" style="height: 160px; position: relative;">
+          <a href="/lindat" class="col-md-7" style="height: 160px; position: relative;">
             <img alt="LINDAT/CLARIAH-CZ logo" class="logo" style="position: absolute; height: 50%; top: 0px; bottom: 0px; margin: auto;" src="assets/images/lindat-logo-new-sm.png">
           </a>
           <a class="col-md-5" style="height: 160px; position: relative;" href="http://www.clarin.eu/">


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated the primary home page link to navigate using a standard hyperlink redirecting to "lindat." This change means clicking the link now causes a full page reload instead of a seamless in-application transition. The external link remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->