### PR TITLE
VSB-TUO/Added handle prefix to docker compose

### DIFF
--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -53,6 +53,8 @@ services:
       assetstore__P__s3__P__awsRegionName: ${S3_REGION_NAME:-}
       assetstore__P__s3__P__pathStyleAccessEnabled: ${S3_PATH_STYLE_ACCESS:-false}
       assetstore__P__s3__P__endpoint: ${S3_ENDPOINT:-}
+      # CNRI Handle prefix
+      handle__P__prefix: 10084
     image: ${DSPACE_REST_IMAGE:-dataquest/dspace:dtq-dev-7.5}
     networks:
       - dspacenet

--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -54,7 +54,7 @@ services:
       assetstore__P__s3__P__pathStyleAccessEnabled: ${S3_PATH_STYLE_ACCESS:-false}
       assetstore__P__s3__P__endpoint: ${S3_ENDPOINT:-}
       # CNRI Handle prefix
-      handle__P__prefix: 10084
+      handle__P__prefix: ${HANDLE_PREFIX:-10084}
     image: ${DSPACE_REST_IMAGE:-dataquest/dspace:dtq-dev-7.5}
     networks:
       - dspacenet


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0.25  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Handle prefix for vsb-tuo is missing in docker compose.
