### PR TITLE
VSB-TUO/Added search messages

### DIFF
--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -5820,8 +5820,8 @@
   // "search.filters.applied.f.relationIspartofseries": "Source title",
   "search.filters.applied.f.relationIspartofseries": "Název zdroje",
 
-  // "search.filters.applied.f.rightsAccess": "Access"
-  "search.filters.applied.f.rightsAccess": "Přístup"
+  // "search.filters.applied.f.rightsAccess": "Access",
+  "search.filters.applied.f.rightsAccess": "Přístup",
 
   // "search.filters.filter.author.head": "Author",
   "search.filters.filter.author.head": "Autor",

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -5817,6 +5817,12 @@
   // "search.filters.applied.f.withdrawn": "Withdrawn",
   "search.filters.applied.f.withdrawn": "Vyřazeno",
 
+  // "search.filters.applied.f.relationIspartofseries": "Source title",
+  "search.filters.applied.f.relationIspartofseries": "Název zdroje",
+
+  // "search.filters.applied.f.rightsAccess": "Access"
+  "search.filters.applied.f.rightsAccess": "Přístup"
+
   // "search.filters.filter.author.head": "Author",
   "search.filters.filter.author.head": "Autor",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3887,6 +3887,10 @@
 
   "search.filters.applied.f.withdrawn": "Withdrawn",
 
+  "search.filters.applied.f.relationIspartofseries": "Source title",
+
+  "search.filters.applied.f.rightsAccess": "Access"
+
   "search.filters.filter.author.head": "Author",
 
   "search.filters.filter.author.placeholder": "Author name",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3889,7 +3889,7 @@
 
   "search.filters.applied.f.relationIspartofseries": "Source title",
 
-  "search.filters.applied.f.rightsAccess": "Access"
+  "search.filters.applied.f.rightsAccess": "Access",
 
   "search.filters.filter.author.head": "Author",
 


### PR DESCRIPTION
## Problem description
Fix of FE problems that occurred after deployment.
- added missing i18n keys (search.filters.applied.f.relationIspartofseries & search.filters.applied.f.rightsAccess)

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [x] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [x] Requested review from Copilot