### PR TITLE
UFAL/License administration editing extended license labels

### DIFF
--- a/src/app/clarin-licenses/clarin-license-table/modal/define-license-form/define-license-form.component.ts
+++ b/src/app/clarin-licenses/clarin-license-table/modal/define-license-form/define-license-form.component.ts
@@ -151,7 +151,7 @@ export class DefineLicenseFormComponent implements OnInit {
    * Add or remove checkbox value from form array based on the checkbox selection
    * @param event
    * @param formName
-   * @param extendedClarinLicenseLabel
+   * @param checkBoxValue
    */
   changeCheckboxValue(event: any, formName: string, checkBoxValue) {
     let form = null;
@@ -169,7 +169,7 @@ export class DefineLicenseFormComponent implements OnInit {
     if (event.target.checked) {
       form.push(checkBoxValue);
     } else {
-      let index = form.findIndex(item => item.name === checkBoxValue.name);
+      let index = form.findIndex(item => item.id === checkBoxValue.id);
       form.splice(index, 1);
     }
   }


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Issue #857 (initially #789 when editing of license required info was fixed). Function chnageCheckboxValue is called for both of the types of checkboxes (required info && extended labels). Unchecking was based on finding index by succeeding the condition: `(item => item.name === checkBoxValue.name)` but `name` is just property of Required Info objects - because of that, findIndex returned `0` when Extended Label checkbox was unchecked, because property `name` was not there. Condition has to be based on `id` property, which is placed in both of these objects.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy when removing unchecked items from the license selection form. Unchecked values are now correctly identified and removed based on their unique identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->