### PR TITLE
UFAL/License agreement page component errors

### DIFF
--- a/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.html
+++ b/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.html
@@ -24,9 +24,9 @@
   </div>
   <div class="row pt-3">
     <div class="col-12">
-      <span>{{'clarin.license.agreement.signer.header.info.0' | translate}}</span>
+      <span>{{'clarin.license.agreement.signer.header.info.0' | translate}} </span>
       <a [href]="'mailto:'+(helpDesk$ | async)?.payload?.values[0]">{{'clarin.license.agreement.signer.header.info.1' | translate}}</a>
-      <span>{{'clarin.license.agreement.signer.header.info.2' | translate}}</span>
+      <span> {{'clarin.license.agreement.signer.header.info.2' | translate}}</span>
     </div>
   </div>
   <div class="row pt-3">

--- a/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.html
+++ b/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.html
@@ -24,9 +24,9 @@
   </div>
   <div class="row pt-3">
     <div class="col-12">
-      <span>{{'clarin.license.agreement.signer.header.info.0' | translate}} </span>
-      <a [href]="'mailto:'+(helpDesk$ | async)?.payload?.values[0]">{{'clarin.license.agreement.signer.header.info.1' | translate}}</a>
-      <span> {{'clarin.license.agreement.signer.header.info.2' | translate}}</span>
+      <span>{{'clarin.license.agreement.signer.header.info.0' | translate}}</span>
+      <a class="ml-1 mr-1" [href]="'mailto:'+(helpDesk$ | async)?.payload?.values[0]">{{'clarin.license.agreement.signer.header.info.1' | translate}}</a>
+      <span>{{'clarin.license.agreement.signer.header.info.2' | translate}}</span>
     </div>
   </div>
   <div class="row pt-3">

--- a/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
+++ b/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
@@ -170,7 +170,7 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
    */
   loadLicenseContentSeznam() {
     this.item$.subscribe((item) => {
-      if (item.firstMetadataValue('dc.rights') === this.LICENSE_NAME_SEZNAM) {
+      if (item?.firstMetadataValue('dc.rights') === this.LICENSE_NAME_SEZNAM) {
         this.htmlContentService.getHmtlContentByPathAndLocale(this.LICENSE_PATH_SEZNAM_CZ).then(content => {
           this.licenseContentSeznam.next(content);
         });


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
There were some errors in the console after [PR#844](https://github.com/dataquest-dev/dspace-angular/pull/844)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved spacing between text elements and the mailto link in the license agreement signer header section for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->