### PR TITLE
ZCU-PUB/Missing translation in cs.json5

### DIFF
--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -2160,6 +2160,8 @@
   "footer.link.contact-us": "Kontaktujte nás",
   // "footer.link.university": "University Library",
   "footer.link.university": "Univerzitni Knihovna",
+  // "footer.theme.by.message": "Theme by",
+  "footer.theme.by.message": "Theme by",
   // "forgot-email.form.header": "Forgot Password",
   "forgot-email.form.header": "Zapomenuté heslo",
   // "forgot-email.form.info": "Enter the email address associated with the account.",


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
In Czech translation in footer was visible: `footer.theme.by.message` instead of e.g., `Theme by` 
