### PR TITLE
UFAL/Do not add `dtoken` into the URL if it is null (#860)

### DIFF
--- a/src/app/bitstream-page/clarin-zip-download-page/clarin-zip-download-page.component.ts
+++ b/src/app/bitstream-page/clarin-zip-download-page/clarin-zip-download-page.component.ts
@@ -71,8 +71,11 @@ export class ClarinZipDownloadPageComponent extends ClarinBitstreamDownloadPageC
           this.bitstreams$.next([...current, ...bitstreamsRD.payload.page]);
           this.bitstreamRD$ = createSuccessfulRemoteDataObject$(this.bitstreams$.getValue()[0]);
           this.dtoken = isUndefined(this.route.snapshot.queryParams.dtoken) ? null : this.route.snapshot.queryParams.dtoken;
-          this.zipDownloadLink.next(this.halService.getRootHref() +
-            `/core/items/${itemRD.payload.uuid}/allzip?handleId=${itemRD?.payload?.handle}&dtoken=${this.dtoken}`);
+          const baseUrl = this.halService.getRootHref() +
+            `/core/items/${itemRD.payload.uuid}/allzip?handleId=${itemRD?.payload?.handle}`;
+          // Do not add `dtoken` into the URL if it is null
+          const dtokenParam = this.dtoken ? `&dtoken=${this.dtoken}` : '';
+          this.zipDownloadLink.next(baseUrl + dtokenParam);
           super.ngOnInit();
         }
       });


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the construction of download links to ensure the token parameter is only included when valid, preventing unnecessary or invalid parameters in the URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->