### PR TITLE
Ufal dtq sync

### DIFF
--- a/docker/docker-compose-mac.yml
+++ b/docker/docker-compose-mac.yml
@@ -1,0 +1,11 @@
+services:
+  dspacesolr:
+    platform: linux/amd64
+  dspacedb:
+    platform: linux/amd64
+  dspace:
+    platform: linux/amd64
+  dspace-angular:
+    platform: linux/amd64
+  dspace-cli:
+    platform: linux/amd64

--- a/src/app/home-page/home-page.component.html
+++ b/src/app/home-page/home-page.component.html
@@ -61,6 +61,8 @@
     </div>
     <div class="row justify-content-center pt-3">
       <a href="javascript:void(0);" (click)="redirectToSearch('')">{{'home-page.advanced-search' | translate}}</a>
+      <span class="mx-2">|</span>
+      <a routerLink="/community-list">{{'menu.section.browse_global_communities_and_collections' | translate}}</a>
     </div>
     <div class="row justify-content-center pt-5">
       <div class="col-md-9 responsive-padding">


### PR DESCRIPTION
the compose file when added with `-f` overrides the default mac platform
the other commit just adds a community-list link to homepage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new navigation link on the home page to browse global communities and collections.
  - Introduced a Docker Compose configuration for Mac with predefined services for easier setup.

- **Style**
  - Inserted a visual separator between navigation links on the home page for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->