### PR TITLE
ZCU-PUB/Fixed encoding of the filename from the URL

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,6 @@
 import { APP_BASE_HREF, CommonModule, DOCUMENT } from '@angular/common';
 import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
-import { Injectable, NgModule } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
@@ -31,8 +31,8 @@ import { APP_CONFIG, AppConfig } from '../config/app-config.interface';
 import { StoreDevModules } from '../config/store/devtools';
 import { RootModule } from './root.module';
 import { ScriptLoaderService } from './clarin-navbar-top/script-loader-service';
-import { DefaultUrlSerializer, UrlSerializer, UrlTree } from '@angular/router';
-import { encodeSpecialURICharacters } from './shared/clarin-shared-util';
+import { UrlSerializer } from '@angular/router';
+import { BitstreamUrlSerializer } from './core/url-serializer/bitstream-url-serializer';
 
 export function getConfig() {
   return environment;
@@ -46,30 +46,6 @@ const getBaseHref = (document: Document, appConfig: AppConfig): string => {
 
 export function getMetaReducers(appConfig: AppConfig): MetaReducer<AppState>[] {
   return appConfig.debug ? [...appMetaReducers, ...debugMetaReducers] : appMetaReducers;
-}
-
-/**
- * This class intercepts the parsing of URLs to ensure that the filename in the URL is properly encoded.
- * But it only does this for URLs that start with '/bitstream/'.
- */
-@Injectable({ providedIn: 'root' })
-export class BitstreamUrlSerializer extends DefaultUrlSerializer {
-  FILENAME_INDEX = 5;
-  // Intercept parsing of every URL
-  parse(url: string): UrlTree {
-    if (url.startsWith('/bitstream/')) {
-      // Split the URL to isolate the filename
-      const parts = url.split('/');
-      if (parts.length > this.FILENAME_INDEX) {
-        // Fetch the filename from the URL
-        const filename = parts.slice(this.FILENAME_INDEX).join();
-        const encodedFilename = encodeSpecialURICharacters(filename);
-        // Reconstruct the URL with the encoded filename
-        url = [...parts.slice(0, this.FILENAME_INDEX), encodedFilename].join('/');
-      }
-    }
-    return super.parse(url);
-  }
 }
 
 const IMPORTS = [

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -54,18 +54,18 @@ export function getMetaReducers(appConfig: AppConfig): MetaReducer<AppState>[] {
  */
 @Injectable({ providedIn: 'root' })
 export class BitstreamUrlSerializer extends DefaultUrlSerializer {
-  FILE_NAME_INDEX = 5;
+  FILENAME_INDEX = 5;
   // Intercept parsing of every URL
   parse(url: string): UrlTree {
     if (url.startsWith('/bitstream/')) {
       // Split the URL to isolate the filename
       const parts = url.split('/');
-      if (parts.length > this.FILE_NAME_INDEX) {
+      if (parts.length > this.FILENAME_INDEX) {
         // Fetch the filename from the URL
-        const filename = parts.slice(this.FILE_NAME_INDEX).join();
+        const filename = parts.slice(this.FILENAME_INDEX).join();
         const encodedFilename = encodeSpecialURICharacters(filename);
         // Reconstruct the URL with the encoded filename
-        url = [...parts.slice(0, this.FILE_NAME_INDEX), encodedFilename].join('/');
+        url = [...parts.slice(0, this.FILENAME_INDEX), encodedFilename].join('/');
       }
     }
     return super.parse(url);

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,6 @@
 import { APP_BASE_HREF, CommonModule, DOCUMENT } from '@angular/common';
 import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
-import { NgModule } from '@angular/core';
+import { Injectable, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
@@ -31,6 +31,8 @@ import { APP_CONFIG, AppConfig } from '../config/app-config.interface';
 import { StoreDevModules } from '../config/store/devtools';
 import { RootModule } from './root.module';
 import { ScriptLoaderService } from './clarin-navbar-top/script-loader-service';
+import { DefaultUrlSerializer, UrlSerializer, UrlTree } from '@angular/router';
+import { encodeSpecialURICharacters } from './shared/clarin-shared-util';
 
 export function getConfig() {
   return environment;
@@ -44,6 +46,30 @@ const getBaseHref = (document: Document, appConfig: AppConfig): string => {
 
 export function getMetaReducers(appConfig: AppConfig): MetaReducer<AppState>[] {
   return appConfig.debug ? [...appMetaReducers, ...debugMetaReducers] : appMetaReducers;
+}
+
+/**
+ * This class intercepts the parsing of URLs to ensure that the filename in the URL is properly encoded.
+ * But it only does this for URLs that start with '/bitstream/'.
+ */
+@Injectable({ providedIn: 'root' })
+export class BitstreamUrlSerializer extends DefaultUrlSerializer {
+  FILE_NAME_INDEX = 5;
+  // Intercept parsing of every URL
+  parse(url: string): UrlTree {
+    if (url.startsWith('/bitstream/')) {
+      // Split the URL to isolate the filename
+      const parts = url.split('/');
+      if (parts.length > this.FILE_NAME_INDEX) {
+        // Fetch the filename from the URL
+        const filename = parts.slice(this.FILE_NAME_INDEX).join();
+        const encodedFilename = encodeSpecialURICharacters(filename);
+        // Reconstruct the URL with the encoded filename
+        url = [...parts.slice(0, this.FILE_NAME_INDEX), encodedFilename].join('/');
+      }
+    }
+    return super.parse(url);
+  }
 }
 
 const IMPORTS = [
@@ -105,6 +131,7 @@ const PROVIDERS = [
     useClass: LogInterceptor,
     multi: true
   },
+  { provide: UrlSerializer, useClass: BitstreamUrlSerializer },
   // register the dynamic matcher used by form. MUST be provided by the app module
   ...DYNAMIC_MATCHER_PROVIDERS,
 ];

--- a/src/app/bitstream-page/legacy-bitstream-url.resolver.ts
+++ b/src/app/bitstream-page/legacy-bitstream-url.resolver.ts
@@ -6,6 +6,7 @@ import { Bitstream } from '../core/shared/bitstream.model';
 import { getFirstCompletedRemoteData } from '../core/shared/operators';
 import { hasNoValue } from '../shared/empty.util';
 import { BitstreamDataService } from '../core/data/bitstream-data.service';
+import { encodeSpecialURICharacters } from '../shared/clarin-shared-util';
 
 /**
  * This class resolves a bitstream based on the DSpace 6 XMLUI or JSPUI bitstream download URLs
@@ -40,7 +41,7 @@ export class LegacyBitstreamUrlResolver implements Resolve<RemoteData<Bitstream>
       return this.bitstreamDataService.findByItemHandle(
         `${prefix}/${suffix}`,
         sequenceId,
-        filename,
+        encodeSpecialURICharacters(filename),
       ).pipe(
         getFirstCompletedRemoteData()
       );

--- a/src/app/bitstream-page/legacy-bitstream-url.resolver.ts
+++ b/src/app/bitstream-page/legacy-bitstream-url.resolver.ts
@@ -6,7 +6,7 @@ import { Bitstream } from '../core/shared/bitstream.model';
 import { getFirstCompletedRemoteData } from '../core/shared/operators';
 import { hasNoValue } from '../shared/empty.util';
 import { BitstreamDataService } from '../core/data/bitstream-data.service';
-import { encodeSpecialURICharacters } from '../shared/clarin-shared-util';
+import { encodeRFC3986URIComponent } from '../shared/clarin-shared-util';
 
 /**
  * This class resolves a bitstream based on the DSpace 6 XMLUI or JSPUI bitstream download URLs
@@ -41,7 +41,7 @@ export class LegacyBitstreamUrlResolver implements Resolve<RemoteData<Bitstream>
       return this.bitstreamDataService.findByItemHandle(
         `${prefix}/${suffix}`,
         sequenceId,
-        encodeSpecialURICharacters(filename),
+        encodeRFC3986URIComponent(filename),
       ).pipe(
         getFirstCompletedRemoteData()
       );

--- a/src/app/core/url-serializer/bitstream-url-serializer.spec.ts
+++ b/src/app/core/url-serializer/bitstream-url-serializer.spec.ts
@@ -1,0 +1,43 @@
+import { TestBed } from '@angular/core/testing';
+import { BitstreamUrlSerializer } from './bitstream-url-serializer';
+import { DefaultUrlSerializer, UrlTree } from '@angular/router';
+
+describe('BitstreamUrlSerializer', () => {
+  let serializer: BitstreamUrlSerializer;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [BitstreamUrlSerializer]
+    });
+    serializer = TestBed.inject(BitstreamUrlSerializer);
+  });
+
+  it('should be created', () => {
+    expect(serializer).toBeTruthy();
+  });
+
+  it('should not modify URLs that do not start with /bitstream/', () => {
+    const url = '/some/other/path/file.pdf';
+    const result = serializer.parse(url);
+    const expected = new DefaultUrlSerializer().parse(url);
+    expect(result).toEqual(expected);
+  });
+
+  it('should encode special characters in the filename in /bitstream/ URLs', () => {
+    const originalUrl = '/bitstream/id/123/456/some file(name)[v1].pdf';
+    const expectedEncodedFilename = 'some%20file%28name%29%5Bv1%5D.pdf';
+    const expectedUrl = `/bitstream/id/123/456/${expectedEncodedFilename}`;
+
+    const result: UrlTree = serializer.parse(originalUrl);
+
+    const resultUrl = new DefaultUrlSerializer().serialize(result);
+    expect(resultUrl).toBe(expectedUrl);
+  });
+
+  it('should not modify /bitstream/ URL if there is no filename', () => {
+    const url = '/bitstream/id/123/456';
+    const result = serializer.parse(url);
+    const expected = new DefaultUrlSerializer().parse(url);
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/app/core/url-serializer/bitstream-url-serializer.ts
+++ b/src/app/core/url-serializer/bitstream-url-serializer.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { DefaultUrlSerializer, UrlTree } from '@angular/router';
-import { encodeSpecialURICharacters } from '../../shared/clarin-shared-util';
+import { encodeRFC3986URIComponent } from '../../shared/clarin-shared-util';
 
 /**
  * This class intercepts the parsing of URLs to ensure that the filename in the URL is properly encoded.
@@ -17,7 +17,7 @@ export class BitstreamUrlSerializer extends DefaultUrlSerializer {
       if (parts.length > this.FILENAME_INDEX) {
         // Fetch the filename from the URL
         const filename = parts.slice(this.FILENAME_INDEX).join();
-        const encodedFilename = encodeSpecialURICharacters(filename);
+        const encodedFilename = encodeRFC3986URIComponent(filename);
         // Reconstruct the URL with the encoded filename
         url = [...parts.slice(0, this.FILENAME_INDEX), encodedFilename].join('/');
       }

--- a/src/app/core/url-serializer/bitstream-url-serializer.ts
+++ b/src/app/core/url-serializer/bitstream-url-serializer.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { DefaultUrlSerializer, UrlTree } from '@angular/router';
+import { encodeSpecialURICharacters } from '../../shared/clarin-shared-util';
+
+/**
+ * This class intercepts the parsing of URLs to ensure that the filename in the URL is properly encoded.
+ * But it only does this for URLs that start with '/bitstream/'.
+ */
+@Injectable({ providedIn: 'root' })
+export class BitstreamUrlSerializer extends DefaultUrlSerializer {
+  FILENAME_INDEX = 5;
+  // Intercept parsing of every URL
+  parse(url: string): UrlTree {
+    if (url.startsWith('/bitstream/')) {
+      // Split the URL to isolate the filename
+      const parts = url.split('/');
+      if (parts.length > this.FILENAME_INDEX) {
+        // Fetch the filename from the URL
+        const filename = parts.slice(this.FILENAME_INDEX).join();
+        const encodedFilename = encodeSpecialURICharacters(filename);
+        // Reconstruct the URL with the encoded filename
+        url = [...parts.slice(0, this.FILENAME_INDEX), encodedFilename].join('/');
+      }
+    }
+    return super.parse(url);
+  }
+}

--- a/src/app/shared/clarin-shared-util.ts
+++ b/src/app/shared/clarin-shared-util.ts
@@ -87,3 +87,18 @@ export function makeLinks(text: string): string {
   const regex = /(?:https?|ftp):\/\/[^\s)]+|www\.[^\s)]+/g;
   return text?.replace(regex, (url) => `<a href="${url}" target="_blank">${url}</a>`);
 }
+
+/**
+ * Encode special characters in a URI part to ensure it is safe for use in a URL.
+ * The special characters are `()[]` and the space character.
+ * @param uriPart
+ */
+export function encodeSpecialURICharacters(uriPart: string) {
+  // Decode the filename to handle any encoded characters
+  const decodedFileName = decodeURIComponent(uriPart);
+  // Encode special characters in the filename
+  return encodeURIComponent(decodedFileName)
+    .replace(/[()]/g, c => '%' + c.charCodeAt(0).toString(16).toUpperCase())
+    .replace(/\[/g, '%5B')
+    .replace(/\]/g, '%5D');
+}

--- a/src/app/shared/clarin-shared-util.ts
+++ b/src/app/shared/clarin-shared-util.ts
@@ -93,12 +93,10 @@ export function makeLinks(text: string): string {
  * The special characters are `()[]` and the space character.
  * @param uriPart
  */
-export function encodeSpecialURICharacters(uriPart: string) {
+export function encodeRFC3986URIComponent(uriPart: string) {
   // Decode the filename to handle any encoded characters
   const decodedFileName = decodeURIComponent(uriPart);
   // Encode special characters in the filename
   return encodeURIComponent(decodedFileName)
-    .replace(/[()]/g, c => '%' + c.charCodeAt(0).toString(16).toUpperCase())
-    .replace(/\[/g, '%5B')
-    .replace(/\]/g, '%5D');
+    .replace(/[()]/g, c => '%' + c.charCodeAt(0).toString(16).toUpperCase());
 }


### PR DESCRIPTION
Added an URL serializer to fix encoding of the special characters from the URL e.g., `[`, `(` because the filename wasn't properly parsed.

| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
