### PR TITLE
Ufal/seznam license request

### DIFF
--- a/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
+++ b/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
@@ -143,6 +143,7 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
    ngOnInit(): void {
     // Load CurrentItem by bitstreamID to show itemHandle
     this.loadCurrentItem();
+
     // Load helpDeskEmail from configuration property - BE
     this.loadHelpDeskEmail();
     // Load IPAddress by API to show user IP Address
@@ -162,17 +163,24 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
     this.loadUserRegistrationAndUserMetadata();
 
     // Load the Seznam dataset license content
-    this.loadLicenseContentSeznam();
+    this.item$.subscribe((item$) => {
+        console.log(this.item$.value.metadata?.['dc.rights']?.[0]?.value);
+        if (this.item$.value.metadata?.['dc.rights']?.[0]?.value == this.LICENSE_NAME_SEZNAM) {
+          this.loadLicenseContentSeznam();
+        }
+    });
+    //this.loadLicenseContentSeznam();
   }
 
   /**
    * Load the content for the special license. This content is shown directly in this approval page.
    */
   loadLicenseContentSeznam() {
-    this.htmlContentService.getHmtlContentByPathAndLocale(this.LICENSE_PATH_SEZNAM_CZ).then(content => {
-      this.licenseContentSeznam.next(content);
-    });
-    return true;
+      this.htmlContentService.getHmtlContentByPathAndLocale(this.LICENSE_PATH_SEZNAM_CZ).then(content => {
+        this.licenseContentSeznam.next(content);
+      });
+
+      return true;
   }
 
   public accept() {

--- a/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
+++ b/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
@@ -174,7 +174,6 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
         this.htmlContentService.getHmtlContentByPathAndLocale(this.LICENSE_PATH_SEZNAM_CZ).then(content => {
           this.licenseContentSeznam.next(content);
         });
-        return true;
       }
     });
   }

--- a/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
+++ b/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
@@ -143,7 +143,6 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
    ngOnInit(): void {
     // Load CurrentItem by bitstreamID to show itemHandle
     this.loadCurrentItem();
-
     // Load helpDeskEmail from configuration property - BE
     this.loadHelpDeskEmail();
     // Load IPAddress by API to show user IP Address
@@ -169,18 +168,16 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
           this.loadLicenseContentSeznam();
         }
     });
-    //this.loadLicenseContentSeznam();
   }
 
   /**
    * Load the content for the special license. This content is shown directly in this approval page.
    */
   loadLicenseContentSeznam() {
-      this.htmlContentService.getHmtlContentByPathAndLocale(this.LICENSE_PATH_SEZNAM_CZ).then(content => {
-        this.licenseContentSeznam.next(content);
-      });
-
-      return true;
+    this.htmlContentService.getHmtlContentByPathAndLocale(this.LICENSE_PATH_SEZNAM_CZ).then(content => {
+      this.licenseContentSeznam.next(content);
+    });
+    return true;
   }
 
   public accept() {

--- a/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
+++ b/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
@@ -164,7 +164,7 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
     // Load the Seznam dataset license content
     this.item$.subscribe((item$) => {
         console.log(this.item$.value.metadata?.['dc.rights']?.[0]?.value);
-        if (this.item$.value.metadata?.['dc.rights']?.[0]?.value == this.LICENSE_NAME_SEZNAM) {
+        if (this.item$.value.metadata?.['dc.rights']?.[0]?.value === this.LICENSE_NAME_SEZNAM) {
           this.loadLicenseContentSeznam();
         }
     });

--- a/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
+++ b/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
@@ -170,7 +170,7 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
    */
   loadLicenseContentSeznam() {
     this.item$.subscribe((item) => {
-      if (this.item$.value.firstMetadataValue('dc.rights') === this.LICENSE_NAME_SEZNAM) {
+      if (item.firstMetadataValue('dc.rights') === this.LICENSE_NAME_SEZNAM) {
         this.htmlContentService.getHmtlContentByPathAndLocale(this.LICENSE_PATH_SEZNAM_CZ).then(content => {
           this.licenseContentSeznam.next(content);
         });

--- a/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
+++ b/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
@@ -162,12 +162,7 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
     this.loadUserRegistrationAndUserMetadata();
 
     // Load the Seznam dataset license content
-    this.item$.subscribe((item$) => {
-        console.log(this.item$.value.metadata?.['dc.rights']?.[0]?.value);
-        if (this.item$.value.metadata?.['dc.rights']?.[0]?.value === this.LICENSE_NAME_SEZNAM) {
-          this.loadLicenseContentSeznam();
-        }
-    });
+    this.loadSeznamDatasetLicenseContent();
   }
 
   /**
@@ -392,6 +387,14 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
             this.userMetadata$.next(userMetadata.payload);
           });
       });
+  }
+
+  private loadSeznamDatasetLicenseContent() {
+    this.item$.subscribe((item$) => {
+      if (this.item$.value.firstMetadataValue('dc.rights') === this.LICENSE_NAME_SEZNAM) {
+        this.loadLicenseContentSeznam();
+      }
+    });
   }
 
   private loadCurrentUser() {

--- a/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
+++ b/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
@@ -162,17 +162,21 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
     this.loadUserRegistrationAndUserMetadata();
 
     // Load the Seznam dataset license content
-    this.loadSeznamDatasetLicenseContent();
+    this.loadLicenseContentSeznam();
   }
 
   /**
    * Load the content for the special license. This content is shown directly in this approval page.
    */
   loadLicenseContentSeznam() {
-    this.htmlContentService.getHmtlContentByPathAndLocale(this.LICENSE_PATH_SEZNAM_CZ).then(content => {
-      this.licenseContentSeznam.next(content);
+    this.item$.subscribe((item) => {
+      if (this.item$.value.firstMetadataValue('dc.rights') === this.LICENSE_NAME_SEZNAM) {
+        this.htmlContentService.getHmtlContentByPathAndLocale(this.LICENSE_PATH_SEZNAM_CZ).then(content => {
+          this.licenseContentSeznam.next(content);
+        });
+        return true;
+      }
     });
-    return true;
   }
 
   public accept() {
@@ -387,14 +391,6 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
             this.userMetadata$.next(userMetadata.payload);
           });
       });
-  }
-
-  private loadSeznamDatasetLicenseContent() {
-    this.item$.subscribe((item$) => {
-      if (this.item$.value.firstMetadataValue('dc.rights') === this.LICENSE_NAME_SEZNAM) {
-        this.loadLicenseContentSeznam();
-      }
-    });
   }
 
   private loadCurrentUser() {


### PR DESCRIPTION
…nses

| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Request for szn-dataset-license.html was sent even when the license (which needs agreement) was different (for example Hamledt 3.0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved license content loading to display the Seznam dataset license only when applicable, based on item metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->