### PR TITLE
ufal/show-no-spinner-when-item-has-no-files

### DIFF
--- a/src/app/item-page/simple/field-components/preview-section/preview-section.component.html
+++ b/src/app/item-page/simple/field-components/preview-section/preview-section.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="(listOfFiles | async) as files; else loading">
   <!-- Show "No files" message -->
-  <div *ngIf="isArrayAndEmpty(files)" class="text-center text-muted my-3">
+  <div *ngIf="hasNoFiles" class="text-center text-muted my-3">
     {{ 'item.view.box.no-files.message' | translate }}
   </div>
 

--- a/src/app/item-page/simple/field-components/preview-section/preview-section.component.html
+++ b/src/app/item-page/simple/field-components/preview-section/preview-section.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="(listOfFiles | async) as files; else loading">
   <!-- Show "No files" message -->
-  <div *ngIf="isArrayAndEmpty(files) && files.length === 0" class="text-center text-muted my-3">
+  <div *ngIf="isArrayAndEmpty(files) class="text-center text-muted my-3">
     {{ 'item.view.box.no-files.message' | translate }}
   </div>
 

--- a/src/app/item-page/simple/field-components/preview-section/preview-section.component.html
+++ b/src/app/item-page/simple/field-components/preview-section/preview-section.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="(listOfFiles | async) as files; else loading">
   <!-- Show "No files" message -->
-  <div *ngIf="isArrayAndEmpty(files) class="text-center text-muted my-3">
+  <div *ngIf="isArrayAndEmpty(files)" class="text-center text-muted my-3">
     {{ 'item.view.box.no-files.message' | translate }}
   </div>
 

--- a/src/app/item-page/simple/field-components/preview-section/preview-section.component.html
+++ b/src/app/item-page/simple/field-components/preview-section/preview-section.component.html
@@ -1,10 +1,24 @@
-<!-- Loading Spinner -->
-<div *ngIf="(listOfFiles | async)?.length === 0" class="d-flex flex-column justify-content-center align-items-center my-3">
-  <div class="spinner-border text-primary" role="status"></div>
-  <div class="px-4 pt-2">{{'item.preview.loading-files' | translate}}
-    <a *ngIf="emailToContact" [href]="'mailto:' + emailToContact" class="email-text">{{ emailToContact }}</a>
+<ng-container *ngIf="(listOfFiles | async) as files; else loading">
+  <!-- Show "No files" message -->
+  <div *ngIf="files.length === 0" class="text-center text-muted my-3">
+    {{ 'item.view.box.no-files.message' | translate }}
   </div>
-</div>
-<div *ngFor="let file of (listOfFiles | async)">
-  <ds-file-description [fileInput] = 'file'></ds-file-description>
-</div>
+
+  <!-- Show list of files -->
+  <div *ngFor="let file of files">
+    <ds-file-description [fileInput]="file"></ds-file-description>
+  </div>
+</ng-container>
+
+<!-- Spinner shown only while listOfFiles is null or undefined -->
+<ng-template #loading>
+  <div class="d-flex flex-column justify-content-center align-items-center my-3">
+    <div class="spinner-border text-primary" role="status"></div>
+    <div class="px-4 pt-2">
+      {{ 'item.preview.loading-files' | translate }}
+      <a *ngIf="emailToContact" [href]="'mailto:' + emailToContact" class="email-text">
+        {{ emailToContact }}
+      </a>
+    </div>
+  </div>
+</ng-template>

--- a/src/app/item-page/simple/field-components/preview-section/preview-section.component.html
+++ b/src/app/item-page/simple/field-components/preview-section/preview-section.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="(listOfFiles | async) as files; else loading">
   <!-- Show "No files" message -->
-  <div *ngIf="hasNoFiles" class="text-center text-muted my-3">
+  <div *ngIf="(hasNoFiles | async)" class="text-center text-muted my-3">
     {{ 'item.view.box.no-files.message' | translate }}
   </div>
 

--- a/src/app/item-page/simple/field-components/preview-section/preview-section.component.html
+++ b/src/app/item-page/simple/field-components/preview-section/preview-section.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="(listOfFiles | async) as files; else loading">
   <!-- Show "No files" message -->
-  <div *ngIf="files.length === 0" class="text-center text-muted my-3">
+  <div *ngIf="isArrayAndEmpty(files) && files.length === 0" class="text-center text-muted my-3">
     {{ 'item.view.box.no-files.message' | translate }}
   </div>
 

--- a/src/app/item-page/simple/field-components/preview-section/preview-section.component.ts
+++ b/src/app/item-page/simple/field-components/preview-section/preview-section.component.ts
@@ -16,7 +16,7 @@ export class PreviewSectionComponent implements OnInit {
 
   listOfFiles: BehaviorSubject<MetadataBitstream[]> = new BehaviorSubject<MetadataBitstream[]>([] as any);
   emailToContact: string;
-  hasNoFiles = true;
+  hasNoFiles: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(true);
 
   constructor(protected registryService: RegistryService,
               private configService: ConfigurationDataService) {} // Modified
@@ -27,7 +27,7 @@ export class PreviewSectionComponent implements OnInit {
       .pipe(getAllSucceededRemoteListPayload())
       .subscribe((data: MetadataBitstream[]) => {
         this.listOfFiles.next(data);
-        this.hasNoFiles = !Array.isArray(data) || data.length === 0;
+        this.hasNoFiles.next(!Array.isArray(data) || data.length === 0);
       });
     this.configService.findByPropertyName('lr.help.mail')?.subscribe(remoteData => {
       this.emailToContact = remoteData.payload?.values?.[0];

--- a/src/app/item-page/simple/field-components/preview-section/preview-section.component.ts
+++ b/src/app/item-page/simple/field-components/preview-section/preview-section.component.ts
@@ -32,5 +32,7 @@ export class PreviewSectionComponent implements OnInit {
     });
   }
 
-
+  isArrayAndEmpty(value: unknown): boolean {
+    return Array.isArray(value) && value.length === 0;
+  }
 }

--- a/src/app/item-page/simple/field-components/preview-section/preview-section.component.ts
+++ b/src/app/item-page/simple/field-components/preview-section/preview-section.component.ts
@@ -16,6 +16,7 @@ export class PreviewSectionComponent implements OnInit {
 
   listOfFiles: BehaviorSubject<MetadataBitstream[]> = new BehaviorSubject<MetadataBitstream[]>([] as any);
   emailToContact: string;
+  hasNoFiles = true;
 
   constructor(protected registryService: RegistryService,
               private configService: ConfigurationDataService) {} // Modified
@@ -26,13 +27,10 @@ export class PreviewSectionComponent implements OnInit {
       .pipe(getAllSucceededRemoteListPayload())
       .subscribe((data: MetadataBitstream[]) => {
         this.listOfFiles.next(data);
+        this.hasNoFiles = !Array.isArray(data) || data.length === 0;
       });
     this.configService.findByPropertyName('lr.help.mail')?.subscribe(remoteData => {
       this.emailToContact = remoteData.payload?.values?.[0];
     });
-  }
-
-  isArrayAndEmpty(value: unknown): value is unknown[] {
-    return Array.isArray(value) && value.length === 0;
   }
 }

--- a/src/app/item-page/simple/field-components/preview-section/preview-section.component.ts
+++ b/src/app/item-page/simple/field-components/preview-section/preview-section.component.ts
@@ -32,7 +32,7 @@ export class PreviewSectionComponent implements OnInit {
     });
   }
 
-  isArrayAndEmpty(value: unknown): boolean {
+  isArrayAndEmpty(value: unknown): value is unknown[] {
     return Array.isArray(value) && value.length === 0;
   }
 }


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0.5  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
When Item has no files, there is messages about problem and files loading with spinner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the display logic for file previews, providing clearer separation between loading, empty, and populated states.
  * Loading spinner now appears only while files are being loaded, not when the list is empty.
  * Enhanced user experience with more explicit messaging for each state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->