### PR TITLE
 UFAL/Filename encoding encodes the fileName with the rest of the URL

### DIFF
--- a/src/app/core/url-serializer/bitstream-url-serializer.spec.ts
+++ b/src/app/core/url-serializer/bitstream-url-serializer.spec.ts
@@ -40,4 +40,15 @@ describe('BitstreamUrlSerializer', () => {
     const expected = new DefaultUrlSerializer().parse(url);
     expect(result).toEqual(expected);
   });
+
+  it('should encode the filename and preserve query parameters in /bitstream/ URLs', () => {
+    const originalUrl = '/bitstream/handle/123/456/some file.pdf?sequence=3&isAllowed=y';
+    const expectedEncodedFilename = 'some%20file.pdf';
+    const expectedUrl = `/bitstream/handle/123/456/${expectedEncodedFilename}?sequence=3&isAllowed=y`;
+
+    const result: UrlTree = serializer.parse(originalUrl);
+
+    const resultUrl = new DefaultUrlSerializer().serialize(result);
+    expect(resultUrl).toBe(expectedUrl);
+  });
 });

--- a/src/app/core/url-serializer/bitstream-url-serializer.ts
+++ b/src/app/core/url-serializer/bitstream-url-serializer.ts
@@ -12,14 +12,20 @@ export class BitstreamUrlSerializer extends DefaultUrlSerializer {
   // Intercept parsing of every URL
   parse(url: string): UrlTree {
     if (url.startsWith('/bitstream/')) {
-      // Split the URL to isolate the filename
-      const parts = url.split('/');
+      // Separate the path from the query string
+      const [path, query] = url.split('?');
+
+      // Split the path to isolate the filename
+      const parts = path.split('/');
       if (parts.length > this.FILENAME_INDEX) {
-        // Fetch the filename from the URL
-        const filename = parts.slice(this.FILENAME_INDEX).join();
+        const filename = parts.slice(this.FILENAME_INDEX).join('/');
         const encodedFilename = encodeRFC3986URIComponent(filename);
-        // Reconstruct the URL with the encoded filename
-        url = [...parts.slice(0, this.FILENAME_INDEX), encodedFilename].join('/');
+
+        // Reconstruct the path with the encoded filename
+        const newPath = [...parts.slice(0, this.FILENAME_INDEX), encodedFilename].join('/');
+
+        // Reattach query string if present
+        url = query ? `${newPath}?${query}` : newPath;
       }
     }
     return super.parse(url);


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Check the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of filenames with spaces and query parameters in URLs to ensure filenames are correctly encoded and query parameters are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->