### PR TITLE
UFAL/License agreement loading spinner after submitting

### DIFF
--- a/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.html
+++ b/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.html
@@ -88,15 +88,15 @@
   </div>
   <div class="row pt-3">
     <div class="col-12">
-      <button class="btn btn-success max-width" [disabled]="error$.value.length !== 0 || isLoading" (click)="accept()">
+      <button class="btn btn-success max-width" [disabled]="error$.value.length !== 0 || (isLoading | async)" (click)="accept()">
 
         <!-- normal state -->
-      <ng-container *ngIf="!isLoading">
+      <ng-container *ngIf="!(isLoading | async)">
         {{'clarin.license.agreement.button.agree' | translate}}
       </ng-container>
 
       <!-- loading state -->
-      <ng-container *ngIf="isLoading">
+      <ng-container *ngIf="isLoading | async">
         <span
           class="spinner-border spinner-border-sm"
           role="status"

--- a/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.html
+++ b/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.html
@@ -89,21 +89,13 @@
   <div class="row pt-3">
     <div class="col-12">
       <button class="btn btn-success max-width" [disabled]="error$.value.length !== 0 || (isLoading | async)" (click)="accept()">
-
-        <!-- normal state -->
-      <ng-container *ngIf="!(isLoading | async)">
         {{'clarin.license.agreement.button.agree' | translate}}
-      </ng-container>
-
-      <!-- loading state -->
-      <ng-container *ngIf="isLoading | async">
         <span
-          class="spinner-border spinner-border-sm"
+          *ngIf="isLoading | async"
+          class="ml-1 spinner-border spinner-border-sm"
           role="status"
           aria-hidden="true"
         ></span>
-      </ng-container>
-
       </button>
     </div>
   </div>

--- a/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.html
+++ b/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.html
@@ -88,8 +88,22 @@
   </div>
   <div class="row pt-3">
     <div class="col-12">
-      <button class="btn btn-success max-width" [disabled]="error$.value.length !== 0" (click)="accept()">
+      <button class="btn btn-success max-width" [disabled]="error$.value.length !== 0 || isLoading" (click)="accept()">
+
+        <!-- normal state -->
+      <ng-container *ngIf="!isLoading">
         {{'clarin.license.agreement.button.agree' | translate}}
+      </ng-container>
+
+      <!-- loading state -->
+      <ng-container *ngIf="isLoading">
+        <span
+          class="spinner-border spinner-border-sm"
+          role="status"
+          aria-hidden="true"
+        ></span>
+      </ng-container>
+
       </button>
     </div>
   </div>

--- a/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
+++ b/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
@@ -125,7 +125,7 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
   /**
    * Indicates when the submission is in progress and resets after completion
    */
-  isLoading = false;
+  isLoading: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
   constructor(
     protected clarinLicenseResourceMappingService: ClarinLicenseResourceMappingService,
@@ -191,7 +191,7 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
       return;
     }
 
-    this.isLoading = true;
+    this.isLoading.next(true);
 
     const requestId = this.requestService.generateRequestId();
     // Response type must be `text` because it throws response as error byd status code is 200 (Success).
@@ -223,7 +223,7 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
     const response = this.rdbService.buildFromRequestUUID(requestId);
     // Process response
     response
-      .pipe(getFirstCompletedRemoteData(), finalize(() => this.isLoading = false))
+      .pipe(getFirstCompletedRemoteData(), finalize(() => this.isLoading.next(false)))
       .subscribe(responseRD$ => {
         if (hasFailed(responseRD$.state)) {
           this.notificationService.error(

--- a/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
+++ b/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Bitstream } from '../../core/shared/bitstream.model';
 import { BehaviorSubject, Observable, of as observableOf } from 'rxjs';
-import { switchMap, take } from 'rxjs/operators';
+import { finalize, switchMap, take } from 'rxjs/operators';
 import { followLink } from '../../shared/utils/follow-link-config.model';
 import { ClarinUserRegistration } from '../../core/shared/clarin/clarin-user-registration.model';
 import { ClarinUserMetadata } from '../../core/shared/clarin/clarin-user-metadata.model';
@@ -122,6 +122,11 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
    */
   licenseContentSeznam: BehaviorSubject<string> = new BehaviorSubject<string>('');
 
+  /**
+   * If agree button is clicked, loading triggers
+   */
+  isLoading: boolean = false;
+
   constructor(
     protected clarinLicenseResourceMappingService: ClarinLicenseResourceMappingService,
     protected configurationDataService: ConfigurationDataService,
@@ -186,6 +191,8 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
       return;
     }
 
+    this.isLoading = true;
+
     const requestId = this.requestService.generateRequestId();
     // Response type must be `text` because it throws response as error byd status code is 200 (Success).
     const requestOptions: HttpOptions = Object.create({
@@ -216,7 +223,7 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
     const response = this.rdbService.buildFromRequestUUID(requestId);
     // Process response
     response
-      .pipe(getFirstCompletedRemoteData())
+      .pipe(getFirstCompletedRemoteData(), finalize(() => this.isLoading = false))
       .subscribe(responseRD$ => {
         if (hasFailed(responseRD$.state)) {
           this.notificationService.error(

--- a/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
+++ b/src/app/bitstream-page/clarin-license-agreement-page/clarin-license-agreement-page.component.ts
@@ -123,9 +123,9 @@ export class ClarinLicenseAgreementPageComponent implements OnInit {
   licenseContentSeznam: BehaviorSubject<string> = new BehaviorSubject<string>('');
 
   /**
-   * If agree button is clicked, loading triggers
+   * Indicates when the submission is in progress and resets after completion
    */
-  isLoading: boolean = false;
+  isLoading = false;
 
   constructor(
     protected clarinLicenseResourceMappingService: ClarinLicenseResourceMappingService,


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
In some specific occasions (e.g. #842), waiting for a response is too long.
It would be helpful to see an indicator of loading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The "Agree" button on the license agreement page now shows a loading spinner and is disabled while processing, providing clear feedback and preventing repeated clicks during submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->