### PR TITLE
Run Python import weekly

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,6 @@
 name: Deploy DSpace
 
 on:
-  schedule:
-    - cron: '0 21 * * 6'  # Runs every Saturday at 9 PM
   workflow_call:
     inputs:
       INSTANCE:
@@ -39,18 +37,6 @@ on:
         type: boolean
 
 jobs:
-  import-every-week:
-    # Only run this job when triggered by the schedule event
-    if: github.event_name == 'schedule'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Call the deploy action with predefined inputs
-        uses: ./.github/workflows/deploy.yml
-        with:
-          INSTANCE: '8'
-          IMPORT: true
-          ERASE_DB: true
-
   deploy-5:
     if: inputs.INSTANCE == '*' || inputs.INSTANCE == '5'
     runs-on: dspace-dep-1

--- a/.github/workflows/import-weekly.yml
+++ b/.github/workflows/import-weekly.yml
@@ -1,0 +1,13 @@
+name: Import Weekly
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # every Sunday at midnight UTC
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy.yml
+    with:
+      INSTANCE: '8'
+      IMPORT: true
+      ERASE_DB: true


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
You cannot call a workflow (.github/workflows/*.yml) like an action (i.e., using uses: ./.github/workflows/deploy.yml) directly in a steps: block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated scheduled deployment to run every Sunday at midnight UTC through a new workflow.
	- Removed the previous scheduled deployment from the existing workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->