### PR TITLE
VSB-TUO/Removed forgot site to be unavailable

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -12,7 +12,6 @@ import {
   BITSTREAM_MODULE_PATH,
   ERROR_PAGE,
   FORBIDDEN_PATH,
-  FORGOT_PASSWORD_PATH,
   HEALTH_PAGE_PATH,
   INFO_MODULE_PATH,
   INTERNAL_SERVER_ERROR,
@@ -103,12 +102,6 @@ import { STATIC_PAGE_PATH } from './static-page/static-page-routing-paths';
             loadChildren: () => import('./register-page/register-page.module')
               .then((m) => m.RegisterPageModule),
             canActivate: [SiteRegisterGuard]
-          },
-          {
-            path: FORGOT_PASSWORD_PATH,
-            loadChildren: () => import('./forgot-password/forgot-password.module')
-              .then((m) => m.ForgotPasswordModule),
-            canActivate: [EndUserAgreementCurrentUserGuard]
           },
           {
             path: COMMUNITY_MODULE_PATH,

--- a/src/app/shared/log-in/methods/password/log-in-password.component.html
+++ b/src/app/shared/log-in/methods/password/log-in-password.component.html
@@ -31,7 +31,4 @@
   <a class="dropdown-item" *ngIf="canRegister$ | async" [routerLink]="[getRegisterRoute()]" [attr.data-test]="'register' | dsBrowserOnly" tabindex="0">
     {{ 'login.form.new-user' | translate }}
   </a>
-  <a class="dropdown-item" [routerLink]="[getForgotRoute()]" [attr.data-test]="'forgot' | dsBrowserOnly" tabindex="0">
-    {{ 'login.form.forgot-password' | translate }}
-  </a>
 </div>

--- a/src/app/shared/log-in/methods/password/log-in-password.component.ts
+++ b/src/app/shared/log-in/methods/password/log-in-password.component.ts
@@ -15,7 +15,7 @@ import { AuthMethod } from '../../../../core/auth/models/auth.method';
 import { AuthService } from '../../../../core/auth/auth.service';
 import { HardRedirectService } from '../../../../core/services/hard-redirect.service';
 import { CoreState } from '../../../../core/core-state.model';
-import { getForgotPasswordRoute, getRegisterRoute } from '../../../../app-routing-paths';
+import { getRegisterRoute } from '../../../../app-routing-paths';
 import { FeatureID } from '../../../../core/data/feature-authorization/feature-id';
 import { AuthorizationDataService } from '../../../../core/data/feature-authorization/authorization-data.service';
 
@@ -119,10 +119,6 @@ export class LogInPasswordComponent implements OnInit {
 
   getRegisterRoute() {
     return getRegisterRoute();
-  }
-
-  getForgotRoute() {
-    return getForgotPasswordRoute();
   }
 
   /**

--- a/src/themes/custom/lazy-theme.module.ts
+++ b/src/themes/custom/lazy-theme.module.ts
@@ -67,8 +67,6 @@ import { FullItemPageComponent } from './app/item-page/full/full-item-page.compo
 import { LoginPageComponent } from './app/login-page/login-page.component';
 import { LogoutPageComponent } from './app/logout-page/logout-page.component';
 import { CreateProfileComponent } from './app/register-page/create-profile/create-profile.component';
-import { ForgotEmailComponent } from './app/forgot-password/forgot-password-email/forgot-email.component';
-import { ForgotPasswordFormComponent } from './app/forgot-password/forgot-password-form/forgot-password-form.component';
 import { ProfilePageComponent } from './app/profile-page/profile-page.component';
 import { RegisterEmailComponent } from './app/register-page/register-email/register-email.component';
 import { MyDSpacePageComponent } from './app/my-dspace-page/my-dspace-page.component';
@@ -191,8 +189,6 @@ const DECLARATIONS = [
   LoginPageComponent,
   LogoutPageComponent,
   CreateProfileComponent,
-  ForgotEmailComponent,
-  ForgotPasswordFormComponent,
   ProfilePageComponent,
   RegisterEmailComponent,
   MyDSpacePageComponent,


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
Removed the unwanted option to register new users to VSB DSpace by removing the "forgot password" link from the login component's HTML template and completely eliminating the `/forgot` route from the application routing.