### PR TITLE
FIX: Add quotes to curl download command

### DIFF
--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
@@ -106,9 +106,11 @@ export class ClarinFilesSectionComponent implements OnInit {
 
       return file.name;
     });
+    
     const url =`${this.halService.getRootHref()}/core/items/${this.item.id}/allzip?handleId=${this.itemHandle}`;
     this.command = `curl -o "allzip.zip" "${url}"`;
   }
+
   loadDownloadZipConfigProperties() {
     this.configurationService.findByPropertyName('download.all.limit.min.file.count')
       .pipe(

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
@@ -107,9 +107,8 @@ export class ClarinFilesSectionComponent implements OnInit {
       return file.name;
     });
 
-    this.command = `curl -o allzip.zip ` + this.halService.getRootHref() + `/core/items/${this.item.id}/allzip?handleId=${this.itemHandle}`;
+    this.command = 'curl -o "allzip.zip" "' + this.halService.getRootHref() + '/core/items/' + this.item.id + '/allzip?handleId=' + this.itemHandle + '"';
   }
-
   loadDownloadZipConfigProperties() {
     this.configurationService.findByPropertyName('download.all.limit.min.file.count')
       .pipe(

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
@@ -106,8 +106,8 @@ export class ClarinFilesSectionComponent implements OnInit {
 
       return file.name;
     });
-    
-    const url =`${this.halService.getRootHref()}/core/items/${this.item.id}/allzip?handleId=${this.itemHandle}`;
+
+    const url = `${this.halService.getRootHref()}/core/items/${this.item.id}/allzip?handleId=${this.itemHandle}`;
     this.command = `curl -o "allzip.zip" "${url}"`;
   }
 

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
@@ -106,8 +106,8 @@ export class ClarinFilesSectionComponent implements OnInit {
 
       return file.name;
     });
-
-    this.command = 'curl -o "allzip.zip" "' + this.halService.getRootHref() + '/core/items/' + this.item.id + '/allzip?handleId=' + this.itemHandle + '"';
+    const url =`${this.halService.getRootHref()}/core/items/${this.item.id}/allzip?handleId=${this.itemHandle}`;
+    this.command = `curl -o "allzip.zip" "${url}"`;
   }
   loadDownloadZipConfigProperties() {
     this.configurationService.findByPropertyName('download.all.limit.min.file.count')


### PR DESCRIPTION
This pull request addresses the issue where the generated `curl` command for downloading files was missing quotes around the filename and the URL. This could cause issues when pasting the command into a command-line environment.

The fix was applied in the `generateCurlCommand()` method within the `clarin-files-section.component.ts` file. The string concatenation was modified to wrap both the output filename (`allzip.zip`) and the full URL in double quotes (`"`).

Closes #933

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting of the generated curl command by adding quotes around the output filename and URL to ensure better compatibility when copying and running the command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->