### PR TITLE
TUL/Disable static page playwright test

### DIFF
--- a/config/config.tul.ui.tests.json
+++ b/config/config.tul.ui.tests.json
@@ -6,7 +6,8 @@
       "has_resource_select": false,
       "has_contact_person": false,
       "has_license_select": false,
-      "has_size_dropdown": false
+      "has_size_dropdown": false,
+      "has_static_page": false
     },
     "locators": {
       "title": "DSpace :: Home",


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
### Reported issues
### Not-reported issues
## Analysis
(Write here, if there is needed describe some specific problem. Erase it, when it is not needed.)
## Problems
The static page was tested by default because the TUL does not have it. But if there was problem with LINDAT, the check for customer TUL was also red. Solution is to disable this test for all customers which do not have it.
