### PR TITLE
UFAL/download-bitstreams-as-separated-api-calling

### DIFF
--- a/src/app/bitstream-page/legacy-bitstream-url-redirect.guard.ts
+++ b/src/app/bitstream-page/legacy-bitstream-url-redirect.guard.ts
@@ -48,9 +48,15 @@ export const legacyBitstreamURLRedirectGuard: CanActivateFn = (
     getFirstCompletedRemoteData(),
     map((rd: RemoteData<Bitstream>) => {
       if (rd.hasSucceeded && !rd.hasNoContent) {
-        const nameSpace = appConfig.ui.nameSpace?.replace(/\/$/, '') || '';
-        const redirectUrl = new URL(nameSpace + `/bitstreams/${rd.payload.uuid}/download`, serverHardRedirectService.getCurrentOrigin()).href;
-        console.log('Legacy bitstream URL redirecting to:', redirectUrl);
+        // Harden namespace handling: trim slashes, neutralize absolute-like values, enforce root-relative path
+        let nameSpace = (appConfig.ui.nameSpace || '').replace(/^\/+|\/+$/g, '');
+        // Neutralize any absolute-like values (http:, https:, //)
+        if (nameSpace.startsWith('http:') || nameSpace.startsWith('https:') || nameSpace.startsWith('//')) {
+          nameSpace = '';
+        }
+        // Always build path starting with /
+        const redirectPath = nameSpace ? `/${nameSpace}/bitstreams/${rd.payload.uuid}/download` : `/bitstreams/${rd.payload.uuid}/download`;
+        const redirectUrl = new URL(redirectPath, serverHardRedirectService.getCurrentOrigin()).href;
         serverHardRedirectService.redirect(redirectUrl, 301);
         return false;
       } else {

--- a/src/app/bitstream-page/legacy-bitstream-url-redirect.guard.ts
+++ b/src/app/bitstream-page/legacy-bitstream-url-redirect.guard.ts
@@ -48,21 +48,9 @@ export const legacyBitstreamURLRedirectGuard: CanActivateFn = (
     getFirstCompletedRemoteData(),
     map((rd: RemoteData<Bitstream>) => {
       if (rd.hasSucceeded && !rd.hasNoContent) {
-        let nameSpace = (appConfig.ui.nameSpace || '').replace(/^\/+|\/+$/g, '');
-        // Neutralize any absolute-like values (http:, https:, //, protocol-relative URLs, or invalid characters)
-        const allowedNamespaceRegex = /^[a-zA-Z0-9_-]+$/;
-        // Check for absolute URLs, protocol-relative URLs, or invalid characters
-        if (
-          nameSpace.startsWith('http:') ||
-          nameSpace.startsWith('https:') ||
-          nameSpace.startsWith('//') ||
-          nameSpace.match(/^\/[^\/]/) || // protocol-relative URL: single slash followed by non-slash
-          !allowedNamespaceRegex.test(nameSpace)
-        ) {
-          nameSpace = '';
-        }
-        const redirectPath = nameSpace ? `/${nameSpace}/bitstreams/${rd.payload.uuid}/download` : `/bitstreams/${rd.payload.uuid}/download`;
-        const redirectUrl = new URL(redirectPath, serverHardRedirectService.getCurrentOrigin()).href;
+        const nameSpace = appConfig.ui.nameSpace?.replace(/\/$/, '') || '';
+        const redirectUrl = new URL(nameSpace + `/bitstreams/${rd.payload.uuid}/download`, serverHardRedirectService.getCurrentOrigin()).href;
+        console.log('Legacy bitstream URL redirecting to:', redirectUrl);
         serverHardRedirectService.redirect(redirectUrl, 301);
         return false;
       } else {

--- a/src/app/bitstream-page/legacy-bitstream-url-redirect.guard.ts
+++ b/src/app/bitstream-page/legacy-bitstream-url-redirect.guard.ts
@@ -9,6 +9,7 @@ import {
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
+import { APP_CONFIG, AppConfig } from '../../config/app-config.interface';
 import { PAGE_NOT_FOUND_PATH } from '../app-routing-paths';
 import { BitstreamDataService } from '../core/data/bitstream-data.service';
 import { RemoteData } from '../core/data/remote-data';
@@ -30,6 +31,7 @@ export const legacyBitstreamURLRedirectGuard: CanActivateFn = (
   bitstreamDataService: BitstreamDataService = inject(BitstreamDataService),
   serverHardRedirectService: HardRedirectService = inject(HardRedirectService),
   router: Router = inject(Router),
+  appConfig: AppConfig = inject(APP_CONFIG),
 ): Observable<UrlTree | boolean> => {
   const prefix = route.params.prefix;
   const suffix = route.params.suffix;
@@ -46,7 +48,10 @@ export const legacyBitstreamURLRedirectGuard: CanActivateFn = (
     getFirstCompletedRemoteData(),
     map((rd: RemoteData<Bitstream>) => {
       if (rd.hasSucceeded && !rd.hasNoContent) {
-        serverHardRedirectService.redirect(new URL(`/bitstreams/${rd.payload.uuid}/download`, serverHardRedirectService.getCurrentOrigin()).href, 301);
+        const nameSpace = appConfig.ui.nameSpace?.replace(/\/$/, '') || '';
+        const redirectUrl = new URL(nameSpace + `/bitstreams/${rd.payload.uuid}/download`, serverHardRedirectService.getCurrentOrigin()).href;
+        console.log('Legacy bitstream URL redirecting to:', redirectUrl);
+        serverHardRedirectService.redirect(redirectUrl, 301);
         return false;
       } else {
         return router.createUrlTree([PAGE_NOT_FOUND_PATH]);

--- a/src/app/bitstream-page/legacy-bitstream-url-redirect.guard.ts
+++ b/src/app/bitstream-page/legacy-bitstream-url-redirect.guard.ts
@@ -50,7 +50,6 @@ export const legacyBitstreamURLRedirectGuard: CanActivateFn = (
       if (rd.hasSucceeded && !rd.hasNoContent) {
         const nameSpace = appConfig.ui.nameSpace?.replace(/\/$/, '') || '';
         const redirectUrl = new URL(nameSpace + `/bitstreams/${rd.payload.uuid}/download`, serverHardRedirectService.getCurrentOrigin()).href;
-        console.log('Legacy bitstream URL redirecting to:', redirectUrl);
         serverHardRedirectService.redirect(redirectUrl, 301);
         return false;
       } else {

--- a/src/app/bitstream-page/legacy-bitstream-url-redirect.guard.ts
+++ b/src/app/bitstream-page/legacy-bitstream-url-redirect.guard.ts
@@ -48,13 +48,19 @@ export const legacyBitstreamURLRedirectGuard: CanActivateFn = (
     getFirstCompletedRemoteData(),
     map((rd: RemoteData<Bitstream>) => {
       if (rd.hasSucceeded && !rd.hasNoContent) {
-        // Harden namespace handling: trim slashes, neutralize absolute-like values, enforce root-relative path
         let nameSpace = (appConfig.ui.nameSpace || '').replace(/^\/+|\/+$/g, '');
-        // Neutralize any absolute-like values (http:, https:, //)
-        if (nameSpace.startsWith('http:') || nameSpace.startsWith('https:') || nameSpace.startsWith('//')) {
+        // Neutralize any absolute-like values (http:, https:, //, protocol-relative URLs, or invalid characters)
+        const allowedNamespaceRegex = /^[a-zA-Z0-9_-]+$/;
+        // Check for absolute URLs, protocol-relative URLs, or invalid characters
+        if (
+          nameSpace.startsWith('http:') ||
+          nameSpace.startsWith('https:') ||
+          nameSpace.startsWith('//') ||
+          nameSpace.match(/^\/[^\/]/) || // protocol-relative URL: single slash followed by non-slash
+          !allowedNamespaceRegex.test(nameSpace)
+        ) {
           nameSpace = '';
         }
-        // Always build path starting with /
         const redirectPath = nameSpace ? `/${nameSpace}/bitstreams/${rd.payload.uuid}/download` : `/bitstreams/${rd.payload.uuid}/download`;
         const redirectUrl = new URL(redirectPath, serverHardRedirectService.getCurrentOrigin()).href;
         serverHardRedirectService.redirect(redirectUrl, 301);

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
@@ -110,7 +110,7 @@ export class ClarinFilesSectionComponent implements OnInit {
     // Generate curl command for individual bitstream downloads
     const baseUrl = `${this.halService.getRootHref()}/bitstream/${this.itemHandle}`;
     const fileNamesFormatted = fileNames.map((fileName, index) => `/${index}/${fileName}`).join(',');
-    this.command = `curl -O ${baseUrl}{${fileNamesFormatted}} -k`;
+    this.command = `curl -O ${baseUrl}{${fileNamesFormatted}}`;
   }
 
   loadDownloadZipConfigProperties() {

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
@@ -107,8 +107,10 @@ export class ClarinFilesSectionComponent implements OnInit {
       return file.name;
     });
 
-    const url = `${this.halService.getRootHref()}/core/items/${this.item.id}/allzip?handleId=${this.itemHandle}`;
-    this.command = `curl -o "allzip.zip" "${url}"`;
+    // Generate curl command for individual bitstream downloads
+    const baseUrl = `${this.halService.getRootHref()}/bitstream/${this.itemHandle}`;
+    const fileNamesFormatted = fileNames.map((fileName, index) => `/${index}/${fileName}`).join(',');
+    this.command = `curl -O ${baseUrl}{${fileNamesFormatted}} -k`;
   }
 
   loadDownloadZipConfigProperties() {


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0.5  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  1  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
When a bitstream is downloaded by name (e.g., https://dev-5.pc:8443/repository/bitstream/123456789/2-5947/0/test.txt), it redirects to https://dev-5.pc:8443/bitstreams/525188bc-7d2e-4ed6-a6d7-1a4b031b67b7/download, but the /repository prefix is missing in the redirected URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Legacy bitstream links now redirect correctly when a UI namespace is configured, preventing broken downloads.
  * Redirects use a permanent (301) redirect to improve bookmarking and SEO.
  * Falls back to a not-found page when the target bitstream cannot be resolved.

* **New Features**
  * Namespace-aware redirect behavior that sanitizes configured namespaces to avoid malformed redirects.
  * Multi-file curl download support using shell brace expansion to fetch individual bitstreams with remote filenames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->