### PR TITLE
UFAL/Ask Only Once license not downloading bitstream without page reload after agreeing

### DIFF
--- a/src/app/bitstream-page/clarin-bitstream-download-page/clarin-bitstream-download-page.component.ts
+++ b/src/app/bitstream-page/clarin-bitstream-download-page/clarin-bitstream-download-page.component.ts
@@ -95,7 +95,7 @@ export class ClarinBitstreamDownloadPageComponent implements OnInit {
       take(1),
       switchMap(([clarinIsAuthorized, isAuthorized, isLoggedIn, bitstream]: [RemoteData<any>, boolean, boolean, Bitstream]) => {
         const isAuthorizedByClarin = this.processClarinAuthorization(clarinIsAuthorized);
-        if (isAuthorizedByClarin && isAuthorized && isLoggedIn) {
+        if ((isAuthorizedByClarin || isAuthorized) && isLoggedIn) {
           return this.fileService.retrieveFileDownloadLink(bitstream._links.content.href).pipe(
             filter((fileLink) => hasValue(fileLink)),
             take(1),

--- a/src/app/bitstream-page/clarin-bitstream-download-page/clarin-bitstream-download-page.component.ts
+++ b/src/app/bitstream-page/clarin-bitstream-download-page/clarin-bitstream-download-page.component.ts
@@ -87,7 +87,7 @@ export class ClarinBitstreamDownloadPageComponent implements OnInit {
         const clarinIsAuthorized$ = this.rdbService.buildFromRequestUUID(requestId);
         // Clarin authorization will check dtoken parameter from the request
         const dtoken = isNotEmpty(this.dtoken) ? '?dtoken=' + this.dtoken : '';
-        const isAuthorized$ = this.authorizationService.isAuthorized(FeatureID.CanDownload, isNotEmpty(bitstream) ? bitstream.self + dtoken : undefined);
+        const isAuthorized$ = this.authorizationService.isAuthorized(FeatureID.CanDownload, isNotEmpty(bitstream) ? bitstream.self + dtoken : undefined, undefined, false);
         const isLoggedIn$ = this.auth.isAuthenticated();
         return observableCombineLatest([clarinIsAuthorized$, isAuthorized$, isLoggedIn$, observableOf(bitstream)]);
       }),
@@ -95,7 +95,7 @@ export class ClarinBitstreamDownloadPageComponent implements OnInit {
       take(1),
       switchMap(([clarinIsAuthorized, isAuthorized, isLoggedIn, bitstream]: [RemoteData<any>, boolean, boolean, Bitstream]) => {
         const isAuthorizedByClarin = this.processClarinAuthorization(clarinIsAuthorized);
-        if ((isAuthorizedByClarin || isAuthorized) && isLoggedIn) {
+        if (isAuthorizedByClarin && isAuthorized && isLoggedIn) {
           return this.fileService.retrieveFileDownloadLink(bitstream._links.content.href).pipe(
             filter((fileLink) => hasValue(fileLink)),
             take(1),


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Bitstream is not downloaded automatically after agreeing (Clarin license agreement page) without a refresh.
More in issue #814 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved access to file download links by allowing retrieval if the user is authorized by either Clarin or general authorization, rather than requiring both. Users still need to be logged in.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->