### PR TITLE
TUL/Added redirect to login page instead of 404 not found page

### DIFF
--- a/src/app/core/data/dso-redirect.service.spec.ts
+++ b/src/app/core/data/dso-redirect.service.spec.ts
@@ -10,6 +10,11 @@ import { RequestService } from './request.service';
 import { createSuccessfulRemoteDataObject } from '../../shared/remote-data.utils';
 import { Item } from '../shared/item.model';
 import { EMBED_SEPARATOR } from './base/base-data.service';
+import { RouterStub } from '../../shared/testing/router.stub';
+import { AppConfig } from '../../../config/app-config.interface';
+import { environment } from '../../../environments/environment';
+import { HardRedirectService } from '../services/hard-redirect.service';
+import { AuthService } from '../auth/auth.service';
 
 describe('DsoRedirectService', () => {
   let scheduler: TestScheduler;
@@ -17,8 +22,10 @@ describe('DsoRedirectService', () => {
   let halService: HALEndpointService;
   let requestService: RequestService;
   let rdbService: RemoteDataBuildService;
-  let router;
+  let redirectService: HardRedirectService;
   let remoteData;
+  let router: any;
+  let authService: AuthService;
   const dsoUUID = '9b4f22f4-164a-49db-8817-3316b6ee5746';
   const dsoHandle = '1234567789/22';
   const encodedHandle = encodeURIComponent(dsoHandle);
@@ -38,9 +45,6 @@ describe('DsoRedirectService', () => {
       generateRequestId: requestUUID,
       send: true
     });
-    router = {
-      navigate: jasmine.createSpy('navigate')
-    };
 
     remoteData = createSuccessfulRemoteDataObject(Object.assign(new Item(), {
       type: 'item',
@@ -52,12 +56,26 @@ describe('DsoRedirectService', () => {
         a: remoteData
       })
     });
+
+    redirectService = jasmine.createSpyObj('redirectService', {
+      redirect: {}
+    });
+
+    router = new RouterStub();
+
+    authService = jasmine.createSpyObj('authService', {
+      setRedirectUrl: {}
+    });
+
     service = new DsoRedirectService(
+      environment as AppConfig,
       requestService,
       rdbService,
       objectCache,
       halService,
+      redirectService,
       router,
+      authService
     );
   });
 
@@ -104,7 +122,7 @@ describe('DsoRedirectService', () => {
       redir.subscribe();
       scheduler.schedule(() => redir);
       scheduler.flush();
-      expect(router.navigate).toHaveBeenCalledWith(['/items/' + remoteData.payload.uuid]);
+      expect(redirectService.redirect).toHaveBeenCalledWith(`${environment.ui.nameSpace}/items/${remoteData.payload.uuid}`);
     });
     it('should navigate to entities route with the corresponding entity type', () => {
       remoteData.payload.type = 'item';
@@ -121,7 +139,7 @@ describe('DsoRedirectService', () => {
       redir.subscribe();
       scheduler.schedule(() => redir);
       scheduler.flush();
-      expect(router.navigate).toHaveBeenCalledWith(['/entities/publication/' + remoteData.payload.uuid]);
+      expect(redirectService.redirect).toHaveBeenCalledWith(`${environment.ui.nameSpace}/entities/publication/${remoteData.payload.uuid}`);
     });
 
     it('should navigate to collections route', () => {
@@ -130,7 +148,7 @@ describe('DsoRedirectService', () => {
       redir.subscribe();
       scheduler.schedule(() => redir);
       scheduler.flush();
-      expect(router.navigate).toHaveBeenCalledWith(['/collections/' + remoteData.payload.uuid]);
+      expect(redirectService.redirect).toHaveBeenCalledWith(`${environment.ui.nameSpace}/collections/${remoteData.payload.uuid}`);
     });
 
     it('should navigate to communities route', () => {
@@ -139,7 +157,7 @@ describe('DsoRedirectService', () => {
       redir.subscribe();
       scheduler.schedule(() => redir);
       scheduler.flush();
-      expect(router.navigate).toHaveBeenCalledWith(['/communities/' + remoteData.payload.uuid]);
+      expect(redirectService.redirect).toHaveBeenCalledWith(`${environment.ui.nameSpace}/communities/${remoteData.payload.uuid}`);
     });
   });
 

--- a/src/app/core/data/dso-redirect.service.ts
+++ b/src/app/core/data/dso-redirect.service.ts
@@ -6,10 +6,10 @@
  * http://www.dspace.org/license/
  */
 /* eslint-disable max-classes-per-file */
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { Observable } from 'rxjs';
-import { tap } from 'rxjs/operators';
+import { take, tap } from 'rxjs/operators';
 import { hasValue } from '../../shared/empty.util';
 import { RemoteDataBuildService } from '../cache/builders/remote-data-build.service';
 import { ObjectCacheService } from '../cache/object-cache.service';
@@ -20,7 +20,10 @@ import { RequestService } from './request.service';
 import { getFirstCompletedRemoteData } from '../shared/operators';
 import { DSpaceObject } from '../shared/dspace-object.model';
 import { IdentifiableDataService } from './base/identifiable-data.service';
-import { getDSORoute } from '../../app-routing-paths';
+import { getDSORoute, getForbiddenRoute } from '../../app-routing-paths';
+import { HardRedirectService } from '../services/hard-redirect.service';
+import { AuthService } from '../auth/auth.service';
+import { APP_CONFIG, AppConfig } from '../../../config/app-config.interface';
 
 const ID_ENDPOINT = 'pid';
 const UUID_ENDPOINT = 'dso';
@@ -70,11 +73,14 @@ export class DsoRedirectService {
   private dataService: DsoByIdOrUUIDDataService;
 
   constructor(
+    @Inject(APP_CONFIG) protected appConfig: AppConfig,
     protected requestService: RequestService,
     protected rdbService: RemoteDataBuildService,
     protected objectCache: ObjectCacheService,
     protected halService: HALEndpointService,
+    private hardRedirectService: HardRedirectService,
     private router: Router,
+    private authService: AuthService,
   ) {
     this.dataService = new DsoByIdOrUUIDDataService(requestService, rdbService, objectCache, halService);
   }
@@ -94,11 +100,40 @@ export class DsoRedirectService {
           if (hasValue(dso.uuid)) {
             let newRoute = getDSORoute(dso);
             if (hasValue(newRoute)) {
-              this.router.navigate([newRoute]);
+              // Use a "301 Moved Permanently" redirect for SEO purposes
+              this.hardRedirectService.redirect(this.appConfig.ui.nameSpace.replace(/\/$/, '') + newRoute);
             }
           }
         }
+        // Handle authentication errors: redirect unauthenticated users to login, authenticated users to forbidden page
+        if (response.hasFailed && (response.statusCode === 401 || response.statusCode === 403)) {
+          const isAuthenticated$ = this.authService.isAuthenticated();
+          isAuthenticated$
+            .pipe(take(1))
+            .subscribe((isAuthenticated) => {
+              if (!isAuthenticated) {
+                // If the user is not authenticated, redirect to login page
+                // Extract redirect URL - remove `https://.../namespace` from the current URL. Keep only `handle/...`
+                const redirectUrl = this.extractHandlePath(window.location.href);
+                this.authService.setRedirectUrl(redirectUrl);
+                void this.router.navigateByUrl('login');
+              } else {
+                // If the user is authenticated but still has no access, redirect to forbidden page
+                void this.router.navigateByUrl(getForbiddenRoute());
+              }
+            });
+        }
       })
     );
+  }
+
+  /**
+   * Extract the handle path from the given URL. Return only `/handle/{PREFIX}/{SUFFIX}`.
+   * @param url the URL to extract the handle path from
+   */
+  extractHandlePath(url: string): string | null {
+    const regex = /\/handle\/[\w.\/-]+$/;
+    const match = url.match(regex);
+    return match ? match[0].substring(1) : null;
   }
 }

--- a/src/app/core/data/dso-redirect.service.ts
+++ b/src/app/core/data/dso-redirect.service.ts
@@ -128,7 +128,7 @@ export class DsoRedirectService {
   }
 
   /**
-   * Extract the handle path from the given URL. Return only `/handle/{PREFIX}/{SUFFIX}`.
+   * Extract the handle path from the given URL. Return only `handle/{PREFIX}/{SUFFIX}` (without leading slash).
    * @param url the URL to extract the handle path from
    */
   extractHandlePath(url: string): string | null {

--- a/src/app/core/data/dso-redirect.service.ts
+++ b/src/app/core/data/dso-redirect.service.ts
@@ -107,7 +107,7 @@ export class DsoRedirectService {
           }
           return of(response);
         }
-        
+
         // Handle authentication errors: redirect unauthenticated users to login, authenticated users to forbidden page
         if (response.hasFailed && (response.statusCode === 401 || response.statusCode === 403)) {
           return this.authService.isAuthenticated().pipe(
@@ -116,7 +116,7 @@ export class DsoRedirectService {
               if (!isAuthenticated) {
                 // If the user is not authenticated, redirect to login page
                 // Extract redirect URL - remove `https://.../namespace` from the current URL. Keep only `handle/...`
-                const redirectUrl = this.extractHandlePath(window.location.href) ?? window.location.pathname;
+                const redirectUrl = this.extractHandlePath(window.location.href);
                 this.authService.setRedirectUrl(redirectUrl);
                 void this.router.navigateByUrl('login');
               } else {
@@ -127,7 +127,7 @@ export class DsoRedirectService {
             switchMap(() => of(response))
           );
         }
-        
+
         // Return the response for all other cases
         return of(response);
       })

--- a/src/app/core/data/dso-redirect.service.ts
+++ b/src/app/core/data/dso-redirect.service.ts
@@ -8,8 +8,8 @@
 /* eslint-disable max-classes-per-file */
 import { Inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
-import { Observable } from 'rxjs';
-import { take, tap } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { take, tap, switchMap } from 'rxjs/operators';
 import { hasValue } from '../../shared/empty.util';
 import { RemoteDataBuildService } from '../cache/builders/remote-data-build.service';
 import { ObjectCacheService } from '../cache/object-cache.service';
@@ -94,7 +94,8 @@ export class DsoRedirectService {
     this.dataService.setLinkPath(identifierType);
     return this.dataService.findById(id).pipe(
       getFirstCompletedRemoteData(),
-      tap((response) => {
+      switchMap((response) => {
+        // Handle successful responses
         if (response.hasSucceeded) {
           const dso = response.payload;
           if (hasValue(dso.uuid)) {
@@ -104,13 +105,14 @@ export class DsoRedirectService {
               this.hardRedirectService.redirect(this.appConfig.ui.nameSpace.replace(/\/$/, '') + newRoute);
             }
           }
+          return of(response);
         }
+        
         // Handle authentication errors: redirect unauthenticated users to login, authenticated users to forbidden page
         if (response.hasFailed && (response.statusCode === 401 || response.statusCode === 403)) {
-          const isAuthenticated$ = this.authService.isAuthenticated();
-          isAuthenticated$
-            .pipe(take(1))
-            .subscribe((isAuthenticated) => {
+          return this.authService.isAuthenticated().pipe(
+            take(1),
+            tap((isAuthenticated) => {
               if (!isAuthenticated) {
                 // If the user is not authenticated, redirect to login page
                 // Extract redirect URL - remove `https://.../namespace` from the current URL. Keep only `handle/...`
@@ -121,8 +123,13 @@ export class DsoRedirectService {
                 // If the user is authenticated but still has no access, redirect to forbidden page
                 void this.router.navigateByUrl(getForbiddenRoute());
               }
-            });
+            }),
+            switchMap(() => of(response))
+          );
         }
+        
+        // Return the response for all other cases
+        return of(response);
       })
     );
   }

--- a/src/app/core/data/dso-redirect.service.ts
+++ b/src/app/core/data/dso-redirect.service.ts
@@ -114,7 +114,7 @@ export class DsoRedirectService {
               if (!isAuthenticated) {
                 // If the user is not authenticated, redirect to login page
                 // Extract redirect URL - remove `https://.../namespace` from the current URL. Keep only `handle/...`
-                const redirectUrl = this.extractHandlePath(window.location.href);
+                const redirectUrl = this.extractHandlePath(window.location.href) ?? window.location.pathname;
                 this.authService.setRedirectUrl(redirectUrl);
                 void this.router.navigateByUrl('login');
               } else {


### PR DESCRIPTION
## Problem description

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [x] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [x] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [x] Requested review from Copilot