### PR TITLE
UFAL/License Administration Labels & Required Info checkboxes should work properly

### DIFF
--- a/src/app/clarin-licenses/clarin-license-table/modal/define-license-form/define-license-form.component.ts
+++ b/src/app/clarin-licenses/clarin-license-table/modal/define-license-form/define-license-form.component.ts
@@ -171,6 +171,7 @@ export class DefineLicenseFormComponent implements OnInit {
     } else {
       let index = null;
 
+      // Required Info needs to be checked by some other property, because id is glitching
       if (formName === 'requiredInfo') {
         index = form.findIndex(item => item.name === checkBoxValue.name);
       } else {

--- a/src/app/clarin-licenses/clarin-license-table/modal/define-license-form/define-license-form.component.ts
+++ b/src/app/clarin-licenses/clarin-license-table/modal/define-license-form/define-license-form.component.ts
@@ -169,7 +169,7 @@ export class DefineLicenseFormComponent implements OnInit {
     if (event.target.checked) {
       form.push(checkBoxValue);
     } else {
-      let index = null;
+      let index = -1;
 
       // Required Info needs to be checked by some other property, because id is glitching
       if (formName === 'requiredInfo') {

--- a/src/app/clarin-licenses/clarin-license-table/modal/define-license-form/define-license-form.component.ts
+++ b/src/app/clarin-licenses/clarin-license-table/modal/define-license-form/define-license-form.component.ts
@@ -177,7 +177,7 @@ export class DefineLicenseFormComponent implements OnInit {
         index = form.findIndex(item => item && checkBoxValue.id === item.id);
       }
 
-      if (index != -1) {
+      if (index !== -1) {
         form.splice(index, 1);
       }
     }

--- a/src/app/clarin-licenses/clarin-license-table/modal/define-license-form/define-license-form.component.ts
+++ b/src/app/clarin-licenses/clarin-license-table/modal/define-license-form/define-license-form.component.ts
@@ -169,14 +169,13 @@ export class DefineLicenseFormComponent implements OnInit {
     if (event.target.checked) {
       form.push(checkBoxValue);
     } else {
-      let index = -1;
-
       // Required Info needs to be checked by some other property, because id is glitching
-      if (formName === 'requiredInfo') {
-        index = form.findIndex(item => item.name === checkBoxValue.name);
-      } else {
-        index = form.findIndex(item => item && checkBoxValue.id === item.id);
-      }
+      const index = form.findIndex(item =>
+        item && (
+          formName === 'requiredInfo'
+          ? item.name === checkBoxValue.name
+          : checkBoxValue.id === item.id)
+        );
 
       if (index !== -1) {
         form.splice(index, 1);

--- a/src/app/clarin-licenses/clarin-license-table/modal/define-license-form/define-license-form.component.ts
+++ b/src/app/clarin-licenses/clarin-license-table/modal/define-license-form/define-license-form.component.ts
@@ -169,8 +169,17 @@ export class DefineLicenseFormComponent implements OnInit {
     if (event.target.checked) {
       form.push(checkBoxValue);
     } else {
-      let index = form.findIndex(item => item.id === checkBoxValue.id);
-      form.splice(index, 1);
+      let index = null;
+
+      if (formName === 'requiredInfo') {
+        index = form.findIndex(item => item.name === checkBoxValue.name);
+      } else {
+        index = form.findIndex(item => item && checkBoxValue.id === item.id);
+      }
+
+      if (index != -1) {
+        form.splice(index, 1);
+      }
     }
   }
 


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
When editing required user info in licenses/manage-table with checkboxes, it does not work correctly. ID property of requiredInfo objects is ordered differently `after submit` and `while editing`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved checkbox handling in license definition forms to prevent errors when removing items, ensuring more reliable form interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->