### PR TITLE
UFAL/Show openaire input field every time the EU funding type is selected

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model.ts
@@ -123,13 +123,8 @@ export class DynamicComplexModel extends DynamicConcatModel {
         if (this.name === SPONSOR_METADATA_NAME) {
           // if funding type is `EU`
           if (index === FUNDING_TYPE_INDEX && DEFAULT_EU_FUNDING_TYPES.includes(val.value)) {
-            isEUFund = true;
-          }
-          // if funding type is `EU` and input field is `openaire_id` -> show `openaire_id` readonly input field
-          if (index === EU_IDENTIFIER_INDEX && isEUFund && val.value.includes(EU_PROJECT_PREFIX)) {
+            // Show EU identifier input field
             (this.get(EU_IDENTIFIER_INDEX) as DsDynamicInputModel).hidden = false;
-          } else {
-            (this.get(EU_IDENTIFIER_INDEX) as DsDynamicInputModel).hidden = true;
           }
         }
       } else if (hasValue((this.get(index) as DsDynamicInputModel))) {

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model.ts
@@ -109,8 +109,6 @@ export class DynamicComplexModel extends DynamicConcatModel {
     // remove undefined values
     values = values.filter(v => v);
 
-    // if funding type is `EU`
-    let isEUFund = false;
     values.forEach((val, index) =>  {
       if (val.value) {
         // do not set value if it bigger than allowed length


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the logic for displaying the EU identifier input field in funding forms. The field is now always shown when the funding type is EU, improving consistency in the user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->