### PR TITLE
UFAL/Added spacing between clarin & dspace logo

### DIFF
--- a/src/app/login-page/login-page.component.html
+++ b/src/app/login-page/login-page.component.html
@@ -1,10 +1,12 @@
 <div class="container w-100 h-100">
   <div class="text-center mt-5 row justify-content-center">
     <div>
-      <img class="mb-4 login-logo" src="assets/images/dspace-logo.png" alt="{{'repository.image.logo' | translate}}">
-      <a href="https://www.clarin.eu/">
-        <img class="clarin-logo" src="assets/images/clarin-logo.svg" alt="Clarin logo" >
-      </a>
+      <div class="d-flex justify-content-around">
+        <img class="mb-4 login-logo" src="assets/images/dspace-logo.png" alt="{{'repository.image.logo' | translate}}">
+        <a href="https://www.clarin.eu/">
+          <img class="clarin-logo" src="assets/images/clarin-logo.svg" alt="Clarin logo" >
+        </a>
+      </div>
       <h1 class="h3 mb-0 font-weight-normal">{{"login.form.header" | translate}}</h1>
       <ds-themed-log-in
       [isStandalonePage]="true"></ds-themed-log-in>

--- a/src/app/login-page/login-page.component.html
+++ b/src/app/login-page/login-page.component.html
@@ -1,10 +1,10 @@
 <div class="container w-100 h-100">
   <div class="text-center mt-5 row justify-content-center">
     <div>
-      <div class="d-flex justify-content-around align-items-center w-100">
-        <img class="mb-4 login-logo" src="assets/images/dspace-logo.png" alt="{{'repository.image.logo' | translate}}">
+      <div class="mb-4 d-flex justify-content-center align-items-center w-100">
+        <img class="login-logo" src="assets/images/dspace-logo.png" alt="{{'repository.image.logo' | translate}}">
         <a href="https://www.clarin.eu/" target="_blank" rel="noopener noreferrer">
-          <img class="clarin-logo" src="assets/images/clarin-logo.svg" alt="Clarin logo" >
+          <img class="ml-5 clarin-logo" src="assets/images/clarin-logo.svg" alt="Clarin logo" >
         </a>
       </div>
       <h1 class="h3 mb-0 font-weight-normal">{{"login.form.header" | translate}}</h1>

--- a/src/app/login-page/login-page.component.html
+++ b/src/app/login-page/login-page.component.html
@@ -1,9 +1,9 @@
 <div class="container w-100 h-100">
   <div class="text-center mt-5 row justify-content-center">
     <div>
-      <div class="d-flex justify-content-around">
+      <div class="d-flex justify-content-around align-items-center w-100">
         <img class="mb-4 login-logo" src="assets/images/dspace-logo.png" alt="{{'repository.image.logo' | translate}}">
-        <a href="https://www.clarin.eu/">
+        <a href="https://www.clarin.eu/" target="_blank" rel="noopener noreferrer">
           <img class="clarin-logo" src="assets/images/clarin-logo.svg" alt="Clarin logo" >
         </a>
       </div>


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Logos in login page were sticked together with no spacing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved the layout of the login page by grouping the DSpace and Clarin logos into a flex container for better visual alignment and spacing.
  - Updated the Clarin logo link to open in a new tab securely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->