### PR TITLE
UFAL/Added same spacing styles via bootstrap as in login page

### DIFF
--- a/src/app/logout-page/logout-page.component.html
+++ b/src/app/logout-page/logout-page.component.html
@@ -1,10 +1,12 @@
 <div class="container w-100 h-100">
   <div class="text-center mt-5 row justify-content-md-center">
-    <div class="mx-auto">
-      <img class="mb-4 login-logo" src="assets/images/dspace-logo.png">
-      <a href="https://www.clarin.eu/">
-        <img class="clarin-logo" src="assets/images/clarin-logo.svg" alt="Clarin logo" >
-      </a>
+    <div>
+      <div class="mb-4 d-flex justify-content-center align-items-center w-100">
+        <img class="login-logo" src="assets/images/dspace-logo.png" alt="{{'repository.image.logo' | translate}}">
+        <a href="https://www.clarin.eu/" target="_blank" rel="noopener noreferrer">
+          <img class="ml-5 clarin-logo" src="assets/images/clarin-logo.svg" alt="Clarin logo" >
+        </a>
+      </div>
       <h1 class="h3 mb-0 font-weight-normal">{{"logout.form.header" | translate}}</h1>
       <ds-log-out></ds-log-out>
     </div>


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Missing spacing between logos on log-out page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved layout and alignment of logos on the logout page for better visual consistency and centering.

- **Accessibility**
  - Added descriptive alt text to the DSpace logo for improved screen reader support.

- **Bug Fixes**
  - Enhanced security for external links by opening them in a new tab with appropriate security attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->