### PR TITLE
minify docker image size

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,9 +28,12 @@ jobs:
     # Use the reusable-docker-build.yml script from DSpace/DSpace repo to build our Docker image
     uses: dataquest-dev/DSpace/.github/workflows/reusable-docker-build.yml@dtq-dev
     with:
-      build_id: dspace-angular
+      build_id: dspace-angular-dev
       image_name: dataquest/dspace-angular
       dockerfile_path: ./Dockerfile
+      tags_flavor: suffix=-dev
+      # As this is a "dev" image, its tags are all suffixed with "-dev". Otherwise, it uses the same
+      # tagging logic as the primary 'dspace/dspace-angular' image above.
       run_python_version_script: true
       python_version_script_dest: src/static-files/VERSION_D.html
     secrets:
@@ -42,16 +45,13 @@ jobs:
   #############################################################
   dspace-angular-dist:
     # Ensure this job never runs on forked repos. It's only executed for 'dataquest/dspace-angular'
-    if: github.repository == 'dataquest-dev/dspace-angular' && false # not used for now
+    if: github.repository == 'dataquest-dev/dspace-angular'
     # Use the reusable-docker-build.yml script from DSpace/DSpace repo to build our Docker image
     uses: dataquest-dev/DSpace/.github/workflows/reusable-docker-build.yml@dtq-dev
     with:
-      build_id: dspace-angular-dist
+      build_id: dspace-angular
       image_name: dspace/dspace-angular
       dockerfile_path: ./Dockerfile.dist
-      # As this is a "dist" image, its tags are all suffixed with "-dist". Otherwise, it uses the same
-      # tagging logic as the primary 'dspace/dspace-angular' image above.
-      tags_flavor: suffix=-dist
       run_python_version_script: true
       python_version_script_dest: src/static-files/VERSION_D.html
     secrets:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,7 @@ jobs:
     uses: dataquest-dev/DSpace/.github/workflows/reusable-docker-build.yml@dtq-dev
     with:
       build_id: dspace-angular
-      image_name: dspace/dspace-angular
+      image_name: dataquest/dspace-angular
       dockerfile_path: ./Dockerfile.dist
       run_python_version_script: true
       python_version_script_dest: src/static-files/VERSION_D.html

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -15,6 +15,9 @@ COPY package.json yarn.lock ./
 RUN yarn install --network-timeout 300000
 
 ADD . /app/
+
+# Set memory limit for build process - Angular builds require more memory
+ENV NODE_OPTIONS="--max_old_space_size=4096"
 RUN yarn build:prod
 
 FROM node:18-alpine


### PR DESCRIPTION
both dockerfiles are now pushed to docker hub, the smaller will replace dataquest/dspace-angular and the full image will go into dataquest/dspace-angular-dev

issue: https://github.com/dataquest-dev/dspace-customers/issues/343

| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
### Reported issues
### Not-reported issues
## Analysis
(Write here, if there is needed describe some specific problem. Erase it, when it is not needed.)
## Problems
(Write here, if some unexpected problems occur during solving issues. Erase it, when it is not needed.) 
