### PR TITLE
UFAL/Publisher search redirect not work #880

### DIFF
--- a/src/app/shared/clarin-item-box-view/clarin-item-box-view.component.ts
+++ b/src/app/shared/clarin-item-box-view/clarin-item-box-view.component.ts
@@ -147,14 +147,19 @@ export class ClarinItemBoxViewComponent implements OnInit {
     this.itemUri = getItemPageRoute(this.item);
     this.itemDescription = this.item?.firstMetadataValue('dc.description');
     this.itemPublisher = this.item?.firstMetadataValue('dc.publisher');
-    this.publisherRedirectLink = this.baseUrl + '/search?f.publisher=' + encodeURIComponent(this.itemPublisher)
-      + ',equals';
     this.itemDate = this.clarinDateService.composeItemDate(this.item);
 
     await this.assignBaseUrl();
+    this.publisherRedirectLink = this.getSearchEndpoint() + '?f.publisher=' + encodeURIComponent(this.itemPublisher)
+      + ',equals';
     this.getItemCommunity();
     this.loadItemLicense();
     this.getItemFilesSize();
+  }
+
+  private getSearchEndpoint(): string {
+    // Return the search endpoint URL for with the base URL. Remove trailing slashes to ensure a clean URL.
+    return this.baseUrl.replace(/\/+$/, '') +  '/search';
   }
 
   private getItemFilesSize() {
@@ -193,8 +198,7 @@ export class ClarinItemBoxViewComponent implements OnInit {
           .pipe(getFirstSucceededRemoteDataPayload())
           .subscribe((community: Community) => {
             this.itemCommunity.next(community);
-            const encodedRedirectLink = this.baseUrl +
-              '/search?f.items_owning_community=' + encodeURIComponent(this.dsoNameService.getName(community)) + ',equals';
+            const encodedRedirectLink = this.getSearchEndpoint() + '?f.items_owning_community=' + encodeURIComponent(this.dsoNameService.getName(community)) + ',equals';
             this.communitySearchRedirect.next(encodedRedirectLink);
           });
       });


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0.5  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Cherry-pick commits from the customer/lindat branch into the dtq-dev branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of search endpoint URLs to ensure consistency and reliability when redirecting to search pages. No visible changes to functionality for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->