### PR TITLE
UFAL/Cherrypick Total Downloads

### DIFF
--- a/src/app/core/statistics/models/usage-report.model.ts
+++ b/src/app/core/statistics/models/usage-report.model.ts
@@ -47,5 +47,6 @@ export interface Point {
   type: string;
   values: {
     views: number;
-  }[];
+    [key: string]: number;
+  };
 }

--- a/src/app/core/statistics/usage-report-data.service.ts
+++ b/src/app/core/statistics/usage-report-data.service.ts
@@ -20,7 +20,7 @@ import { RequestParam } from '../cache/models/request-param.model';
 /**
  * A service to retrieve {@link UsageReport}s from the REST API
  */
-@Injectable()
+@Injectable({ providedIn: 'root' })
 @dataService(USAGE_REPORT)
 export class UsageReportDataService extends IdentifiableDataService<UsageReport> implements SearchData<UsageReport> {
   private searchData: SearchDataImpl<UsageReport>;

--- a/src/app/item-page/item-page.module.ts
+++ b/src/app/item-page/item-page.module.ts
@@ -91,7 +91,6 @@ import { ClarinIdentifierItemFieldComponent } from './simple/field-components/cl
 import { ClarinDateItemFieldComponent } from './simple/field-components/clarin-date-item-field/clarin-date-item-field.component';
 import { ClarinDescriptionItemFieldComponent } from './simple/field-components/clarin-description-item-field/clarin-description-item-field.component';
 import { ClarinFilesSectionComponent } from './clarin-files-section/clarin-files-section.component';
-import { UsageReportDataService } from '../core/statistics/usage-report-data.service';
 
 const ENTRY_COMPONENTS = [
   // put only entry components that use custom decorator
@@ -184,9 +183,6 @@ const DECLARATIONS = [
   ],
   exports: [
     ...DECLARATIONS,
-  ],
-  providers: [
-    UsageReportDataService,
   ]
 })
 export class ItemPageModule {

--- a/src/app/item-page/item-page.module.ts
+++ b/src/app/item-page/item-page.module.ts
@@ -57,6 +57,7 @@ import { ItemAlertsComponent } from './alerts/item-alerts.component';
 import { ItemVersionsModule } from './versions/item-versions.module';
 import { BitstreamRequestACopyPageComponent } from './bitstreams/request-a-copy/bitstream-request-a-copy-page.component';
 import { FileSectionComponent } from './simple/field-components/file-section/file-section.component';
+import { TotalDownloadsComponent } from './simple/field-components/file-section/total-downloads.component';
 import { ItemSharedModule } from './item-shared.module';
 import { DsoPageModule } from '../shared/dso-page/dso-page.module';
 import { ThemedItemAlertsComponent } from './alerts/themed-item-alerts.component';
@@ -90,6 +91,7 @@ import { ClarinIdentifierItemFieldComponent } from './simple/field-components/cl
 import { ClarinDateItemFieldComponent } from './simple/field-components/clarin-date-item-field/clarin-date-item-field.component';
 import { ClarinDescriptionItemFieldComponent } from './simple/field-components/clarin-description-item-field/clarin-description-item-field.component';
 import { ClarinFilesSectionComponent } from './clarin-files-section/clarin-files-section.component';
+import { UsageReportDataService } from '../core/statistics/usage-report-data.service';
 
 const ENTRY_COMPONENTS = [
   // put only entry components that use custom decorator
@@ -99,6 +101,7 @@ const ENTRY_COMPONENTS = [
 
 const DECLARATIONS = [
   FileSectionComponent,
+  TotalDownloadsComponent,
   ThemedFileSectionComponent,
   ItemPageComponent,
   ThemedItemPageComponent,
@@ -181,6 +184,9 @@ const DECLARATIONS = [
   ],
   exports: [
     ...DECLARATIONS,
+  ],
+  providers: [
+    UsageReportDataService,
   ]
 })
 export class ItemPageModule {

--- a/src/app/item-page/simple/field-components/file-section/total-downloads.component.html
+++ b/src/app/item-page/simple/field-components/file-section/total-downloads.component.html
@@ -1,4 +1,6 @@
-<ds-metadata-field-wrapper [label]="downloadsLabel | translate">
+<ds-metadata-field-wrapper
+  *ngIf="totalDownloadsEnabled | async"
+  [label]="downloadsLabel | translate">
   <div class="total-downloads-section">
     <div class="total-downloads-count">
       <span>{{ totalDownloads }}</span>

--- a/src/app/item-page/simple/field-components/file-section/total-downloads.component.html
+++ b/src/app/item-page/simple/field-components/file-section/total-downloads.component.html
@@ -1,0 +1,7 @@
+<ds-metadata-field-wrapper [label]="downloadsLabel | translate">
+  <div class="total-downloads-section">
+    <div class="total-downloads-count">
+      <span>{{ totalDownloads }}</span>
+    </div>
+  </div>
+</ds-metadata-field-wrapper>

--- a/src/app/item-page/simple/field-components/file-section/total-downloads.component.ts
+++ b/src/app/item-page/simple/field-components/file-section/total-downloads.component.ts
@@ -1,0 +1,73 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { UsageReportDataService } from 'src/app/core/statistics/usage-report-data.service';
+import { catchError } from 'rxjs/operators';
+import { of } from 'rxjs';
+
+/**
+ * Component that displays the total number of downloads for all bitstreams within a DSpace item.
+ *
+ * This component fetches download statistics for a given item using its UUID and aggregates
+ * the download counts from all bitstreams associated with that item. The result is displayed
+ * as a single total download count.
+ */
+@Component({
+  selector: 'ds-total-downloads',
+  templateUrl: './total-downloads.component.html',
+  styleUrls: ['./total-downloads.component.scss']
+})
+export class TotalDownloadsComponent implements OnInit {
+
+  /**
+   * The UUID of the DSpace item for which to fetch download statistics.
+   */
+  @Input() itemUuid!: string;
+
+  /**
+   * The total number of downloads across all bitstreams for the item.
+   * Defaults to 0 and will show 0 if no data is available or an error occurs.
+   */
+  totalDownloads: number = 0;
+
+  /**
+   * The translation key for the downloadsLabel displayed alongside the download count.
+   */
+  readonly downloadsLabel = 'item.page.files.downloads';
+
+
+  constructor(private usageReportDataService: UsageReportDataService) { }
+
+  /**
+   * Fetches the total download statistics for the item specified by itemUuid.
+   * The component will:
+   * 1. Call the UsageReportDataService with the item UUID and 'TotalDownloads' report type
+   * 2. Aggregate all download counts (views) from all bitstreams in the response
+   * 3. Set the totalDownloads property with the sum
+   * 4. Handle errors gracefully by setting totalDownloads to 0 and logging the error
+   *
+   * @throws Will log an error to console if the API call fails, but won't throw an exception
+   */
+  ngOnInit(): void {
+    if (!this.itemUuid) {
+      return;
+    }
+
+    const reportType = 'TotalDownloads';
+    this.usageReportDataService.getStatistic(this.itemUuid, reportType)
+      .pipe(
+        catchError(error => {
+          console.error('Failed to fetch total downloads statistics:', error);
+          return of(null);
+        })
+      )
+      .subscribe(report => {
+        if (report) {
+          this.totalDownloads = report.points.reduce((total, point) => {
+            const views = point.values.views || 0;
+            return total + views;
+          }, 0);
+        } else {
+          this.totalDownloads = 0; // Show 0 instead of null when no data is available
+        }
+      });
+  }
+}

--- a/src/app/item-page/simple/field-components/file-section/total-downloads.component.ts
+++ b/src/app/item-page/simple/field-components/file-section/total-downloads.component.ts
@@ -1,14 +1,18 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { UsageReportDataService } from 'src/app/core/statistics/usage-report-data.service';
+import { ConfigurationDataService } from 'src/app/core/data/configuration-data.service';
 import { catchError } from 'rxjs/operators';
-import { of } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 
 /**
  * Component that displays the total number of downloads for all bitstreams within a DSpace item.
  *
- * This component fetches download statistics for a given item using its UUID and aggregates
- * the download counts from all bitstreams associated with that item. The result is displayed
- * as a single total download count.
+ * This component checks the 'item.view.total.downloads.enabled' configuration property
+ * to determine if download statistics should be displayed. If enabled, it fetches download
+ * statistics for a given item using its UUID and aggregates the download counts from all
+ * bitstreams associated with that item. The result is displayed as a single total download count.
+ *
+ * If the configuration is disabled or set to 'false', the component will not be displayed.
  */
 @Component({
   selector: 'ds-total-downloads',
@@ -26,7 +30,14 @@ export class TotalDownloadsComponent implements OnInit {
    * The total number of downloads across all bitstreams for the item.
    * Defaults to 0 and will show 0 if no data is available or an error occurs.
    */
-  totalDownloads: number = 0;
+  totalDownloads: number | null = 0;
+
+  /**
+   * Flag indicating whether the total downloads feature is enabled in the configuration.
+   * Uses BehaviorSubject to allow reactive updates. Defaults to false and will only be
+   * set to true if the configuration explicitly contains 'true' value.
+   */
+  totalDownloadsEnabled = new BehaviorSubject<boolean>(false);
 
   /**
    * The translation key for the downloadsLabel displayed alongside the download count.
@@ -34,15 +45,21 @@ export class TotalDownloadsComponent implements OnInit {
   readonly downloadsLabel = 'item.page.files.downloads';
 
 
-  constructor(private usageReportDataService: UsageReportDataService) { }
+  constructor(
+    private usageReportDataService: UsageReportDataService,
+    private configService: ConfigurationDataService
+  ) { }
 
   /**
-   * Fetches the total download statistics for the item specified by itemUuid.
+   * Fetches the configuration to check if total downloads should be shown,
+   * and if enabled, fetches the total download statistics for the item specified by itemUuid.
    * The component will:
-   * 1. Call the UsageReportDataService with the item UUID and 'TotalDownloads' report type
-   * 2. Aggregate all download counts (views) from all bitstreams in the response
-   * 3. Set the totalDownloads property with the sum
-   * 4. Handle errors gracefully by setting totalDownloads to 0 and logging the error
+   * 1. Check the 'item.view.total.downloads.enabled' configuration property
+   * 2. If enabled (configuration value is explicitly 'true'), call the UsageReportDataService
+   *    If configuration is not found or fails to load, defaults to false (disabled)
+   * 3. Aggregate all download counts (views) from all bitstreams in the response
+   * 4. Set the totalDownloads property with the sum
+   * 5. Handle errors gracefully by returning null and logging the error
    *
    * @throws Will log an error to console if the API call fails, but won't throw an exception
    */
@@ -51,6 +68,34 @@ export class TotalDownloadsComponent implements OnInit {
       return;
     }
 
+    // First, check if total downloads feature is enabled in configuration
+    this.configService.findByPropertyName('item.view.total.downloads.enabled')
+      .pipe(
+        catchError(error => {
+          console.error('Failed to fetch total downloads configuration:', error);
+          // Default to false if configuration cannot be retrieved
+          return of(null);
+        })
+      )
+      .subscribe(configData => {
+        // Extract configuration value, default to 'false' if not found
+        const itemViewTotalDownloadsEnabled = configData?.payload?.values?.[0];
+        this.totalDownloadsEnabled.next(itemViewTotalDownloadsEnabled === 'true');
+
+        // Only fetch download statistics if the feature is enabled
+        if (this.totalDownloadsEnabled.value) {
+          this.fetchDownloadStatistics();
+        } else {
+          this.totalDownloads = null; // Ensure it's null when disabled
+        }
+      });
+  }
+
+  /**
+   * Private method to fetch download statistics from the usage report service.
+   * This method is called only when the total downloads feature is enabled.
+   */
+  private fetchDownloadStatistics(): void {
     const reportType = 'TotalDownloads';
     this.usageReportDataService.getStatistic(this.itemUuid, reportType)
       .pipe(

--- a/src/app/statistics-page/statistics-page.module.ts
+++ b/src/app/statistics-page/statistics-page.module.ts
@@ -4,7 +4,6 @@ import { CommonModule } from '@angular/common';
 import { CoreModule } from '../core/core.module';
 import { SharedModule } from '../shared/shared.module';
 import { StatisticsModule } from '../statistics/statistics.module';
-import { UsageReportDataService } from '../core/statistics/usage-report-data.service';
 import { SiteStatisticsPageComponent } from './site-statistics-page/site-statistics-page.component';
 import { StatisticsTableComponent } from './statistics-table/statistics-table.component';
 import { ItemStatisticsPageComponent } from './item-statistics-page/item-statistics-page.component';
@@ -35,9 +34,6 @@ const components = [
     StatisticsModule.forRoot()
   ],
   declarations: components,
-  providers: [
-    UsageReportDataService,
-  ],
   exports: components
 })
 

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -3794,6 +3794,9 @@
   // "item.page.files": "Files",
   "item.page.files": "Soubory",
 
+  // "item.page.files.downloads": "Downloads",
+  "item.page.files.downloads": "Stažení",
+
   // "item.page.filesection.description": "Description:",
   "item.page.filesection.description": "Popis:",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -2529,6 +2529,8 @@
 
   "item.page.files": "Files",
 
+  "item.page.files.downloads": "Downloads",
+
   "item.page.filesection.description": "Description:",
 
   "item.page.filesection.download": "Download",


### PR DESCRIPTION
* Added new feature for downloads of item's bitstreams

* Fixed Copilot's suggestions: any type & redundant property access pattern

| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Cherrypick our new feature for displaying the Total Downloads of each item's bitstreams (sum of bitstreams download)