### PR TITLE
MENDELU/Sync translations from v7 to v9

### DIFF
--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -663,8 +663,7 @@
   "admin.access-control.groups.form.delete-group.modal.header": "Odstranit skupinu \"{{ dsoName }}\"",
 
   // "admin.access-control.groups.form.delete-group.modal.info": "Are you sure you want to delete Group \"{{ dsoName }}\" and all its associated policies?",
-  // TODO Source message changed - Revise the translation
-  "admin.access-control.groups.form.delete-group.modal.info": "Určitě chcete odstranit skupinu \"{{ dsoName }}\"",
+  "admin.access-control.groups.form.delete-group.modal.info": "Určitě chcete odstranit skupinu \"{{ dsoName }}\"  a všechny s ní spojené zásady?",
 
   // "admin.access-control.groups.form.delete-group.modal.cancel": "Cancel",
   "admin.access-control.groups.form.delete-group.modal.cancel": "Zrušit",
@@ -2461,7 +2460,6 @@
   "cookies.consent.content-notice.description": "Shromažďujeme a zpracováváme vaše osobní údaje pro tyto účely: {purposes}",
 
   // "cookies.consent.content-notice.learnMore": "Customize",
-  // TODO Source message changed - Revise the translation
   "cookies.consent.content-notice.learnMore": "Přizpůsobit",
 
   // "cookies.consent.content-modal.description": "Here you can see and customize the information that we collect about you.",
@@ -2714,7 +2712,6 @@
   "dso-selector.claim.item.create-from-scratch": "Vytvořit nový",
 
   // "dso-selector.results-could-not-be-retrieved": "Something went wrong, please refresh again ↻",
-  // TODO Source message changed - Revise the translation
   "dso-selector.results-could-not-be-retrieved": "Něco se nepovedlo, zkuste, prosím, načíst znovu ↻",
 
   // "supervision-group-selector.header": "Supervision Group Selector",
@@ -3156,8 +3153,7 @@
   "form.repeatable.sort.tip": "Přetáhněte záznam na novou pozici",
 
   // "grant-deny-request-copy.deny": "Deny access request",
-  // TODO Source message changed - Revise the translation
-  "grant-deny-request-copy.deny": "Neposílat kopii",
+  "grant-deny-request-copy.deny": "Zamítnout žádost o přístup",
 
   // "grant-deny-request-copy.revoke": "Revoke access",
   "grant-deny-request-copy.revoke": "Zrušit přístup",
@@ -3187,8 +3183,7 @@
   "grant-deny-request-copy.email.subject.empty": "Zadejte prosím předmět zprávy",
 
   // "grant-deny-request-copy.grant": "Grant access request",
-  // TODO Source message changed - Revise the translation
-  "grant-deny-request-copy.grant": "Odeslat kopii",
+  "grant-deny-request-copy.grant": "Schválit žádost o přístup",
 
   // "grant-deny-request-copy.header": "Document copy request",
   "grant-deny-request-copy.header": "Žádost o kopii dokumentu",
@@ -3242,7 +3237,6 @@
   "grant-request-copy.access-period.+1MONTH": "1 měsíc",
 
   // "grant-request-copy.access-period.+3MONTHS": "3 months",
-  // TODO Source message changed - Revise the translation
   "grant-request-copy.access-period.+3MONTHS": "3 měsíce",
 
   // "grant-request-copy.access-period.FOREVER": "Forever",
@@ -4524,7 +4518,6 @@
   "item.preview.dc.rights": "Práva",
 
   // "item.preview.dc.identifier.other": "Other Identifier",
-  // TODO Source message changed - Revise the translation
   "item.preview.dc.identifier.other": "Další identifikátor:",
 
   // "item.preview.dc.relation.issn": "ISSN",
@@ -4615,8 +4608,7 @@
   "item.preview.dc.identifier.openalex": "Identifikátor OpenAlex",
 
   // "item.preview.dc.description": "Description",
-  // TODO Source message changed - Revise the translation
-  "item.preview.dc.description": "Popis:",
+  "item.preview.dc.description": "Popis",
 
   // "item.select.confirm": "Confirm selected",
   "item.select.confirm": "Potvrdit vybrané",
@@ -6602,8 +6594,7 @@
   "relationships.Person.isOrgUnitOfPerson.OrgUnit": "Organizační jednotky",
 
   // "relationships.Person.isPublicationOfContributor.Publication": "Publications (contributor to)",
-  // TODO Source message changed - Revise the translation
-  "relationships.Person.isPublicationOfContributor.Publication": "Publikace",
+  "relationships.Person.isPublicationOfContributor.Publication": "Publikace (jako spoluautor)",
 
   // "relationships.Project.isPublicationOfProject.Publication": "Publications",
   "relationships.Project.isPublicationOfProject.Publication": "Publikace",
@@ -6630,12 +6621,10 @@
   "relationships.OrgUnit.isPublicationOfAuthor.Publication": "Autorské publikace",
 
   // "relationships.OrgUnit.isPublicationOfContributor.Publication": "Publications (contributor to)",
-  // TODO Source message changed - Revise the translation
-  "relationships.OrgUnit.isPublicationOfContributor.Publication": "Publikace",
+  "relationships.OrgUnit.isPublicationOfContributor.Publication": "Publikace (jako spoluautor)",
 
   // "relationships.OrgUnit.isProjectOfFundingAgency.Project": "Research Projects (funder of)",
-  // TODO Source message changed - Revise the translation
-  "relationships.OrgUnit.isProjectOfFundingAgency.Project": "Výzkumné projekty",
+  "relationships.OrgUnit.isProjectOfFundingAgency.Project": "Výzkumné projekty (poskytovatel financí)",
 
   // "relationships.JournalIssue.isJournalVolumeOfIssue.JournalVolume": "Journal Volume",
   "relationships.JournalIssue.isJournalVolumeOfIssue.JournalVolume": "Ročník časopisu",

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -1617,7 +1617,7 @@
   "browse.metadata.map.breadcrumbs": "Procházet podle geolokace",
 
   // "browse.metadata.map.count.items": "items",
-  "browse.metadata.map.count.items": "záznamů", "No more pages of results",
+  "browse.metadata.map.count.items": "záznamů",
 
   // "pagination.next.button": "Next",
   "pagination.next.button": "Další",
@@ -2472,7 +2472,7 @@
   "cookies.consent.ok": "V pořádku.",
 
   // "cookies.consent.save": "Save",
-  "cookies.consent.content-notice.learnMore": "Přizpůsobit",
+  "cookies.consent.save": "Uložit",
 
   // "cookies.consent.content-notice.description": "We collect and process your personal information for the following purposes: {purposes}",
   "cookies.consent.content-notice.description": "Shromažďujeme a zpracováváme vaše osobní údaje pro tyto účely: {purposes}",
@@ -2529,7 +2529,7 @@
   "cookies.consent.app.title.google-analytics": "Google Analytics",
 
   // "cookies.consent.app.description.google-analytics": "Allows us to track statistical data",
-  "cookies.consent.app.description.google-analytics": "Umožňuje nám sledovat statistická data",
+  "cookies.consent.app.description.google-analytics": "Umožňuje nám sledovat statistické údaje",
 
   // "cookies.consent.app.title.google-recaptcha": "Google reCaptcha",
   "cookies.consent.app.title.google-recaptcha": "Google reCaptcha",
@@ -2703,7 +2703,7 @@
   "dso-selector.placeholder.type.community": "záznam",
 
   // "dso-selector.select.collection.head": "Select a collection",
-  "dso-selector.results-could-not-be-retrieved": "Něco se nepovedlo, zkuste, prosím, načíst znovu ↻",
+  "dso-selector.select.collection.head": "Vyberte kolekci",
 
   // "dso-selector.set-scope.community.head": "Select a search scope",
   "dso-selector.set-scope.community.head": "Vyberte rozsah vyhledávání",
@@ -2721,10 +2721,10 @@
   "dso-selector.claim.item.head": "Tipy pro profil",
 
   // "dso-selector.claim.item.body": "These are existing profiles that may be related to you. If you recognize yourself in one of these profiles, select it and on the detail page, among the options, choose to claim it. Otherwise you can create a new profile from scratch using the button below.",
-  "dso-selector.claim.item.body": "Níže vidíte existující profily, které s vámi mohou souviset. Pokud se v některém z nich poznáváte, vyberte jej a na stránce detailu mezi možnostmi zvolte převzetí profilu. Jinak můžete pomocí tlačítka níže vytvořit nový profil od začátku.",
+  "dso-selector.claim.item.body": "Toto jsou existující profily, které s vámi mohou souviset. Pokud se v některém z těchto profilů poznáváte, vyberte jej a na stránce s podrobnostmi mezi možnostmi zvolte, zda jej chcete nárokovat. V opačném případě si můžete vytvořit nový profil od začátku pomocí tlačítka níže.",
 
   // "dso-selector.claim.item.not-mine-label": "None of these are mine",
-  "dso-selector.claim.item.not-mine-label": "Žádný z nich není můj",
+  "dso-selector.claim.item.not-mine-label": "Žádný z těchto záznamů není můj",
 
   // "dso-selector.claim.item.create-from-scratch": "Create a new one",
   "dso-selector.claim.item.create-from-scratch": "Vytvořit nový",
@@ -3276,7 +3276,7 @@
   "health-page.error.msg": "Služba kontrolující stav systému je momentálně nedostupná.",
 
   // "health-page.property.status": "Status code",
-  "grant-request-copy.access-period.+3MONTHS": "3 měsíce",
+  "health-page.property.status": "Stavový kód",
 
   // "health-page.section.db.title": "Database",
   "health-page.section.db.title": "Databáze",
@@ -4398,7 +4398,7 @@
   "item.page.journal.search.title": "Články v tomto časopise",
 
   // "item.page.link.full": "Full item page",
-  "item.page.link.full": "Zobrazit celý záznam",
+  "item.page.link.full": "Zobrazit úplný záznam",
 
   // "item.page.link.simple": "Simple item page",
   "item.page.link.simple": "Zobrazit minimální záznam",
@@ -4437,7 +4437,7 @@
   "item.page.subject": "Klíčová slova",
 
   // "item.page.uri": "URI",
-  "item.page.uri": "Trvalý identifikátor",
+  "item.page.uri": "Permanentní identifikátor",
 
   // "item.page.bitstreams.view-more": "Show more",
   "item.page.bitstreams.view-more": "Zobrazit více",
@@ -4674,7 +4674,7 @@
   "item.version.history.table.item": "Záznam",
 
   // "item.version.history.table.editor": "Editor",
-  "item.version.history.table.editor": "Editor",
+  "item.version.history.table.editor": "Upravit",
 
   // "item.version.history.table.date": "Date",
   "item.version.history.table.date": "Datum",

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -459,20 +459,16 @@
   "admin.access-control.epeople.table.edit.buttons.remove": "Odstranit \"{{name}}\"",
 
   // "admin.access-control.epeople.table.edit.buttons.remove.modal.header": "Delete Group \"{{ dsoName }}\"",
-  // TODO New key - Add a translation
-  "admin.access-control.epeople.table.edit.buttons.remove.modal.header": "Delete Group \"{{ dsoName }}\"",
+  "admin.access-control.epeople.table.edit.buttons.remove.modal.header": "Odstranit skupinu \"{{ dsoName }}\"",
 
   // "admin.access-control.epeople.table.edit.buttons.remove.modal.info": "Are you sure you want to delete Group \"{{ dsoName }}\" and all its associated policies?",
-  // TODO New key - Add a translation
-  "admin.access-control.epeople.table.edit.buttons.remove.modal.info": "Are you sure you want to delete Group \"{{ dsoName }}\" and all its associated policies?",
+  "admin.access-control.epeople.table.edit.buttons.remove.modal.info": "Opravdu chcete odstranit skupinu \"{{ dsoName }}\" a všechny s ní související zásady?",
 
   // "admin.access-control.epeople.table.edit.buttons.remove.modal.cancel": "Cancel",
-  // TODO New key - Add a translation
-  "admin.access-control.epeople.table.edit.buttons.remove.modal.cancel": "Cancel",
+  "admin.access-control.epeople.table.edit.buttons.remove.modal.cancel": "Zrušit",
 
   // "admin.access-control.epeople.table.edit.buttons.remove.modal.confirm": "Delete",
-  // TODO New key - Add a translation
-  "admin.access-control.epeople.table.edit.buttons.remove.modal.confirm": "Delete",
+  "admin.access-control.epeople.table.edit.buttons.remove.modal.confirm": "Odstranit",
 
   // "admin.access-control.epeople.no-items": "No EPeople to show.",
   "admin.access-control.epeople.no-items": "Žádní uživatelé k zobrazení.",
@@ -809,24 +805,19 @@
   "admin.access-control.groups.form.return": "Zpět",
 
   // "admin.quality-assurance.breadcrumbs": "Quality Assurance",
-  // TODO New key - Add a translation
-  "admin.quality-assurance.breadcrumbs": "Quality Assurance",
+  "admin.quality-assurance.breadcrumbs": "Zajištění kvality",
 
   // "admin.notifications.event.breadcrumbs": "Quality Assurance Suggestions",
-  // TODO New key - Add a translation
-  "admin.notifications.event.breadcrumbs": "Quality Assurance Suggestions",
+  "admin.notifications.event.breadcrumbs": "Doporučení zajištění kvality",
 
   // "admin.notifications.event.page.title": "Quality Assurance Suggestions",
-  // TODO New key - Add a translation
-  "admin.notifications.event.page.title": "Quality Assurance Suggestions",
+  "admin.notifications.event.page.title": "Doporučení zajištění kvality",
 
   // "admin.quality-assurance.page.title": "Quality Assurance",
-  // TODO New key - Add a translation
-  "admin.quality-assurance.page.title": "Quality Assurance",
+  "admin.quality-assurance.page.title": "Zajištění kvality",
 
   // "admin.notifications.source.breadcrumbs": "Quality Assurance",
-  // TODO New key - Add a translation
-  "admin.notifications.source.breadcrumbs": "Quality Assurance",
+  "admin.notifications.source.breadcrumbs": "Zajištění kvality",
 
   // "admin.access-control.groups.form.tooltip.editGroupPage": "On this page, you can modify the properties and members of a group. In the top section, you can edit the group name and description, unless this is an admin group for a collection or community, in which case the group name and description are auto-generated and cannot be edited. In the following sections, you can edit group membership. See [the wiki](https://wiki.lyrasis.org/display/DSDOC7x/Create+or+manage+a+user+group) for more details.",
   "admin.access-control.groups.form.tooltip.editGroupPage": "Na této stránce můžete upravit vlastnosti a členy skupiny. V horní části můžete upravit název a popis skupiny, pokud se nejedá o skupinu admin pro kolekci nebo komunitu. V takovém případě jsou název a popis skupiny vygenerovány automaticky a nelze je upravovat. V následujících částech můžete upravovat členství ve skupině. Další podrobnosti naleznete v části [wiki](https://wiki.lyrasis.org/display/DSDOC7x/Create+or+manage+a+user+group).",
@@ -838,400 +829,301 @@
   "admin.access-control.groups.form.tooltip.editGroup.addSubgroups": "Pro přidání nebo odebrání podskupiny z této skupiny, buď klikněte na „Prohledávat všechny“ nebo použijte vyhledávací okno níže pro vyhledání uživatele. Potom klikněte na tlačítko plus u každého uživatele, kterého chcete přidat, nebo na ikonu odpadkového koše u každého uživatele, kterého chcete odebrat. Seznam níže může obsahovat několik stránek: k přechodu na další stránku použijte ovládací prvky pod seznamem. Až budete hotovi, uložte změny pomocí tlačítka „Uložit“ v horní části.",
 
   // "admin.reports.collections.title": "Collection Filter Report",
-  // TODO New key - Add a translation
-  "admin.reports.collections.title": "Collection Filter Report",
+  "admin.reports.collections.title": "Zpráva o filtru kolekcí",
 
   // "admin.reports.collections.breadcrumbs": "Collection Filter Report",
-  // TODO New key - Add a translation
-  "admin.reports.collections.breadcrumbs": "Collection Filter Report",
+  "admin.reports.collections.breadcrumbs": "Zpráva o filtru kolekcí",
 
   // "admin.reports.collections.head": "Collection Filter Report",
-  // TODO New key - Add a translation
-  "admin.reports.collections.head": "Collection Filter Report",
+  "admin.reports.collections.head": "Zpráva o filtru kolekcí",
 
   // "admin.reports.button.show-collections": "Show Collections",
-  // TODO New key - Add a translation
-  "admin.reports.button.show-collections": "Show Collections",
+  "admin.reports.button.show-collections": "Zobrazit kolekce",
 
   // "admin.reports.collections.collections-report": "Collection Report",
-  // TODO New key - Add a translation
-  "admin.reports.collections.collections-report": "Collection Report",
+  "admin.reports.collections.collections-report": "Zpráva o kolekcích",
 
   // "admin.reports.collections.item-results": "Item Results",
-  // TODO New key - Add a translation
-  "admin.reports.collections.item-results": "Item Results",
+  "admin.reports.collections.item-results": "Výsledky záznamů",
 
   // "admin.reports.collections.community": "Community",
-  // TODO New key - Add a translation
-  "admin.reports.collections.community": "Community",
+  "admin.reports.collections.community": "Komunita",
 
   // "admin.reports.collections.collection": "Collection",
-  // TODO New key - Add a translation
-  "admin.reports.collections.collection": "Collection",
+  "admin.reports.collections.collection": "Kolekce",
 
   // "admin.reports.collections.nb_items": "Nb. Items",
-  // TODO New key - Add a translation
-  "admin.reports.collections.nb_items": "Nb. Items",
+  "admin.reports.collections.nb_items": "Počet záznamů",
 
   // "admin.reports.collections.match_all_selected_filters": "Matching all selected filters",
-  // TODO New key - Add a translation
-  "admin.reports.collections.match_all_selected_filters": "Matching all selected filters",
+  "admin.reports.collections.match_all_selected_filters": "Odpovídá všem vybraným filtrům",
 
   // "admin.reports.items.breadcrumbs": "Metadata Query Report",
-  // TODO New key - Add a translation
-  "admin.reports.items.breadcrumbs": "Metadata Query Report",
+  "admin.reports.items.breadcrumbs": "Zpráva dotazu na metadata",
 
   // "admin.reports.items.head": "Metadata Query Report",
-  // TODO New key - Add a translation
-  "admin.reports.items.head": "Metadata Query Report",
+  "admin.reports.items.head": "Zpráva dotazu na metadata",
 
   // "admin.reports.items.run": "Run Item Query",
-  // TODO New key - Add a translation
-  "admin.reports.items.run": "Run Item Query",
+  "admin.reports.items.run": "Spustit dotaz na záznamy",
 
   // "admin.reports.items.section.collectionSelector": "Collection Selector",
-  // TODO New key - Add a translation
-  "admin.reports.items.section.collectionSelector": "Collection Selector",
+  "admin.reports.items.section.collectionSelector": "Výběr kolekce",
 
   // "admin.reports.items.section.metadataFieldQueries": "Metadata Field Queries",
-  // TODO New key - Add a translation
-  "admin.reports.items.section.metadataFieldQueries": "Metadata Field Queries",
+  "admin.reports.items.section.metadataFieldQueries": "Dotazy na metadatová pole",
 
   // "admin.reports.items.predefinedQueries": "Predefined Queries",
-  // TODO New key - Add a translation
-  "admin.reports.items.predefinedQueries": "Predefined Queries",
+  "admin.reports.items.predefinedQueries": "Předdefinované dotazy",
 
   // "admin.reports.items.section.limitPaginateQueries": "Limit/Paginate Queries",
-  // TODO New key - Add a translation
-  "admin.reports.items.section.limitPaginateQueries": "Limit/Paginate Queries",
+  "admin.reports.items.section.limitPaginateQueries": "Omezení/Stránkování dotazů",
 
   // "admin.reports.items.limit": "Limit/",
-  // TODO New key - Add a translation
   "admin.reports.items.limit": "Limit/",
 
   // "admin.reports.items.offset": "Offset",
-  // TODO New key - Add a translation
-  "admin.reports.items.offset": "Offset",
+  "admin.reports.items.offset": "Posun",
 
   // "admin.reports.items.wholeRepo": "Whole Repository",
-  // TODO New key - Add a translation
-  "admin.reports.items.wholeRepo": "Whole Repository",
+  "admin.reports.items.wholeRepo": "Celý repozitář",
 
   // "admin.reports.items.anyField": "Any field",
-  // TODO New key - Add a translation
-  "admin.reports.items.anyField": "Any field",
+  "admin.reports.items.anyField": "Libovolné pole",
 
   // "admin.reports.items.predicate.exists": "exists",
-  // TODO New key - Add a translation
-  "admin.reports.items.predicate.exists": "exists",
+  "admin.reports.items.predicate.exists": "existuje",
 
   // "admin.reports.items.predicate.doesNotExist": "does not exist",
-  // TODO New key - Add a translation
-  "admin.reports.items.predicate.doesNotExist": "does not exist",
+  "admin.reports.items.predicate.doesNotExist": "neexistuje",
 
   // "admin.reports.items.predicate.equals": "equals",
-  // TODO New key - Add a translation
-  "admin.reports.items.predicate.equals": "equals",
+  "admin.reports.items.predicate.equals": "se rovná",
 
   // "admin.reports.items.predicate.doesNotEqual": "does not equal",
-  // TODO New key - Add a translation
-  "admin.reports.items.predicate.doesNotEqual": "does not equal",
+  "admin.reports.items.predicate.doesNotEqual": "nerovná se",
 
   // "admin.reports.items.predicate.like": "like",
-  // TODO New key - Add a translation
-  "admin.reports.items.predicate.like": "like",
+  "admin.reports.items.predicate.like": "je jako",
 
   // "admin.reports.items.predicate.notLike": "not like",
-  // TODO New key - Add a translation
-  "admin.reports.items.predicate.notLike": "not like",
+  "admin.reports.items.predicate.notLike": "není jako",
 
   // "admin.reports.items.predicate.contains": "contains",
-  // TODO New key - Add a translation
-  "admin.reports.items.predicate.contains": "contains",
+  "admin.reports.items.predicate.contains": "obsahuje",
 
   // "admin.reports.items.predicate.doesNotContain": "does not contain",
-  // TODO New key - Add a translation
-  "admin.reports.items.predicate.doesNotContain": "does not contain",
+  "admin.reports.items.predicate.doesNotContain": "neobsahuje",
 
   // "admin.reports.items.predicate.matches": "matches",
-  // TODO New key - Add a translation
-  "admin.reports.items.predicate.matches": "matches",
+  "admin.reports.items.predicate.matches": "odpovídá",
 
   // "admin.reports.items.predicate.doesNotMatch": "does not match",
-  // TODO New key - Add a translation
-  "admin.reports.items.predicate.doesNotMatch": "does not match",
+  "admin.reports.items.predicate.doesNotMatch": "neodpovídá",
 
   // "admin.reports.items.preset.new": "New Query",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.new": "New Query",
+  "admin.reports.items.preset.new": "Nový dotaz",
 
   // "admin.reports.items.preset.hasNoTitle": "Has No Title",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasNoTitle": "Has No Title",
+  "admin.reports.items.preset.hasNoTitle": "Nemá název",
 
   // "admin.reports.items.preset.hasNoIdentifierUri": "Has No dc.identifier.uri",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasNoIdentifierUri": "Has No dc.identifier.uri",
+  "admin.reports.items.preset.hasNoIdentifierUri": "Nemá dc.identifier.uri",
 
   // "admin.reports.items.preset.hasCompoundSubject": "Has compound subject",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasCompoundSubject": "Has compound subject",
+  "admin.reports.items.preset.hasCompoundSubject": "Má složený předmět",
 
   // "admin.reports.items.preset.hasCompoundAuthor": "Has compound dc.contributor.author",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasCompoundAuthor": "Has compound dc.contributor.author",
+  "admin.reports.items.preset.hasCompoundAuthor": "Má složené dc.contributor.author",
 
   // "admin.reports.items.preset.hasCompoundCreator": "Has compound dc.creator",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasCompoundCreator": "Has compound dc.creator",
+  "admin.reports.items.preset.hasCompoundCreator": "Má složené dc.creator",
 
   // "admin.reports.items.preset.hasUrlInDescription": "Has URL in dc.description",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasUrlInDescription": "Has URL in dc.description",
+  "admin.reports.items.preset.hasUrlInDescription": "Obsahuje URL v dc.description",
 
   // "admin.reports.items.preset.hasFullTextInProvenance": "Has full text in dc.description.provenance",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasFullTextInProvenance": "Has full text in dc.description.provenance",
+  "admin.reports.items.preset.hasFullTextInProvenance": "Obsahuje plný text v dc.description.provenance",
 
   // "admin.reports.items.preset.hasNonFullTextInProvenance": "Has non-full text in dc.description.provenance",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasNonFullTextInProvenance": "Has non-full text in dc.description.provenance",
+  "admin.reports.items.preset.hasNonFullTextInProvenance": "Obsahuje neplný text v dc.description.provenance",
 
   // "admin.reports.items.preset.hasEmptyMetadata": "Has empty metadata",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasEmptyMetadata": "Has empty metadata",
+  "admin.reports.items.preset.hasEmptyMetadata": "Má prázdná metadata",
 
   // "admin.reports.items.preset.hasUnbreakingDataInDescription": "Has unbreaking metadata in description",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasUnbreakingDataInDescription": "Has unbreaking metadata in description",
+  "admin.reports.items.preset.hasUnbreakingDataInDescription": "Obsahuje nezalomitelná metadata v popisu",
 
   // "admin.reports.items.preset.hasXmlEntityInMetadata": "Has XML entity in metadata",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasXmlEntityInMetadata": "Has XML entity in metadata",
+  "admin.reports.items.preset.hasXmlEntityInMetadata": "Obsahuje XML entity v metadatech",
 
   // "admin.reports.items.preset.hasNonAsciiCharInMetadata": "Has non-ascii character in metadata",
-  // TODO New key - Add a translation
-  "admin.reports.items.preset.hasNonAsciiCharInMetadata": "Has non-ascii character in metadata",
+  "admin.reports.items.preset.hasNonAsciiCharInMetadata": "Obsahuje ne‑ASCII znak v metadatech",
 
   // "admin.reports.items.number": "No.",
-  // TODO New key - Add a translation
-  "admin.reports.items.number": "No.",
+  "admin.reports.items.number": "Č.",
 
   // "admin.reports.items.id": "UUID",
-  // TODO New key - Add a translation
   "admin.reports.items.id": "UUID",
 
   // "admin.reports.items.collection": "Collection",
-  // TODO New key - Add a translation
-  "admin.reports.items.collection": "Collection",
+  "admin.reports.items.collection": "Kolekce",
 
   // "admin.reports.items.handle": "URI",
-  // TODO New key - Add a translation
   "admin.reports.items.handle": "URI",
 
   // "admin.reports.items.title": "Title",
-  // TODO New key - Add a translation
-  "admin.reports.items.title": "Title",
+  "admin.reports.items.title": "Název",
 
   // "admin.reports.commons.filters": "Filters",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters": "Filters",
+  "admin.reports.commons.filters": "Filtry",
 
   // "admin.reports.commons.additional-data": "Additional data to return",
-  // TODO New key - Add a translation
-  "admin.reports.commons.additional-data": "Additional data to return",
+  "admin.reports.commons.additional-data": "Další data k vrácení",
 
   // "admin.reports.commons.previous-page": "Prev Page",
-  // TODO New key - Add a translation
-  "admin.reports.commons.previous-page": "Prev Page",
+  "admin.reports.commons.previous-page": "Předchozí stránka",
 
   // "admin.reports.commons.next-page": "Next Page",
-  // TODO New key - Add a translation
-  "admin.reports.commons.next-page": "Next Page",
+  "admin.reports.commons.next-page": "Další stránka",
 
   // "admin.reports.commons.page": "Page",
-  // TODO New key - Add a translation
-  "admin.reports.commons.page": "Page",
+  "admin.reports.commons.page": "Stránka",
 
   // "admin.reports.commons.of": "of",
-  // TODO New key - Add a translation
-  "admin.reports.commons.of": "of",
+  "admin.reports.commons.of": "z",
 
   // "admin.reports.commons.export": "Export for Metadata Update",
-  // TODO New key - Add a translation
-  "admin.reports.commons.export": "Export for Metadata Update",
+  "admin.reports.commons.export": "Export pro aktualizaci metadat",
 
   // "admin.reports.commons.filters.deselect_all": "Deselect all filters",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.deselect_all": "Deselect all filters",
+  "admin.reports.commons.filters.deselect_all": "Zrušit výběr všech filtrů",
 
   // "admin.reports.commons.filters.select_all": "Select all filters",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.select_all": "Select all filters",
+  "admin.reports.commons.filters.select_all": "Vybrat všechny filtry",
 
   // "admin.reports.commons.filters.matches_all": "Matches all specified filters",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.matches_all": "Matches all specified filters",
+  "admin.reports.commons.filters.matches_all": "Odpovídá všem zadaným filtrům",
 
   // "admin.reports.commons.filters.property": "Item Property Filters",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.property": "Item Property Filters",
+  "admin.reports.commons.filters.property": "Filtry vlastností záznamu",
 
   // "admin.reports.commons.filters.property.is_item": "Is Item - always true",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.property.is_item": "Is Item - always true",
+  "admin.reports.commons.filters.property.is_item": "Je záznam – vždy pravdivé",
 
   // "admin.reports.commons.filters.property.is_withdrawn": "Withdrawn Items",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.property.is_withdrawn": "Withdrawn Items",
+  "admin.reports.commons.filters.property.is_withdrawn": "Stažené záznamy",
 
   // "admin.reports.commons.filters.property.is_not_withdrawn": "Available Items - Not Withdrawn",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.property.is_not_withdrawn": "Available Items - Not Withdrawn",
+  "admin.reports.commons.filters.property.is_not_withdrawn": "Dostupné záznamy – nestážené",
 
   // "admin.reports.commons.filters.property.is_discoverable": "Discoverable Items - Not Private",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.property.is_discoverable": "Discoverable Items - Not Private",
+  "admin.reports.commons.filters.property.is_discoverable": "Vyhledatelné záznamy – nejsou soukromé",
 
   // "admin.reports.commons.filters.property.is_not_discoverable": "Not Discoverable - Private Item",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.property.is_not_discoverable": "Not Discoverable - Private Item",
+  "admin.reports.commons.filters.property.is_not_discoverable": "Nevyhledatelné – soukromý záznam",
 
   // "admin.reports.commons.filters.bitstream": "Basic Bitstream Filters",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream": "Basic Bitstream Filters",
+  "admin.reports.commons.filters.bitstream": "Základní filtry souborů",
 
   // "admin.reports.commons.filters.bitstream.has_multiple_originals": "Item has Multiple Original Bitstreams",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream.has_multiple_originals": "Item has Multiple Original Bitstreams",
+  "admin.reports.commons.filters.bitstream.has_multiple_originals": "Záznam má více původních souborů",
 
   // "admin.reports.commons.filters.bitstream.has_no_originals": "Item has No Original Bitstreams",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream.has_no_originals": "Item has No Original Bitstreams",
+  "admin.reports.commons.filters.bitstream.has_no_originals": "Záznam nemá žádné původní soubory",
 
   // "admin.reports.commons.filters.bitstream.has_one_original": "Item has One Original Bitstream",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream.has_one_original": "Item has One Original Bitstream",
+  "admin.reports.commons.filters.bitstream.has_one_original": "Záznam má jeden původní soubor",
 
   // "admin.reports.commons.filters.bitstream_mime": "Bitstream Filters by MIME Type",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream_mime": "Bitstream Filters by MIME Type",
+  "admin.reports.commons.filters.bitstream_mime": "Filtry souborů podle typu MIME",
 
   // "admin.reports.commons.filters.bitstream_mime.has_doc_original": "Item has a Doc Original Bitstream (PDF, Office, Text, HTML, XML, etc)",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream_mime.has_doc_original": "Item has a Doc Original Bitstream (PDF, Office, Text, HTML, XML, etc)",
+  "admin.reports.commons.filters.bitstream_mime.has_doc_original": "Záznam má původní soubor typu dokument (PDF, Office, Text, HTML, XML, atd.)",
 
   // "admin.reports.commons.filters.bitstream_mime.has_image_original": "Item has an Image Original Bitstream",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream_mime.has_image_original": "Item has an Image Original Bitstream",
+  "admin.reports.commons.filters.bitstream_mime.has_image_original": "Záznam má původní soubor typu obrázek",
 
   // "admin.reports.commons.filters.bitstream_mime.has_unsupp_type": "Has Other Bitstream Types (not Doc or Image)",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream_mime.has_unsupp_type": "Has Other Bitstream Types (not Doc or Image)",
+  "admin.reports.commons.filters.bitstream_mime.has_unsupp_type": "Má jiné typy souborů (ne dokument ani obrázek)",
 
   // "admin.reports.commons.filters.bitstream_mime.has_mixed_original": "Item has multiple types of Original Bitstreams (Doc, Image, Other)",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream_mime.has_mixed_original": "Item has multiple types of Original Bitstreams (Doc, Image, Other)",
+  "admin.reports.commons.filters.bitstream_mime.has_mixed_original": "Záznam má více typů původních souborů (dokument, obrázek, jiné)",
 
   // "admin.reports.commons.filters.bitstream_mime.has_pdf_original": "Item has a PDF Original Bitstream",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream_mime.has_pdf_original": "Item has a PDF Original Bitstream",
+  "admin.reports.commons.filters.bitstream_mime.has_pdf_original": "Záznam má původní soubor PDF",
 
   // "admin.reports.commons.filters.bitstream_mime.has_jpg_original": "Item has JPG Original Bitstream",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream_mime.has_jpg_original": "Item has JPG Original Bitstream",
+  "admin.reports.commons.filters.bitstream_mime.has_jpg_original": "Záznam má původní soubor JPG",
 
   // "admin.reports.commons.filters.bitstream_mime.has_small_pdf": "Has unusually small PDF",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream_mime.has_small_pdf": "Has unusually small PDF",
+  "admin.reports.commons.filters.bitstream_mime.has_small_pdf": "Má neobvykle malý soubor PDF",
 
   // "admin.reports.commons.filters.bitstream_mime.has_large_pdf": "Has unusually large PDF",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream_mime.has_large_pdf": "Has unusually large PDF",
+  "admin.reports.commons.filters.bitstream_mime.has_large_pdf": "Má neobvykle velký soubor PDF",
 
   // "admin.reports.commons.filters.bitstream_mime.has_doc_without_text": "Has document bitstream without TEXT item",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bitstream_mime.has_doc_without_text": "Has document bitstream without TEXT item",
+  "admin.reports.commons.filters.bitstream_mime.has_doc_without_text": "Má dokumentový soubor bez položky TEXT",
 
   // "admin.reports.commons.filters.mime": "Supported MIME Type Filters",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.mime": "Supported MIME Type Filters",
+  "admin.reports.commons.filters.mime": "Filtry podporovaných typů MIME",
 
   // "admin.reports.commons.filters.mime.has_only_supp_image_type": "Item Image Bitstreams are Supported",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.mime.has_only_supp_image_type": "Item Image Bitstreams are Supported",
+  "admin.reports.commons.filters.mime.has_only_supp_image_type": "Obrazové soubory záznamu jsou podporované",
 
   // "admin.reports.commons.filters.mime.has_unsupp_image_type": "Item has Image Bitstream that is Unsupported",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.mime.has_unsupp_image_type": "Item has Image Bitstream that is Unsupported",
+  "admin.reports.commons.filters.mime.has_unsupp_image_type": "Záznam má obrazový soubor, který není podporován",
 
   // "admin.reports.commons.filters.mime.has_only_supp_doc_type": "Item Document Bitstreams are Supported",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.mime.has_only_supp_doc_type": "Item Document Bitstreams are Supported",
+  "admin.reports.commons.filters.mime.has_only_supp_doc_type": "Dokumentové soubory záznamu jsou podporované",
 
   // "admin.reports.commons.filters.mime.has_unsupp_doc_type": "Item has Document Bitstream that is Unsupported",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.mime.has_unsupp_doc_type": "Item has Document Bitstream that is Unsupported",
+  "admin.reports.commons.filters.mime.has_unsupp_doc_type": "Záznam má dokumentový soubor, který není podporován",
 
   // "admin.reports.commons.filters.bundle": "Bitstream Bundle Filters",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bundle": "Bitstream Bundle Filters",
+  "admin.reports.commons.filters.bundle": "Filtry svazků souborů",
 
   // "admin.reports.commons.filters.bundle.has_unsupported_bundle": "Has bitstream in an unsupported bundle",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bundle.has_unsupported_bundle": "Has bitstream in an unsupported bundle",
+  "admin.reports.commons.filters.bundle.has_unsupported_bundle": "Má soubor v nepodporovaném svazku",
 
   // "admin.reports.commons.filters.bundle.has_small_thumbnail": "Has unusually small thumbnail",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bundle.has_small_thumbnail": "Has unusually small thumbnail",
+  "admin.reports.commons.filters.bundle.has_small_thumbnail": "Má neobvykle malý náhled",
 
   // "admin.reports.commons.filters.bundle.has_original_without_thumbnail": "Has original bitstream without thumbnail",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bundle.has_original_without_thumbnail": "Has original bitstream without thumbnail",
+  "admin.reports.commons.filters.bundle.has_original_without_thumbnail": "Má původní soubor bez náhledu",
 
   // "admin.reports.commons.filters.bundle.has_invalid_thumbnail_name": "Has invalid thumbnail name (assumes one thumbnail for each original)",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bundle.has_invalid_thumbnail_name": "Has invalid thumbnail name (assumes one thumbnail for each original)",
+  "admin.reports.commons.filters.bundle.has_invalid_thumbnail_name": "Má neplatný název náhledu (předpokládá se jeden náhled pro každý původní soubor)",
 
   // "admin.reports.commons.filters.bundle.has_non_generated_thumb": "Has non-generated thumbnail",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bundle.has_non_generated_thumb": "Has non-generated thumbnail",
+  "admin.reports.commons.filters.bundle.has_non_generated_thumb": "Má negenerovaný náhled",
 
   // "admin.reports.commons.filters.bundle.no_license": "Doesn't have a license",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bundle.no_license": "Doesn't have a license",
+  "admin.reports.commons.filters.bundle.no_license": "Nemá licenci",
 
   // "admin.reports.commons.filters.bundle.has_license_documentation": "Has documentation in the license bundle",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.bundle.has_license_documentation": "Has documentation in the license bundle",
+  "admin.reports.commons.filters.bundle.has_license_documentation": "Má dokumentaci ve svazku licence",
 
   // "admin.reports.commons.filters.permission": "Permission Filters",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.permission": "Permission Filters",
+  "admin.reports.commons.filters.permission": "Filtry oprávnění",
 
   // "admin.reports.commons.filters.permission.has_restricted_original": "Item has Restricted Original Bitstream",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.permission.has_restricted_original": "Item has Restricted Original Bitstream",
+  "admin.reports.commons.filters.permission.has_restricted_original": "Záznam má omezený původní soubor",
 
   // "admin.reports.commons.filters.permission.has_restricted_original.tooltip": "Item has at least one original bitstream that is not accessible to Anonymous user",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.permission.has_restricted_original.tooltip": "Item has at least one original bitstream that is not accessible to Anonymous user",
+  "admin.reports.commons.filters.permission.has_restricted_original.tooltip": "Záznam má alespoň jeden původní soubor, který není přístupný anonymnímu uživateli",
 
   // "admin.reports.commons.filters.permission.has_restricted_thumbnail": "Item has Restricted Thumbnail",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.permission.has_restricted_thumbnail": "Item has Restricted Thumbnail",
+  "admin.reports.commons.filters.permission.has_restricted_thumbnail": "Záznam má omezený náhled",
 
   // "admin.reports.commons.filters.permission.has_restricted_thumbnail.tooltip": "Item has at least one thumbnail that is not accessible to Anonymous user",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.permission.has_restricted_thumbnail.tooltip": "Item has at least one thumbnail that is not accessible to Anonymous user",
+  "admin.reports.commons.filters.permission.has_restricted_thumbnail.tooltip": "Záznam má alespoň jeden náhled, který není přístupný anonymnímu uživateli",
 
   // "admin.reports.commons.filters.permission.has_restricted_metadata": "Item has Restricted Metadata",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.permission.has_restricted_metadata": "Item has Restricted Metadata",
+  "admin.reports.commons.filters.permission.has_restricted_metadata": "Záznam má omezená metadata",
 
   // "admin.reports.commons.filters.permission.has_restricted_metadata.tooltip": "Item has metadata that is not accessible to Anonymous user",
-  // TODO New key - Add a translation
-  "admin.reports.commons.filters.permission.has_restricted_metadata.tooltip": "Item has metadata that is not accessible to Anonymous user",
+  "admin.reports.commons.filters.permission.has_restricted_metadata.tooltip": "Záznam má metadata, která nejsou přístupná anonymnímu uživateli",
 
   // "admin.search.breadcrumbs": "Administrative Search",
   "admin.search.breadcrumbs": "Administrátorské vyhledávání",
@@ -1618,28 +1510,22 @@
   "bitstream-request-a-copy.submit.error": "Něco se pokazilo při odesílání požadavku na záznam.",
 
   // "bitstream-request-a-copy.access-by-token.warning": "You are viewing this item with the secure access link provided to you by the author or repository staff. It is important not to share this link to unauthorised users.",
-  // TODO New key - Add a translation
-  "bitstream-request-a-copy.access-by-token.warning": "You are viewing this item with the secure access link provided to you by the author or repository staff. It is important not to share this link to unauthorised users.",
+  "bitstream-request-a-copy.access-by-token.warning": "Tento záznam si prohlížíte pomocí zabezpečeného odkazu poskytnutého autorem nebo pracovníky repozitáře. Je důležité nesdílet tento odkaz s neoprávněnými uživateli.",
 
   // "bitstream-request-a-copy.access-by-token.expiry-label": "Access provided by this link will expire on",
-  // TODO New key - Add a translation
-  "bitstream-request-a-copy.access-by-token.expiry-label": "Access provided by this link will expire on",
+  "bitstream-request-a-copy.access-by-token.expiry-label": "Přístup poskytnutý tímto odkazem vyprší dne",
 
   // "bitstream-request-a-copy.access-by-token.expired": "Access provided by this link is no longer possible. Access expired on",
-  // TODO New key - Add a translation
-  "bitstream-request-a-copy.access-by-token.expired": "Access provided by this link is no longer possible. Access expired on",
+  "bitstream-request-a-copy.access-by-token.expired": "Přístup poskytnutý tímto odkazem již není možný. Přístup vypršel dne",
 
   // "bitstream-request-a-copy.access-by-token.not-granted": "Access provided by this link is not possible. Access has either not been granted, or has been revoked.",
-  // TODO New key - Add a translation
-  "bitstream-request-a-copy.access-by-token.not-granted": "Access provided by this link is not possible. Access has either not been granted, or has been revoked.",
+  "bitstream-request-a-copy.access-by-token.not-granted": "Přístup poskytnutý tímto odkazem není možný. Přístup buď nebyl udělen, nebo byl zrušen.",
 
   // "bitstream-request-a-copy.access-by-token.re-request": "Follow restricted download links to submit a new request for access.",
-  // TODO New key - Add a translation
-  "bitstream-request-a-copy.access-by-token.re-request": "Follow restricted download links to submit a new request for access.",
+  "bitstream-request-a-copy.access-by-token.re-request": "Sledujte odkazy na omezené stažení a odešlete novou žádost o přístup.",
 
   // "bitstream-request-a-copy.access-by-token.alt-text": "Access to this item is provided by a secure token",
-  // TODO New key - Add a translation
-  "bitstream-request-a-copy.access-by-token.alt-text": "Access to this item is provided by a secure token",
+  "bitstream-request-a-copy.access-by-token.alt-text": "Přístup k tomuto záznamu je poskytnut pomocí zabezpečeného tokenu",
 
   // "browse.back.all-results": "All browse results",
   "browse.back.all-results": "Všechny výsledky procházení",
@@ -1681,8 +1567,7 @@
   "browse.metadata.title": "Název",
 
   // "browse.metadata.srsc": "Subject Category",
-  // TODO New key - Add a translation
-  "browse.metadata.srsc": "Subject Category",
+  "browse.metadata.srsc": "Předmětová kategorie",
 
   // "browse.metadata.author.breadcrumbs": "Browse by Author",
   "browse.metadata.author.breadcrumbs": "Procházet podle autora",
@@ -1697,36 +1582,33 @@
   "browse.metadata.srsc.breadcrumbs": "Procházet podle předmětu",
 
   // "browse.metadata.srsc.tree.description": "Select a subject to add as search filter",
-  // TODO New key - Add a translation
-  "browse.metadata.srsc.tree.description": "Select a subject to add as search filter",
+  "browse.metadata.srsc.tree.description": "Vyberte předmět pro přidání jako filtr vyhledávání",
 
   // "browse.metadata.nsi.breadcrumbs": "Browse by Norwegian Science Index",
   "browse.metadata.nsi.breadcrumbs": "Procházet podle Norwegian Science Index",
 
   // "browse.metadata.nsi.tree.description": "Select an index to add as search filter",
-  // TODO New key - Add a translation
-  "browse.metadata.nsi.tree.description": "Select an index to add as search filter",
+  "browse.metadata.srsc.tree.description": "Vyberte předmět pro přidání jako filtr vyhledávání",
 
   // "browse.metadata.title.breadcrumbs": "Browse by Title",
   "browse.metadata.title.breadcrumbs": "Procházet podle názvu",
 
   // "browse.metadata.map": "Browse by Geolocation",
-  // TODO New key - Add a translation
-  "browse.metadata.map": "Browse by Geolocation",
+  "browse.metadata.map": "Procházet podle geolokace",
 
   // "browse.metadata.map.breadcrumbs": "Browse by Geolocation",
-  // TODO New key - Add a translation
-  "browse.metadata.map.breadcrumbs": "Browse by Geolocation",
+  "browse.metadata.map.breadcrumbs": "Procházet podle geolokace",
 
   // "browse.metadata.map.count.items": "items",
-  // TODO New key - Add a translation
-  "browse.metadata.map.count.items": "items",
+  "browse.metadata.map.count.items": "záznamů", "No more pages of results",
 
   // "pagination.next.button": "Next",
-  "pagination.next.button": "Další",
+  // TODO New key - Add a translation
+  "pagination.next.button": "Next",
 
   // "pagination.previous.button": "Previous",
-  "pagination.previous.button": "Předchozí",
+  // TODO New key - Add a translation
+  "pagination.previous.button": "Previous",
 
   // "pagination.next.button.disabled.tooltip": "No more pages of results",
   "pagination.next.button.disabled.tooltip": "Žádné další stránky výsledků",
@@ -2134,8 +2016,7 @@
   "collection.logo": "Logo kolekce",
 
   // "collection.page.browse.search.head": "Search",
-  // TODO New key - Add a translation
-  "collection.page.browse.search.head": "Search",
+  "collection.page.browse.search.head": "Hledat",
 
   // "collection.page.edit": "Edit this collection",
   "collection.page.edit": "Upravit tuto kolekci",
@@ -2150,16 +2031,13 @@
   "collection.page.news": "Novinky",
 
   // "collection.page.options": "Options",
-  // TODO New key - Add a translation
-  "collection.page.options": "Options",
+  "collection.page.options": "Možnosti",
 
   // "collection.search.breadcrumbs": "Search",
-  // TODO New key - Add a translation
-  "collection.search.breadcrumbs": "Search",
+  "collection.search.breadcrumbs": "Hledat",
 
   // "collection.search.results.head": "Search Results",
-  // TODO New key - Add a translation
-  "collection.search.results.head": "Search Results",
+  "collection.search.results.head": "Výsledky vyhledávání",
 
   // "collection.select.confirm": "Confirm selected",
   "collection.select.confirm": "Potvrdit vybrané",
@@ -2276,8 +2154,7 @@
   "community.browse.logo": "Vybrat logo komunity",
 
   // "community.subcoms-cols.breadcrumbs": "Subcommunities and Collections",
-  // TODO New key - Add a translation
-  "community.subcoms-cols.breadcrumbs": "Subcommunities and Collections",
+  "community.subcoms-cols.breadcrumbs": "Podkomunity a kolekce",
 
   // "community.create.breadcrumbs": "Create Community",
   "community.create.breadcrumbs": "Vytvořit komunitu",
@@ -2328,15 +2205,13 @@
   "community.edit.logo.delete.title": "Smazat logo",
 
   // "community-collection.edit.logo.delete.title": "Confirm deletion",
-  // TODO New key - Add a translation
-  "community-collection.edit.logo.delete.title": "Confirm deletion",
+  "community-collection.edit.logo.delete.title": "Potvrdit odstranění",
 
   // "community.edit.logo.delete-undo.title": "Undo delete",
   "community.edit.logo.delete-undo.title": "Zrušit odstranění",
 
   // "community-collection.edit.logo.delete-undo.title": "Undo delete",
-  // TODO New key - Add a translation
-  "community-collection.edit.logo.delete-undo.title": "Undo delete",
+  "community-collection.edit.logo.delete-undo.title": "Zrušit odstranění",
 
   // "community.edit.logo.label": "Community logo",
   "community.edit.logo.label": "Logo komunity",
@@ -2426,20 +2301,16 @@
   "comcol-role.edit.delete.error.title": "Nepodařilo se smazat skupinu pro roli '{{ role }}'",
 
   // "comcol-role.edit.delete.modal.header": "Delete Group \"{{ dsoName }}\"",
-  // TODO New key - Add a translation
-  "comcol-role.edit.delete.modal.header": "Delete Group \"{{ dsoName }}\"",
+  "comcol-role.edit.delete.modal.header": "Odstranit skupinu \"{{ dsoName }}\"",
 
   // "comcol-role.edit.delete.modal.info": "Are you sure you want to delete Group \"{{ dsoName }}\" and all its associated policies?",
-  // TODO New key - Add a translation
-  "comcol-role.edit.delete.modal.info": "Are you sure you want to delete Group \"{{ dsoName }}\" and all its associated policies?",
+  "comcol-role.edit.delete.modal.info": "Opravdu chcete odstranit skupinu \"{{ dsoName }}\" a všechny s ní spojené zásady?",
 
   // "comcol-role.edit.delete.modal.cancel": "Cancel",
-  // TODO New key - Add a translation
-  "comcol-role.edit.delete.modal.cancel": "Cancel",
+  "comcol-role.edit.delete.modal.cancel": "Zrušit",
 
   // "comcol-role.edit.delete.modal.confirm": "Delete",
-  // TODO New key - Add a translation
-  "comcol-role.edit.delete.modal.confirm": "Delete",
+  "comcol-role.edit.delete.modal.confirm": "Odstranit",
 
   // "comcol-role.edit.community-admin.name": "Administrators",
   "comcol-role.edit.community-admin.name": "Správci",
@@ -2532,22 +2403,20 @@
   "community.page.news": "Novinky",
 
   // "community.page.options": "Options",
-  // TODO New key - Add a translation
-  "community.page.options": "Options",
+  "community.page.options": "Možnosti",
 
   // "community.all-lists.head": "Subcommunities and Collections",
   "community.all-lists.head": "Podkomunity a kolekce",
 
   // "community.search.breadcrumbs": "Search",
-  // TODO New key - Add a translation
-  "community.search.breadcrumbs": "Search",
+  "community.search.breadcrumbs": "Hledat",
 
   // "community.search.results.head": "Search Results",
-  // TODO New key - Add a translation
-  "community.search.results.head": "Search Results",
+  "community.search.results.head": "Výsledky vyhledávání",
 
   // "community.sub-collection-list.head": "Collections in this community",
-  "community.sub-collection-list.head": "Kolekce této komunity",
+  // TODO New key - Add a translation
+  "community.sub-collection-list.head": "Collections in this community",
 
   // "community.sub-community-list.head": "Communities in this Community",
   "community.sub-community-list.head": "Komunity této komunity",
@@ -2583,20 +2452,20 @@
   "cookies.consent.decline": "Odmítnout",
 
   // "cookies.consent.decline-all": "Decline all",
-  // TODO New key - Add a translation
-  "cookies.consent.decline-all": "Decline all",
+  "cookies.consent.decline-all": "Odmítnout vše",
 
   // "cookies.consent.ok": "That's ok",
   "cookies.consent.ok": "V pořádku.",
 
   // "cookies.consent.save": "Save",
-  "cookies.consent.save": "Uložit",
+  "cookies.consent.content-notice.learnMore": "Přizpůsobit",
 
   // "cookies.consent.content-notice.description": "We collect and process your personal information for the following purposes: {purposes}",
-  // TODO Source message changed - Revise the translation
-  "cookies.consent.content-notice.description": "Vaše osobní údaje shromažďujeme a zpracováváme pro následující účely: <strong>Ověření, Preference, Potvrzení a Statistiky</strong>. <br/> Chcete-li se dozvědět více, přečtěte si prosím naše {privacyPolicy}.",
+  // TODO New key - Add a translation
+  "cookies.consent.content-notice.description": "We collect and process your personal information for the following purposes: {purposes}",
 
   // "cookies.consent.content-notice.learnMore": "Customize",
+  // TODO Source message changed - Revise the translation
   "cookies.consent.content-notice.learnMore": "Přizpůsobit",
 
   // "cookies.consent.content-modal.description": "Here you can see and customize the information that we collect about you.",
@@ -2609,14 +2478,15 @@
   "cookies.consent.content-modal.privacy-policy.text": "Chcete-li se dozvědět více, přečtěte si prosím naše {privacyPolicy}.",
 
   // "cookies.consent.content-modal.no-privacy-policy.text": "",
-  // TODO New key - Add a translation
-  "cookies.consent.content-modal.no-privacy-policy.text": "",
+  "cookies.consent.content-modal.no-privacy-policy.text": "",upnosti",
 
   // "cookies.consent.content-modal.title": "Information that we collect",
-  "cookies.consent.content-modal.title": "Informace, které shromažďujeme",
+  // TODO New key - Add a translation
+  "cookies.consent.content-modal.title": "Information that we collect",
 
   // "cookies.consent.app.title.accessibility": "Accessibility Settings",
-  "cookies.consent.app.title.accessibility": "Nastavení přístupnosti",
+  // TODO New key - Add a translation
+  "cookies.consent.app.title.accessibility": "Accessibility Settings",
 
   // "cookies.consent.app.description.accessibility": "Required for saving your accessibility settings locally",
   "cookies.consent.app.description.accessibility": "Požadováno pro lokální uložení nastavení přístupnosti",
@@ -2628,12 +2498,10 @@
   "cookies.consent.app.description.authentication": "Vyžadováno pro přihlášení",
 
   // "cookies.consent.app.title.correlation-id": "Correlation ID",
-  // TODO New key - Add a translation
-  "cookies.consent.app.title.correlation-id": "Correlation ID",
+  "cookies.consent.app.title.correlation-id": "ID korelace",
 
   // "cookies.consent.app.description.correlation-id": "Allow us to track your session in backend logs for support/debugging purposes",
-  // TODO New key - Add a translation
-  "cookies.consent.app.description.correlation-id": "Allow us to track your session in backend logs for support/debugging purposes",
+  "cookies.consent.app.title.correlation-id": "ID korelace",
 
   // "cookies.consent.app.title.preferences": "Preferences",
   "cookies.consent.app.title.preferences": "Preference",
@@ -2645,27 +2513,29 @@
   "cookies.consent.app.title.acknowledgement": "Potvrzení",
 
   // "cookies.consent.app.description.acknowledgement": "Required for saving your acknowledgements and consents",
-  "cookies.consent.app.description.acknowledgement": "Vyžadováno pro uložení Vašich potvrzení a souhlasů",
+  // TODO New key - Add a translation
+  "cookies.consent.app.description.acknowledgement": "Required for saving your acknowledgements and consents",
 
   // "cookies.consent.app.title.google-analytics": "Google Analytics",
+  // TODO New key - Add a translation
   "cookies.consent.app.title.google-analytics": "Google Analytics",
 
   // "cookies.consent.app.description.google-analytics": "Allows us to track statistical data",
-  "cookies.consent.app.description.google-analytics": "Umožňuje nám sledovat statistické údaje",
+  // TODO New key - Add a translation
+  "cookies.consent.app.description.google-analytics": "Allows us to track statistical data",
 
   // "cookies.consent.app.title.google-recaptcha": "Google reCaptcha",
+  // TODO New key - Add a translation
   "cookies.consent.app.title.google-recaptcha": "Google reCaptcha",
 
   // "cookies.consent.app.description.google-recaptcha": "We use google reCAPTCHA service during registration and password recovery",
   "cookies.consent.app.description.google-recaptcha": "Při registraci a obnově hesla používáme službu Google reCAPTCHA",
 
   // "cookies.consent.app.title.matomo": "Matomo",
-  // TODO New key - Add a translation
   "cookies.consent.app.title.matomo": "Matomo",
 
   // "cookies.consent.app.description.matomo": "Allows us to track statistical data",
-  // TODO New key - Add a translation
-  "cookies.consent.app.description.matomo": "Allows us to track statistical data",
+  "cookies.consent.app.description.matomo": "Umožňuje nám sledovat statistické údaje",
 
   // "cookies.consent.purpose.functional": "Functional",
   "cookies.consent.purpose.functional": "Funkční",
@@ -2674,10 +2544,12 @@
   "cookies.consent.purpose.statistical": "Statistický",
 
   // "cookies.consent.purpose.registration-password-recovery": "Registration and Password recovery",
-  "cookies.consent.purpose.registration-password-recovery": "Registrace a obnovení hesla",
+  // TODO New key - Add a translation
+  "cookies.consent.purpose.registration-password-recovery": "Registration and Password recovery",
 
   // "cookies.consent.purpose.sharing": "Sharing",
-  "cookies.consent.purpose.sharing": "Sdílení",
+  // TODO New key - Add a translation
+  "cookies.consent.purpose.sharing": "Sharing",
 
   // "curation-task.task.citationpage.label": "Generate Citation Page",
   "curation-task.task.citationpage.label": "Vytvořit stránku s citacemi",
@@ -2818,45 +2690,51 @@
   "dso-selector.placeholder": "Hledat {{ type }}",
 
   // "dso-selector.placeholder.type.community": "community",
-  // TODO New key - Add a translation
-  "dso-selector.placeholder.type.community": "community",
+  "dso-selector.placeholder.type.community": "komunita",
 
   // "dso-selector.placeholder.type.collection": "collection",
-  // TODO New key - Add a translation
-  "dso-selector.placeholder.type.collection": "collection",
+  "dso-selector.placeholder.type.collection": "kolekce",
 
   // "dso-selector.placeholder.type.item": "item",
-  // TODO New key - Add a translation
-  "dso-selector.placeholder.type.item": "item",
+  "dso-selector.placeholder.type.community": "komunita",
 
   // "dso-selector.select.collection.head": "Select a collection",
-  "dso-selector.select.collection.head": "Vyberte kolekci",
+  "dso-selector.results-could-not-be-retrieved": "Něco se nepovedlo, zkuste, prosím, načíst znovu ↻",
 
   // "dso-selector.set-scope.community.head": "Select a search scope",
-  "dso-selector.set-scope.community.head": "Vyberte oblast vyhledávání",
+  // TODO New key - Add a translation
+  "dso-selector.set-scope.community.head": "Select a search scope",
 
   // "dso-selector.set-scope.community.button": "Search all of DSpace",
-  "dso-selector.set-scope.community.button": "Prohledávat celý repozitář",
+  // TODO New key - Add a translation
+  "dso-selector.set-scope.community.button": "Search all of DSpace",
 
   // "dso-selector.set-scope.community.or-divider": "or",
-  "dso-selector.set-scope.community.or-divider": "nebo",
+  // TODO New key - Add a translation
+  "dso-selector.set-scope.community.or-divider": "or",
 
   // "dso-selector.set-scope.community.input-header": "Search for a community or collection",
-  "dso-selector.set-scope.community.input-header": "Vyhledat komunitu nebo kolekci",
+  // TODO New key - Add a translation
+  "dso-selector.set-scope.community.input-header": "Search for a community or collection",
 
   // "dso-selector.claim.item.head": "Profile tips",
-  "dso-selector.claim.item.head": "Tipy na profily",
+  // TODO New key - Add a translation
+  "dso-selector.claim.item.head": "Profile tips",
 
   // "dso-selector.claim.item.body": "These are existing profiles that may be related to you. If you recognize yourself in one of these profiles, select it and on the detail page, among the options, choose to claim it. Otherwise you can create a new profile from scratch using the button below.",
-  "dso-selector.claim.item.body": "Toto jsou existující profily, které s vámi mohou souviset. Pokud se v některém z těchto profilů poznáváte, vyberte jej a na stránce s podrobnostmi mezi možnostmi zvolte, zda jej chcete nárokovat. V opačném případě si můžete vytvořit nový profil od začátku pomocí tlačítka níže.",
+  // TODO New key - Add a translation
+  "dso-selector.claim.item.body": "These are existing profiles that may be related to you. If you recognize yourself in one of these profiles, select it and on the detail page, among the options, choose to claim it. Otherwise you can create a new profile from scratch using the button below.",
 
   // "dso-selector.claim.item.not-mine-label": "None of these are mine",
-  "dso-selector.claim.item.not-mine-label": "Žádný z těchto záznamů není můj",
+  // TODO New key - Add a translation
+  "dso-selector.claim.item.not-mine-label": "None of these are mine",
 
   // "dso-selector.claim.item.create-from-scratch": "Create a new one",
-  "dso-selector.claim.item.create-from-scratch": "Vytvořit nový",
+  // TODO New key - Add a translation
+  "dso-selector.claim.item.create-from-scratch": "Create a new one",
 
   // "dso-selector.results-could-not-be-retrieved": "Something went wrong, please refresh again ↻",
+  // TODO Source message changed - Revise the translation
   "dso-selector.results-could-not-be-retrieved": "Něco se nepovedlo, zkuste, prosím, načíst znovu ↻",
 
   // "supervision-group-selector.header": "Supervision Group Selector",
@@ -2935,8 +2813,7 @@
   "confirmation-modal.delete-eperson.confirm": "Odstranit",
 
   // "confirmation-modal.delete-community-collection-logo.info": "Are you sure you want to delete the logo?",
-  // TODO New key - Add a translation
-  "confirmation-modal.delete-community-collection-logo.info": "Are you sure you want to delete the logo?",
+  "confirmation-modal.delete-community-collection-logo.info": "Opravdu chcete smazat logo?",
 
   // "confirmation-modal.delete-profile.header": "Delete Profile",
   "confirmation-modal.delete-profile.header": "Odstranit profil",
@@ -2963,36 +2840,35 @@
   "confirmation-modal.delete-subscription.confirm": "Smazat",
 
   // "confirmation-modal.review-account-info.header": "Save the changes",
-  // TODO New key - Add a translation
-  "confirmation-modal.review-account-info.header": "Save the changes",
+  "confirmation-modal.review-account-info.header": "Uložit změny",
 
   // "confirmation-modal.review-account-info.info": "Are you sure you want to save the changes to your profile",
-  // TODO New key - Add a translation
-  "confirmation-modal.review-account-info.info": "Are you sure you want to save the changes to your profile",
+  "confirmation-modal.review-account-info.info": "Opravdu chcete uložit změny svého profilu",
 
   // "confirmation-modal.review-account-info.cancel": "Cancel",
-  // TODO New key - Add a translation
-  "confirmation-modal.review-account-info.cancel": "Cancel",
+  "confirmation-modal.review-account-info.cancel": "Zrušit",
 
   // "confirmation-modal.review-account-info.confirm": "Confirm",
-  // TODO New key - Add a translation
-  "confirmation-modal.review-account-info.confirm": "Confirm",
+  "confirmation-modal.review-account-info.confirm": "Potvrdit",
 
   // "confirmation-modal.review-account-info.save": "Save",
-  // TODO New key - Add a translation
-  "confirmation-modal.review-account-info.save": "Save",
+  "confirmation-modal.review-account-info.save": "Uložit",
 
   // "error.bitstream": "Error fetching bitstream",
-  "error.bitstream": "Chyba při načítání souboru",
+  // TODO New key - Add a translation
+  "error.bitstream": "Error fetching bitstream",
 
   // "error.browse-by": "Error fetching items",
-  "error.browse-by": "Chyba při načítání záznamů",
+  // TODO New key - Add a translation
+  "error.browse-by": "Error fetching items",
 
   // "error.collection": "Error fetching collection",
-  "error.collection": "Chyba při načítání kolekce",
+  // TODO New key - Add a translation
+  "error.collection": "Error fetching collection",
 
   // "error.collections": "Error fetching collections",
-  "error.collections": "Chyba při načítání kolekce",
+  // TODO New key - Add a translation
+  "error.collections": "Error fetching collections",
 
   // "error.community": "Error fetching community",
   "error.community": "Chyba při načítání komunity",
@@ -3040,8 +2916,7 @@
   "error.validation.license.notgranted": "Bez udělení licence nelze záznam dokončit. Pokud v tuto chvíli nemůžete licenci udělit, uložte svou práci a vraťte se k příspěvku později nebo jej smažte.",
 
   // "error.validation.cclicense.required": "You must grant this cclicense to complete your submission. If you are unable to grant the cclicense at this time, you may save your work and return later or remove the submission.",
-  // TODO New key - Add a translation
-  "error.validation.cclicense.required": "You must grant this cclicense to complete your submission. If you are unable to grant the cclicense at this time, you may save your work and return later or remove the submission.",
+  "error.validation.cclicense.required": "Pro dokončení vkladu musíte udělit tuto licenci CC. Pokud v tuto chvíli nemůžete licenci CC udělit, můžete svou práci uložit a vrátit se později nebo vklad odstranit.",
 
   // "error.validation.pattern": "This input is restricted by the current pattern: {{ pattern }}.",
   "error.validation.pattern": "Toto zadání je omezeno aktuálním vzorcem: {{ pattern }}.",
@@ -3089,8 +2964,7 @@
   "file-download-link.restricted": "Soubor s omezeným přístupem",
 
   // "file-download-link.secure-access": "Restricted bitstream available via secure access token",
-  // TODO New key - Add a translation
-  "file-download-link.secure-access": "Restricted bitstream available via secure access token",
+  "file-download-link.secure-access": "Omezený soubor dostupný pomocí zabezpečeného přístupového tokenu",
 
   // "file-section.error.header": "Error obtaining files for this item",
   "file-section.error.header": "Chyba při získávání souborů pro tento záznam",
@@ -3120,23 +2994,27 @@
   "footer.link.feedback": "Odeslat zpětnou vazbu",
 
   // "footer.link.coar-notify-support": "COAR Notify",
-  // TODO New key - Add a translation
   "footer.link.coar-notify-support": "COAR Notify",
 
   // "forgot-email.form.header": "Forgot Password",
-  "forgot-email.form.header": "Zapomenuté heslo",
+  // TODO New key - Add a translation
+  "forgot-email.form.header": "Forgot Password",
 
   // "forgot-email.form.info": "Enter the email address associated with the account.",
-  "forgot-email.form.info": "Zadejte e-mailovou adresu přidruženou k účtu.",
+  // TODO New key - Add a translation
+  "forgot-email.form.info": "Enter the email address associated with the account.",
 
   // "forgot-email.form.email": "Email Address *",
-  "forgot-email.form.email": "E-mailová adresa *",
+  // TODO New key - Add a translation
+  "forgot-email.form.email": "Email Address *",
 
   // "forgot-email.form.email.error.required": "Please fill in an email address",
-  "forgot-email.form.email.error.required": "Vyplňte prosím e-mailovou adresu",
+  // TODO New key - Add a translation
+  "forgot-email.form.email.error.required": "Please fill in an email address",
 
   // "forgot-email.form.email.error.not-email-form": "Please fill in a valid email address",
-  "forgot-email.form.email.error.not-email-form": "Vyplňte prosím platnou e-mailovou adresu",
+  // TODO New key - Add a translation
+  "forgot-email.form.email.error.not-email-form": "Please fill in a valid email address",
 
   // "forgot-email.form.email.hint": "An email will be sent to this address with a further instructions.",
   "forgot-email.form.email.hint": "Na tuto adresu bude zaslán e-mail s dalšími pokyny.",
@@ -3311,8 +3189,7 @@
   "grant-deny-request-copy.deny": "Neposílat kopii",
 
   // "grant-deny-request-copy.revoke": "Revoke access",
-  // TODO New key - Add a translation
-  "grant-deny-request-copy.revoke": "Revoke access",
+  "grant-deny-request-copy.revoke": "Zrušit přístup",
 
   // "grant-deny-request-copy.email.back": "Back",
   "grant-deny-request-copy.email.back": "Zpět",
@@ -3330,7 +3207,8 @@
   "grant-deny-request-copy.email.permissions.label": "Změnit na otevřený přístup",
 
   // "grant-deny-request-copy.email.send": "Send",
-  "grant-deny-request-copy.email.send": "Odeslat",
+  // TODO New key - Add a translation
+  "grant-deny-request-copy.email.send": "Send",
 
   // "grant-deny-request-copy.email.subject": "Subject",
   "grant-deny-request-copy.email.subject": "Předmět",
@@ -3355,8 +3233,7 @@
   "grant-deny-request-copy.intro2": "Po výběru možnosti se zobrazí návrh e-mailové odpovědi, který můžete upravit.",
 
   // "grant-deny-request-copy.previous-decision": "This request was previously granted with a secure access token. You may revoke this access now to immediately invalidate the access token",
-  // TODO New key - Add a translation
-  "grant-deny-request-copy.previous-decision": "This request was previously granted with a secure access token. You may revoke this access now to immediately invalidate the access token",
+  "grant-deny-request-copy.previous-decision": "Tato žádost byla dříve schválena pomocí zabezpečeného přístupového tokenu. Tento přístup můžete nyní zrušit a okamžitě zneplatnit přístupový token",
 
   // "grant-deny-request-copy.processed": "This request has already been processed. You can use the button below to get back to the home page.",
   "grant-deny-request-copy.processed": "Tato žádost již byla zpracována. Pomocí níže uvedeného tlačítka se můžete vrátit na domovskou stránku.",
@@ -3375,48 +3252,44 @@
   "grant-request-copy.intro.attachment": "A message will be sent to the applicant of the request. The requested document(s) will be attached.",
 
   // "grant-request-copy.intro.link": "A message will be sent to the applicant of the request. A secure link providing access to the requested document(s) will be attached. The link will provide access for the duration of time selected in the \"Access Period\" menu below.",
-  // TODO New key - Add a translation
   "grant-request-copy.intro.link": "A message will be sent to the applicant of the request. A secure link providing access to the requested document(s) will be attached. The link will provide access for the duration of time selected in the \"Access Period\" menu below.",
 
   // "grant-request-copy.intro.link.preview": "Below is a preview of the link that will be sent to the applicant:",
-  // TODO New key - Add a translation
-  "grant-request-copy.intro.link.preview": "Below is a preview of the link that will be sent to the applicant:",
+  "grant-request-copy.intro.link.preview": "Níže je náhled odkazu, který bude odeslán žadateli:",
 
   // "grant-request-copy.success": "Successfully granted item request",
   "grant-request-copy.success": "Úspěšně vyřízená žádost o záznam",
 
   // "grant-request-copy.access-period.header": "Access period",
-  // TODO New key - Add a translation
-  "grant-request-copy.access-period.header": "Access period",
+  "grant-request-copy.access-period.header": "Doba přístupu",
 
   // "grant-request-copy.access-period.+1DAY": "1 day",
-  // TODO New key - Add a translation
-  "grant-request-copy.access-period.+1DAY": "1 day",
+  "grant-request-copy.access-period.+1DAY": "1 den",
 
   // "grant-request-copy.access-period.+7DAYS": "1 week",
-  // TODO New key - Add a translation
-  "grant-request-copy.access-period.+7DAYS": "1 week",
+  "grant-request-copy.access-period.+7DAYS": "1 týden",
 
   // "grant-request-copy.access-period.+1MONTH": "1 month",
-  // TODO New key - Add a translation
-  "grant-request-copy.access-period.+1MONTH": "1 month",
+  "grant-request-copy.access-period.+1MONTH": "1 měsíc",
 
   // "grant-request-copy.access-period.+3MONTHS": "3 months",
-  // TODO New key - Add a translation
-  "grant-request-copy.access-period.+3MONTHS": "3 months",
+  // TODO Source message changed - Revise the translation
+  "grant-request-copy.access-period.+3MONTHS": "3 měsíce",
 
   // "grant-request-copy.access-period.FOREVER": "Forever",
-  // TODO New key - Add a translation
-  "grant-request-copy.access-period.FOREVER": "Forever",
+  "grant-request-copy.access-period.FOREVER": "Navždy",
 
   // "health.breadcrumbs": "Health",
-  "health.breadcrumbs": "Stav systému",
+  // TODO New key - Add a translation
+  "health.breadcrumbs": "Health",
 
   // "health-page.heading": "Health",
-  "health-page.heading": "Stav systému",
+  // TODO New key - Add a translation
+  "health-page.heading": "Health",
 
   // "health-page.info-tab": "Info",
-  "health-page.info-tab": "Informace",
+  // TODO New key - Add a translation
+  "health-page.info-tab": "Info",
 
   // "health-page.status-tab": "Status",
   "health-page.status-tab": "Stav",
@@ -3425,12 +3298,14 @@
   "health-page.error.msg": "Služba kontrolující stav systému je momentálně nedostupná.",
 
   // "health-page.property.status": "Status code",
-  "health-page.property.status": "Stavový kód",
+  "grant-request-copy.access-period.+3MONTHS": "3 měsíce",
 
   // "health-page.section.db.title": "Database",
-  "health-page.section.db.title": "Databáze",
+  // TODO New key - Add a translation
+  "health-page.section.db.title": "Database",
 
   // "health-page.section.geoIp.title": "GeoIp",
+  // TODO New key - Add a translation
   "health-page.section.geoIp.title": "GeoIp",
 
   // "health-page.section.solrAuthorityCore.title": "Solr: authority core",
@@ -3620,12 +3495,10 @@
   "info.feedback.page_help": "Stránka, která se týká vaší zpětné vazby",
 
   // "info.coar-notify-support.title": "COAR Notify Support",
-  // TODO New key - Add a translation
-  "info.coar-notify-support.title": "COAR Notify Support",
+  "info.coar-notify-support.title": "Podpora COAR Notify",
 
   // "info.coar-notify-support.breadcrumbs": "COAR Notify Support",
-  // TODO New key - Add a translation
-  "info.coar-notify-support.breadcrumbs": "COAR Notify Support",
+  "info.coar-notify-support.breadcrumbs": "Podpora COAR Notify",
 
   // "item.alerts.private": "This item is non-discoverable",
   "item.alerts.private": "Tento záznam je nevyhledatelný",
@@ -3634,36 +3507,41 @@
   "item.alerts.withdrawn": "Tento záznam byl stažen",
 
   // "item.alerts.reinstate-request": "Request reinstate",
-  // TODO New key - Add a translation
-  "item.alerts.reinstate-request": "Request reinstate",
+  "item.alerts.reinstate-request": "Požádat o obnovení",
 
   // "quality-assurance.event.table.person-who-requested": "Requested by",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.person-who-requested": "Requested by",
+  "quality-assurance.event.table.person-who-requested": "Požádal",
 
   // "item.edit.authorizations.heading": "With this editor you can view and alter the policies of an item, plus alter policies of individual item components: bundles and bitstreams. Briefly, an item is a container of bundles, and bundles are containers of bitstreams. Containers usually have ADD/REMOVE/READ/WRITE policies, while bitstreams only have READ/WRITE policies.",
   "item.edit.authorizations.heading": "Pomocí tohoto editoru můžete zobrazit a měnit politiky záznamu a také měnit politiky jednotlivých součástí záznamu: svazků a souborů. Stručně řečeno, záznam je kontejnerem svazků a svazky jsou kontejnery souborů. Kontejnery mají obvykle zásady ADD/REMOVE/READ/WRITE, zatímco soubory mají pouze zásady READ/WRITE.",
 
   // "item.edit.authorizations.title": "Edit item's Policies",
-  "item.edit.authorizations.title": "Upravit politiky záznamu",
+  // TODO New key - Add a translation
+  "item.edit.authorizations.title": "Edit item's Policies",
 
   // "item.badge.status": "Item status:",
-  "item.badge.status": "Stav položky:",
+  // TODO New key - Add a translation
+  "item.badge.status": "Item status:",
 
   // "item.badge.private": "Non-discoverable",
-  "item.badge.private": "Nedohledatelné",
+  // TODO New key - Add a translation
+  "item.badge.private": "Non-discoverable",
 
   // "item.badge.withdrawn": "Withdrawn",
-  "item.badge.withdrawn": "Vyřazeno",
+  // TODO New key - Add a translation
+  "item.badge.withdrawn": "Withdrawn",
 
   // "item.bitstreams.upload.bundle": "Bundle",
-  "item.bitstreams.upload.bundle": "Svazek",
+  // TODO New key - Add a translation
+  "item.bitstreams.upload.bundle": "Bundle",
 
   // "item.bitstreams.upload.bundle.placeholder": "Select a bundle or input new bundle name",
-  "item.bitstreams.upload.bundle.placeholder": "Vyberte svazek nebo zadejte nový název svazku",
+  // TODO New key - Add a translation
+  "item.bitstreams.upload.bundle.placeholder": "Select a bundle or input new bundle name",
 
   // "item.bitstreams.upload.bundle.new": "Create bundle",
-  "item.bitstreams.upload.bundle.new": "Vytvořit svazek",
+  // TODO New key - Add a translation
+  "item.bitstreams.upload.bundle.new": "Create bundle",
 
   // "item.bitstreams.upload.bundles.empty": "This item doesn't contain any bundles to upload a bitstream to.",
   "item.bitstreams.upload.bundles.empty": "Tento záznam neobsahuje žádné svazky, do kterých by bylo možné nahrát soubor.",
@@ -3969,16 +3847,13 @@
   "item.edit.metadata.edit.value": "Upravit hodnotu",
 
   // "item.edit.metadata.edit.authority.key": "Edit authority key",
-  // TODO New key - Add a translation
-  "item.edit.metadata.edit.authority.key": "Edit authority key",
+  "item.edit.metadata.edit.authority.key": "Upravit autoritní klíč",
 
   // "item.edit.metadata.edit.buttons.enable-free-text-editing": "Enable free-text editing",
-  // TODO New key - Add a translation
-  "item.edit.metadata.edit.buttons.enable-free-text-editing": "Enable free-text editing",
+  "item.edit.metadata.edit.buttons.enable-free-text-editing": "Povolit úpravy volného textu",
 
   // "item.edit.metadata.edit.buttons.disable-free-text-editing": "Disable free-text editing",
-  // TODO New key - Add a translation
-  "item.edit.metadata.edit.buttons.disable-free-text-editing": "Disable free-text editing",
+  "item.edit.metadata.edit.buttons.disable-free-text-editing": "Zakázat úpravy volného textu",
 
   // "item.edit.metadata.edit.buttons.confirm": "Confirm",
   "item.edit.metadata.edit.buttons.confirm": "Potvrdit",
@@ -3996,16 +3871,20 @@
   "item.edit.metadata.edit.buttons.undo": "Vrátit změny",
 
   // "item.edit.metadata.edit.buttons.unedit": "Stop editing",
-  "item.edit.metadata.edit.buttons.unedit": "Zastavit úpravy",
+  // TODO New key - Add a translation
+  "item.edit.metadata.edit.buttons.unedit": "Stop editing",
 
   // "item.edit.metadata.edit.buttons.virtual": "This is a virtual metadata value, i.e. a value inherited from a related entity. It can’t be modified directly. Add or remove the corresponding relationship in the \"Relationships\" tab",
-  "item.edit.metadata.edit.buttons.virtual": "Tato hodnota metadat je virtuální, tedy děděná z provázané entity. Nemůže být změněna napřímo. Přidejte či odeberte příslušný vztah na záložce \"Vztahy\".",
+  // TODO New key - Add a translation
+  "item.edit.metadata.edit.buttons.virtual": "This is a virtual metadata value, i.e. a value inherited from a related entity. It can’t be modified directly. Add or remove the corresponding relationship in the \"Relationships\" tab",
 
   // "item.edit.metadata.empty": "The item currently doesn't contain any metadata. Click Add to start adding a metadata value.",
-  "item.edit.metadata.empty": "Záznam aktuálně neobsahuje žádná metadata. Kliknutím na tlačítko Přidat začněte přidávat hodnotu metadat.",
+  // TODO New key - Add a translation
+  "item.edit.metadata.empty": "The item currently doesn't contain any metadata. Click Add to start adding a metadata value.",
 
   // "item.edit.metadata.headers.edit": "Edit",
-  "item.edit.metadata.headers.edit": "Upravit",
+  // TODO New key - Add a translation
+  "item.edit.metadata.headers.edit": "Edit",
 
   // "item.edit.metadata.headers.field": "Field",
   "item.edit.metadata.headers.field": "Pole",
@@ -4062,16 +3941,13 @@
   "item.edit.metadata.save-button": "Uložit",
 
   // "item.edit.metadata.authority.label": "Authority: ",
-  // TODO New key - Add a translation
-  "item.edit.metadata.authority.label": "Authority: ",
+  "item.edit.metadata.authority.label": "Autorita: ",
 
   // "item.edit.metadata.edit.buttons.open-authority-edition": "Unlock the authority key value for manual editing",
-  // TODO New key - Add a translation
-  "item.edit.metadata.edit.buttons.open-authority-edition": "Unlock the authority key value for manual editing",
+  "item.edit.metadata.edit.buttons.open-authority-edition": "Odemknout hodnotu autoritního klíče pro ruční úpravy",
 
   // "item.edit.metadata.edit.buttons.close-authority-edition": "Lock the authority key value for manual editing",
-  // TODO New key - Add a translation
-  "item.edit.metadata.edit.buttons.close-authority-edition": "Lock the authority key value for manual editing",
+  "item.edit.metadata.edit.buttons.close-authority-edition": "Uzamknout hodnotu autoritního klíče pro ruční úpravy",
 
   // "item.edit.modify.overview.field": "Field",
   "item.edit.modify.overview.field": "Pole",
@@ -4092,16 +3968,20 @@
   "item.edit.move.discard-button": "Vyřadit",
 
   // "item.edit.move.description": "Select the collection you wish to move this item to. To narrow down the list of displayed collections, you can enter a search query in the box.",
-  "item.edit.move.description": "Vyberte kolekci, do které chcete tento záznam přesunout. Chcete-li omezit seznam zobrazených kolekcí, můžete do pole zadat vyhledávací dotaz.",
+  // TODO New key - Add a translation
+  "item.edit.move.description": "Select the collection you wish to move this item to. To narrow down the list of displayed collections, you can enter a search query in the box.",
 
   // "item.edit.move.error": "An error occurred when attempting to move the item",
-  "item.edit.move.error": "Při pokusu o přesun záznamu došlo k chybě",
+  // TODO New key - Add a translation
+  "item.edit.move.error": "An error occurred when attempting to move the item",
 
   // "item.edit.move.head": "Move item: {{id}}",
-  "item.edit.move.head": "Přesunout záznam: {{id}}",
+  // TODO New key - Add a translation
+  "item.edit.move.head": "Move item: {{id}}",
 
   // "item.edit.move.inheritpolicies.checkbox": "Inherit policies",
-  "item.edit.move.inheritpolicies.checkbox": "Zdědit politiky",
+  // TODO New key - Add a translation
+  "item.edit.move.inheritpolicies.checkbox": "Inherit policies",
 
   // "item.edit.move.inheritpolicies.description": "Inherit the default policies of the destination collection",
   "item.edit.move.inheritpolicies.description": "Zdědit výchozí politiky cílové kolekce",
@@ -4436,8 +4316,7 @@
   "item.page.volume-title": "Název svazku",
 
   // "item.page.dcterms.spatial": "Geospatial point",
-  // TODO New key - Add a translation
-  "item.page.dcterms.spatial": "Geospatial point",
+  "item.page.dcterms.spatial": "Geoprostorový bod",
 
   // "item.search.results.head": "Item Search Results",
   "item.search.results.head": "Výsledky vyhledávání",
@@ -4452,20 +4331,16 @@
   "item.truncatable-part.show-less": "Sbalit",
 
   // "item.qa-event-notification.check.notification-info": "There are {{num}} pending suggestions related to your account",
-  // TODO New key - Add a translation
-  "item.qa-event-notification.check.notification-info": "There are {{num}} pending suggestions related to your account",
+  "item.qa-event-notification.check.notification-info": "K vašemu účtu se vztahuje {{num}} čekajících doporučení",
 
   // "item.qa-event-notification-info.check.button": "View",
-  // TODO New key - Add a translation
-  "item.qa-event-notification-info.check.button": "View",
+  "item.qa-event-notification-info.check.button": "Zobrazit",
 
   // "mydspace.qa-event-notification.check.notification-info": "There are {{num}} pending suggestions related to your account",
-  // TODO New key - Add a translation
-  "mydspace.qa-event-notification.check.notification-info": "There are {{num}} pending suggestions related to your account",
+  "mydspace.qa-event-notification.check.notification-info": "K vašemu účtu se vztahuje {{num}} čekajících doporučení",
 
   // "mydspace.qa-event-notification-info.check.button": "View",
-  // TODO New key - Add a translation
-  "mydspace.qa-event-notification-info.check.button": "View",
+  "mydspace.qa-event-notification-info.check.button": "Zobrazit",
 
   // "workflow-item.search.result.delete-supervision.modal.header": "Delete Supervision Order",
   "workflow-item.search.result.delete-supervision.modal.header": "Smazat příkaz k supervizi",
@@ -4583,8 +4458,7 @@
   "item.page.link.simple": "Zobrazit minimální záznam",
 
   // "item.page.options": "Options",
-  // TODO New key - Add a translation
-  "item.page.options": "Options",
+  "item.page.options": "Možnosti",
 
   // "item.page.orcid.title": "ORCID",
   "item.page.orcid.title": "ORCID",
@@ -4626,8 +4500,7 @@
   "item.page.bitstreams.collapse": "Sbalit",
 
   // "item.page.bitstreams.primary": "Primary",
-  // TODO New key - Add a translation
-  "item.page.bitstreams.primary": "Primary",
+  "item.page.bitstreams.primary": "Primární",
 
   // "item.page.filesection.original.bundle": "Original bundle",
   "item.page.filesection.original.bundle": "Původní svazek",
@@ -4642,12 +4515,10 @@
   "item.page.version.create": "Vytvořit novou verzi",
 
   // "item.page.withdrawn": "Request a withdrawal for this item",
-  // TODO New key - Add a translation
-  "item.page.withdrawn": "Request a withdrawal for this item",
+  "item.page.withdrawn": "Požádat o stažení tohoto záznamu",
 
   // "item.page.reinstate": "Request reinstatement",
-  // TODO New key - Add a translation
-  "item.page.reinstate": "Request reinstatement",
+  "item.page.reinstate": "Požádat o obnovení",
 
   // "item.page.version.hasDraft": "A new version cannot be created because there is an in-progress submission in the version history",
   "item.page.version.hasDraft": "Nová verze nemůže být vytvořena, protože v historii verzí už další rozpracovaná verze existuje.",
@@ -4659,8 +4530,7 @@
   "item.page.claim.tooltip": "Prohlásit tento záznam za profil",
 
   // "item.page.image.alt.ROR": "ROR logo",
-  // TODO New key - Add a translation
-  "item.page.image.alt.ROR": "ROR logo",
+  "item.page.image.alt.ROR": "Logo ROR",
 
   // "item.preview.dc.identifier.uri": "Identifier:",
   "item.preview.dc.identifier.uri": "Identifikátor:",
@@ -4672,8 +4542,7 @@
   "item.preview.dc.date.issued": "Datum vydání:",
 
   // "item.preview.dc.description": "Description:",
-  // TODO New key - Add a translation
-  "item.preview.dc.description": "Description:",
+  "item.preview.dc.description": "Popis:",
 
   // "item.preview.dc.description.abstract": "Abstract:",
   "item.preview.dc.description.abstract": "Abstrakt:",
@@ -4694,8 +4563,7 @@
   "item.preview.dc.type": "Typ:",
 
   // "item.preview.oaire.version": "Version",
-  // TODO New key - Add a translation
-  "item.preview.oaire.version": "Version",
+  "item.preview.oaire.version": "Verze",
 
   // "item.preview.oaire.citation.issue": "Issue",
   "item.preview.oaire.citation.issue": "Číslo",
@@ -4704,16 +4572,13 @@
   "item.preview.oaire.citation.volume": "Ročník",
 
   // "item.preview.oaire.citation.title": "Citation container",
-  // TODO New key - Add a translation
-  "item.preview.oaire.citation.title": "Citation container",
+  "item.preview.oaire.citation.title": "Zdroj citace",
 
   // "item.preview.oaire.citation.startPage": "Citation start page",
-  // TODO New key - Add a translation
-  "item.preview.oaire.citation.startPage": "Citation start page",
+  "item.preview.oaire.citation.startPage": "Počáteční strana citace",
 
   // "item.preview.oaire.citation.endPage": "Citation end page",
-  // TODO New key - Add a translation
-  "item.preview.oaire.citation.endPage": "Citation end page",
+  "item.preview.oaire.citation.endPage": "Koncová strana citace",
 
   // "item.preview.dc.relation.hasversion": "Has version",
   "item.preview.dc.relation.hasversion": "Má verzi",
@@ -4725,6 +4590,7 @@
   "item.preview.dc.rights": "Práva",
 
   // "item.preview.dc.identifier.other": "Other Identifier",
+  // TODO Source message changed - Revise the translation
   "item.preview.dc.identifier.other": "Další identifikátor:",
 
   // "item.preview.dc.relation.issn": "ISSN",
@@ -4781,7 +4647,6 @@
   "item.preview.oaire.fundingStream": "Tok finančních prostředků:",
 
   // "item.preview.oairecerif.identifier.url": "URL",
-  // TODO New key - Add a translation
   "item.preview.oairecerif.identifier.url": "URL",
 
   // "item.preview.organization.address.addressCountry": "Country",
@@ -4829,8 +4694,8 @@
   "item.preview.dc.identifier.openalex": "OpenAlex Identifier",
 
   // "item.preview.dc.description": "Description",
-  // TODO New key - Add a translation
-  "item.preview.dc.description": "Description",
+  // TODO Source message changed - Revise the translation
+  "item.preview.dc.description": "Popis:",
 
   // "item.select.confirm": "Confirm selected",
   "item.select.confirm": "Potvrdit vybrané",
@@ -4962,8 +4827,7 @@
   "item.version.create.modal.button.cancel": "Zrušit",
 
   // "item.qa.withdrawn-reinstate.create.modal.button.cancel": "Cancel",
-  // TODO New key - Add a translation
-  "item.qa.withdrawn-reinstate.create.modal.button.cancel": "Cancel",
+  "item.qa.withdrawn-reinstate.create.modal.button.cancel": "Zrušit",
 
   // "item.version.create.modal.button.cancel.tooltip": "Do not create new version",
   "item.version.create.modal.button.cancel.tooltip": "Nevytvářet novou verzi",
@@ -5168,8 +5032,7 @@
   "journal.page.publisher": "Nakladatel",
 
   // "journal.page.options": "Options",
-  // TODO New key - Add a translation
-  "journal.page.options": "Options",
+  "journal.page.options": "Možnosti",
 
   // "journal.page.titleprefix": "Journal: ",
   "journal.page.titleprefix": "Časopis: ",
@@ -5208,15 +5071,13 @@
   "journalissue.page.number": "Číslo",
 
   // "journalissue.page.options": "Options",
-  // TODO New key - Add a translation
-  "journalissue.page.options": "Options",
+  "journalissue.page.options": "Možnosti",
 
   // "journalissue.page.titleprefix": "Journal Issue: ",
   "journalissue.page.titleprefix": "Číslo časopisu: ",
 
   // "journalissue.search.results.head": "Journal Issue Search Results",
-  // TODO New key - Add a translation
-  "journalissue.search.results.head": "Journal Issue Search Results",
+  "journalissue.search.results.head": "Výsledky vyhledávání čísla časopisu",
 
   // "journalvolume.listelement.badge": "Journal Volume",
   "journalvolume.listelement.badge": "Ročník časopisu",
@@ -5231,8 +5092,7 @@
   "journalvolume.page.issuedate": "Datum vydání",
 
   // "journalvolume.page.options": "Options",
-  // TODO New key - Add a translation
-  "journalvolume.page.options": "Options",
+  "journalvolume.page.options": "Možnosti",
 
   // "journalvolume.page.titleprefix": "Journal Volume: ",
   "journalvolume.page.titleprefix": "Ročník časopisu: ",
@@ -5241,8 +5101,7 @@
   "journalvolume.page.volume": "Ročník",
 
   // "journalvolume.search.results.head": "Journal Volume Search Results",
-  // TODO New key - Add a translation
-  "journalvolume.search.results.head": "Journal Volume Search Results",
+  "journalvolume.search.results.head": "Výsledky vyhledávání ročníků časopisu",
 
   // "iiifsearchable.listelement.badge": "Document Media",
   "iiifsearchable.listelement.badge": "Média dokumentů",
@@ -7305,7 +7164,6 @@
   "search.filters.applied.f.withdrawn": "Vyřazeno",
 
   // "search.filters.applied.operator.equals": "",
-  // TODO New key - Add a translation
   "search.filters.applied.operator.equals": "",
 
   // "search.filters.applied.operator.notequals": " not equals",
@@ -7313,7 +7171,6 @@
   "search.filters.applied.operator.notequals": " not equals",
 
   // "search.filters.applied.operator.authority": "",
-  // TODO New key - Add a translation
   "search.filters.applied.operator.authority": "",
 
   // "search.filters.applied.operator.notauthority": " not authority",
@@ -7329,7 +7186,6 @@
   "search.filters.applied.operator.notcontains": " not contains",
 
   // "search.filters.applied.operator.query": "",
-  // TODO New key - Add a translation
   "search.filters.applied.operator.query": "",
 
   // "search.filters.applied.f.point": "Coordinates",
@@ -7657,12 +7513,10 @@
   "search.filters.has_content_in_original_bundle.false": "Ne",
 
   // "search.filters.has_geospatial_metadata.true": "Yes",
-  // TODO New key - Add a translation
-  "search.filters.has_geospatial_metadata.true": "Yes",
+  "search.filters.has_geospatial_metadata.true": "Ano",
 
   // "search.filters.has_geospatial_metadata.false": "No",
-  // TODO New key - Add a translation
-  "search.filters.has_geospatial_metadata.false": "No",
+  "search.filters.has_geospatial_metadata.false": "Ne",
 
   // "search.filters.discoverable.true": "No",
   "search.filters.discoverable.true": "Ne",
@@ -8029,7 +7883,6 @@
   "submission.import-external.source.dataciteProject": "DataCite",
 
   // "submission.import-external.source.doi": "DOI",
-  // TODO New key - Add a translation
   "submission.import-external.source.doi": "DOI",
 
   // "submission.import-external.source.scielo": "SciELO",
@@ -8270,8 +8123,7 @@
   "submission.sections.describe.relationship-lookup.external-source.import-modal.head.arxiv": "Import z arXiv",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.ror": "Import from ROR",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.ror": "Import from ROR",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.ror": "Import z ROR",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.import": "Import",
   "submission.sections.describe.relationship-lookup.external-source.import-modal.import": "Import",
@@ -8406,19 +8258,15 @@
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.arxiv": "arXiv ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.ror": "ROR ({{ count }})",
-  // TODO New key - Add a translation
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.ror": "ROR ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.orcidWorks": "ORCID ({{ count }})",
-  // TODO New key - Add a translation
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.orcidWorks": "ORCID ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.crossref": "Crossref ({{ count }})",
-  // TODO New key - Add a translation
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.crossref": "Crossref ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.scopus": "Scopus ({{ count }})",
-  // TODO New key - Add a translation
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.scopus": "Scopus ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaire": "OpenAIRE Search by Authors ({{ count }})",
@@ -8438,7 +8286,6 @@
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.sherpaJournalIssn": "Sherpa Journals by ISSN ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexPerson": "OpenAlex ({{ count }})",
-  // TODO New key - Add a translation
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexPerson": "OpenAlex ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexInstitution": "OpenAlex Search by Institution ({{ count }})",
@@ -8557,7 +8404,6 @@
   "submission.sections.describe.relationship-lookup.title.isPublicationOfAuthor": "Publikace",
 
   // "submission.sections.describe.relationship-lookup.title.isOrgUnitOfProject": "OrgUnit",
-  // TODO New key - Add a translation
   "submission.sections.describe.relationship-lookup.title.isOrgUnitOfProject": "OrgUnit",
 
   // "submission.sections.describe.relationship-lookup.search-tab.toggle-dropdown": "Toggle dropdown",
@@ -8669,28 +8515,22 @@
   "submission.sections.describe.relationship-lookup.selection-tab.title.wos": "Výsledky vyhledávání",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.ror": "Search Results",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.selection-tab.title.ror": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.ror": "Výsledky vyhledávání",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.openalexPerson": "Search Results",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.selection-tab.title.openalexPerson": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.openalexPerson": "Výsledky vyhledávání",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.openalexInstitution": "Search Results",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.selection-tab.title.openalexInstitution": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.openalexInstitution": "Výsledky vyhledávání",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.openalexPublisher": "Search Results",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.selection-tab.title.openalexPublisher": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.openalexPublisher": "Výsledky vyhledávání",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.openalexFunder": "Search Results",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.selection-tab.title.openalexFunder": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.openalexFunder": "Výsledky vyhledávání",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.dataciteProject": "Search Results",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.selection-tab.title.dataciteProject": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.dataciteProject": "Výsledky vyhledávání",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title": "Search Results",
   "submission.sections.describe.relationship-lookup.selection-tab.title": "Výsledky vyhledávání",
@@ -10132,24 +9972,19 @@
   "vocabulary-treeview.search.form.add": "Přidat",
 
   // "admin.notifications.publicationclaim.breadcrumbs": "Publication Claim",
-  // TODO New key - Add a translation
-  "admin.notifications.publicationclaim.breadcrumbs": "Publication Claim",
+  "admin.notifications.publicationclaim.breadcrumbs": "Nárokování publikace",
 
   // "admin.notifications.publicationclaim.page.title": "Publication Claim",
-  // TODO New key - Add a translation
-  "admin.notifications.publicationclaim.page.title": "Publication Claim",
+  "admin.notifications.publicationclaim.page.title": "Nárokování publikace",
 
   // "coar-notify-support.title": "COAR Notify Protocol",
-  // TODO New key - Add a translation
-  "coar-notify-support.title": "COAR Notify Protocol",
+  "coar-notify-support.title": "Protokol COAR Notify",
 
   // "coar-notify-support-title.content": "Here, we fully support the COAR Notify protocol, which is designed to enhance the communication between repositories. To learn more about the COAR Notify protocol, visit the <a href=\"https://notify.coar-repositories.org/\" rel=\"noopener noreferrer\">COAR Notify website</a>.",
-  // TODO New key - Add a translation
-  "coar-notify-support-title.content": "Here, we fully support the COAR Notify protocol, which is designed to enhance the communication between repositories. To learn more about the COAR Notify protocol, visit the <a href=\"https://notify.coar-repositories.org/\" rel=\"noopener noreferrer\">COAR Notify website</a>.",
+  "coar-notify-support-title.content": "Zde plně podporujeme protokol COAR Notify, který je navržen pro zlepšení komunikace mezi repozitáři. Chcete-li se o protokolu COAR Notify dozvědět více, navštivte <a href=\"https://notify.coar-repositories.org/\" rel=\"noopener noreferrer\">web COAR Notify</a>.",
 
   // "coar-notify-support.ldn-inbox.title": "LDN InBox",
-  // TODO New key - Add a translation
-  "coar-notify-support.ldn-inbox.title": "LDN InBox",
+  "coar-notify-support.ldn-inbox.title": "LDN schránka",
 
   // "coar-notify-support.ldn-inbox.content": "For your convenience, our LDN (Linked Data Notifications) InBox is easily accessible at {{ ldnInboxUrl }}. The LDN InBox enables seamless communication and data exchange, ensuring efficient and effective collaboration.",
   // TODO New key - Add a translation
@@ -10168,453 +10003,313 @@
   "coar-notify-support.message-moderation.feedback-form": " Feedback form.",
 
   // "service.overview.delete.header": "Delete Service",
-  // TODO New key - Add a translation
-  "service.overview.delete.header": "Delete Service",
+  "service.overview.delete.header": "Odstranit službu",
 
   // "ldn-registered-services.title": "Registered Services",
-  // TODO New key - Add a translation
-  "ldn-registered-services.title": "Registered Services",
+  "ldn-registered-services.title": "Registrované služby",
   // "ldn-registered-services.table.name": "Name",
-  // TODO New key - Add a translation
-  "ldn-registered-services.table.name": "Name",
+  "ldn-registered-services.table.name": "Název",
   // "ldn-registered-services.table.description": "Description",
-  // TODO New key - Add a translation
-  "ldn-registered-services.table.description": "Description",
+  "ldn-registered-services.table.description": "Popis",
   // "ldn-registered-services.table.status": "Status",
-  // TODO New key - Add a translation
-  "ldn-registered-services.table.status": "Status",
+  "ldn-registered-services.table.status": "Stav",
   // "ldn-registered-services.table.action": "Action",
-  // TODO New key - Add a translation
-  "ldn-registered-services.table.action": "Action",
+  "ldn-registered-services.table.action": "Akce",
   // "ldn-registered-services.new": "NEW",
-  // TODO New key - Add a translation
-  "ldn-registered-services.new": "NEW",
+  "ldn-registered-services.new": "NOVÉ",
   // "ldn-registered-services.new.breadcrumbs": "Registered Services",
-  // TODO New key - Add a translation
-  "ldn-registered-services.new.breadcrumbs": "Registered Services",
+  "ldn-registered-services.new.breadcrumbs": "Registrované služby",
 
   // "ldn-service.overview.table.enabled": "Enabled",
-  // TODO New key - Add a translation
-  "ldn-service.overview.table.enabled": "Enabled",
+  "ldn-service.overview.table.enabled": "Povoleno",
   // "ldn-service.overview.table.disabled": "Disabled",
-  // TODO New key - Add a translation
-  "ldn-service.overview.table.disabled": "Disabled",
+  "ldn-service.overview.table.disabled": "Zakázáno",
   // "ldn-service.overview.table.clickToEnable": "Click to enable",
-  // TODO New key - Add a translation
-  "ldn-service.overview.table.clickToEnable": "Click to enable",
+  "ldn-service.overview.table.clickToEnable": "Kliknutím povolit",
   // "ldn-service.overview.table.clickToDisable": "Click to disable",
-  // TODO New key - Add a translation
-  "ldn-service.overview.table.clickToDisable": "Click to disable",
+  "ldn-service.overview.table.clickToDisable": "Kliknutím zakázat",
 
   // "ldn-edit-registered-service.title": "Edit Service",
-  // TODO New key - Add a translation
-  "ldn-edit-registered-service.title": "Edit Service",
+  "ldn-edit-registered-service.title": "Upravit službu",
   // "ldn-create-service.title": "Create service",
-  // TODO New key - Add a translation
-  "ldn-create-service.title": "Create service",
+  "ldn-create-service.title": "Vytvořit službu",
   // "service.overview.create.modal": "Create Service",
-  // TODO New key - Add a translation
-  "service.overview.create.modal": "Create Service",
+  "service.overview.create.modal": "Vytvořit službu",
   // "service.overview.create.body": "Please confirm the creation of this service.",
-  // TODO New key - Add a translation
-  "service.overview.create.body": "Please confirm the creation of this service.",
+  "service.overview.create.body": "Potvrďte prosím vytvoření této služby.",
   // "ldn-service-status": "Status",
-  // TODO New key - Add a translation
-  "ldn-service-status": "Status",
+  "ldn-service-status": "Stav",
   // "service.confirm.create": "Create",
-  // TODO New key - Add a translation
-  "service.confirm.create": "Create",
+  "service.confirm.create": "Vytvořit",
   // "service.refuse.create": "Cancel",
-  // TODO New key - Add a translation
-  "service.refuse.create": "Cancel",
+  "service.refuse.create": "Zrušit",
   // "ldn-register-new-service.title": "Register a new service",
-  // TODO New key - Add a translation
-  "ldn-register-new-service.title": "Register a new service",
+  "ldn-register-new-service.title": "Zaregistrovat novou službu",
   // "ldn-new-service.form.label.submit": "Save",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.submit": "Save",
+  "ldn-new-service.form.label.submit": "Uložit",
   // "ldn-new-service.form.label.name": "Name",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.name": "Name",
+  "ldn-new-service.form.label.name": "Název",
   // "ldn-new-service.form.label.description": "Description",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.description": "Description",
+  "ldn-new-service.form.label.description": "Popis",
   // "ldn-new-service.form.label.url": "Service URL",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.url": "Service URL",
+  "ldn-new-service.form.label.url": "URL služby",
   // "ldn-new-service.form.label.ip-range": "Service IP range",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.ip-range": "Service IP range",
+  "ldn-new-service.form.label.ip-range": "Rozsah IP služby",
   // "ldn-new-service.form.label.score": "Level of trust",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.score": "Level of trust",
+  "ldn-new-service.form.label.score": "Úroveň důvěry",
   // "ldn-new-service.form.label.ldnUrl": "LDN Inbox URL",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.ldnUrl": "LDN Inbox URL",
+  "ldn-new-service.form.label.ldnUrl": "URL LDN schránky",
   // "ldn-new-service.form.placeholder.name": "Please provide service name",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.placeholder.name": "Please provide service name",
+  "ldn-new-service.form.placeholder.name": "Zadejte název služby",
   // "ldn-new-service.form.placeholder.description": "Please provide a description regarding your service",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.placeholder.description": "Please provide a description regarding your service",
+  "ldn-new-service.form.placeholder.description": "Zadejte popis vaší služby",
   // "ldn-new-service.form.placeholder.url": "Please input the URL for users to check out more information about the service",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.placeholder.url": "Please input the URL for users to check out more information about the service",
+  "ldn-new-service.form.placeholder.url": "Zadejte URL, na kterém si uživatelé mohou přečíst více informací o službě",
   // "ldn-new-service.form.placeholder.lowerIp": "IPv4 range lower bound",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.placeholder.lowerIp": "IPv4 range lower bound",
+  "ldn-new-service.form.placeholder.lowerIp": "Dolní mez rozsahu IPv4",
   // "ldn-new-service.form.placeholder.upperIp": "IPv4 range upper bound",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.placeholder.upperIp": "IPv4 range upper bound",
+  "ldn-new-service.form.placeholder.upperIp": "Horní mez rozsahu IPv4",
   // "ldn-new-service.form.placeholder.ldnUrl": "Please specify the URL of the LDN Inbox",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.placeholder.ldnUrl": "Please specify the URL of the LDN Inbox",
+  "ldn-new-service.form.placeholder.ldnUrl": "Uveďte URL LDN schránky",
   // "ldn-new-service.form.placeholder.score": "Please enter a value between 0 and 1. Use the “.” as decimal separator",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.placeholder.score": "Please enter a value between 0 and 1. Use the “.” as decimal separator",
+  "ldn-new-service.form.placeholder.score": "Zadejte hodnotu mezi 0 a 1. Jako desetinný oddělovač použijte “.”",
   // "ldn-service.form.label.placeholder.default-select": "Select a pattern",
-  // TODO New key - Add a translation
-  "ldn-service.form.label.placeholder.default-select": "Select a pattern",
+  "ldn-service.form.label.placeholder.default-select": "Vyberte vzor",
 
   // "ldn-service.form.pattern.ack-accept.label": "Acknowledge and Accept",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-accept.label": "Acknowledge and Accept",
+  "ldn-service.form.pattern.ack-accept.label": "Potvrdit a přijmout",
   // "ldn-service.form.pattern.ack-accept.description": "This pattern is used to acknowledge and accept a request (offer). It implies an intention to act on the request.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-accept.description": "This pattern is used to acknowledge and accept a request (offer). It implies an intention to act on the request.",
+  "ldn-service.form.pattern.ack-accept.description": "Tento vzor se používá k potvrzení a přijetí požadavku (nabídky). Vyjadřuje záměr na žádost reagovat.",
   // "ldn-service.form.pattern.ack-accept.category": "Acknowledgements",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-accept.category": "Acknowledgements",
+  "ldn-service.form.pattern.ack-accept.category": "Potvrzení",
 
   // "ldn-service.form.pattern.ack-reject.label": "Acknowledge and Reject",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-reject.label": "Acknowledge and Reject",
+  "ldn-service.form.pattern.ack-reject.label": "Potvrdit a odmítnout",
   // "ldn-service.form.pattern.ack-reject.description": "This pattern is used to acknowledge and reject a request (offer). It signifies no further action regarding the request.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-reject.description": "This pattern is used to acknowledge and reject a request (offer). It signifies no further action regarding the request.",
+  "ldn-service.form.pattern.ack-reject.description": "Tento vzor se používá k potvrzení a odmítnutí požadavku (nabídky). Neznamená žádnou další akci k žádosti.",
   // "ldn-service.form.pattern.ack-reject.category": "Acknowledgements",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-reject.category": "Acknowledgements",
+  "ldn-service.form.pattern.ack-reject.category": "Potvrzení",
 
   // "ldn-service.form.pattern.ack-tentative-accept.label": "Acknowledge and Tentatively Accept",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-tentative-accept.label": "Acknowledge and Tentatively Accept",
+  "ldn-service.form.pattern.ack-tentative-accept.label": "Potvrdit a předběžně přijmout",
   // "ldn-service.form.pattern.ack-tentative-accept.description": "This pattern is used to acknowledge and tentatively accept a request (offer). It implies an intention to act, which may change.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-tentative-accept.description": "This pattern is used to acknowledge and tentatively accept a request (offer). It implies an intention to act, which may change.",
+  "ldn-service.form.pattern.ack-tentative-accept.description": "Tento vzor se používá k potvrzení a předběžnému přijetí požadavku (nabídky). Vyjadřuje záměr jednat, který se může změnit.",
   // "ldn-service.form.pattern.ack-tentative-accept.category": "Acknowledgements",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-tentative-accept.category": "Acknowledgements",
+  "ldn-service.form.pattern.ack-tentative-accept.category": "Potvrzení",
 
   // "ldn-service.form.pattern.ack-tentative-reject.label": "Acknowledge and Tentatively Reject",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-tentative-reject.label": "Acknowledge and Tentatively Reject",
+  "ldn-service.form.pattern.ack-tentative-reject.label": "Potvrdit a předběžně odmítnout",
   // "ldn-service.form.pattern.ack-tentative-reject.description": "This pattern is used to acknowledge and tentatively reject a request (offer). It signifies no further action, subject to change.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-tentative-reject.description": "This pattern is used to acknowledge and tentatively reject a request (offer). It signifies no further action, subject to change.",
+  "ldn-service.form.pattern.ack-tentative-reject.description": "Tento vzor se používá k potvrzení a předběžnému odmítnutí požadavku (nabídky). Neznamená žádnou další akci, může se změnit.",
   // "ldn-service.form.pattern.ack-tentative-reject.category": "Acknowledgements",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.ack-tentative-reject.category": "Acknowledgements",
+  "ldn-service.form.pattern.ack-tentative-reject.category": "Potvrzení",
 
   // "ldn-service.form.pattern.announce-endorsement.label": "Announce Endorsement",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-endorsement.label": "Announce Endorsement",
+  "ldn-service.form.pattern.announce-endorsement.label": "Oznámit doporučení",
   // "ldn-service.form.pattern.announce-endorsement.description": "This pattern is used to announce the existence of an endorsement, referencing the endorsed resource.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-endorsement.description": "This pattern is used to announce the existence of an endorsement, referencing the endorsed resource.",
+  "ldn-service.form.pattern.announce-endorsement.description": "Tento vzor se používá k oznámení existence doporučení s odkazem na doporučený zdroj.",
   // "ldn-service.form.pattern.announce-endorsement.category": "Announcements",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-endorsement.category": "Announcements",
+  "ldn-service.form.pattern.announce-endorsement.category": "Oznámení",
 
   // "ldn-service.form.pattern.announce-ingest.label": "Announce Ingest",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-ingest.label": "Announce Ingest",
+  "ldn-service.form.pattern.announce-ingest.label": "Oznámit převzetí",
   // "ldn-service.form.pattern.announce-ingest.description": "This pattern is used to announce that a resource has been ingested.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-ingest.description": "This pattern is used to announce that a resource has been ingested.",
+  "ldn-service.form.pattern.announce-ingest.description": "Tento vzor se používá k oznámení, že byl zdroj převzat.",
   // "ldn-service.form.pattern.announce-ingest.category": "Announcements",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-ingest.category": "Announcements",
+  "ldn-service.form.pattern.announce-ingest.category": "Oznámení",
 
   // "ldn-service.form.pattern.announce-relationship.label": "Announce Relationship",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-relationship.label": "Announce Relationship",
+  "ldn-service.form.pattern.announce-relationship.label": "Oznámit vztah",
   // "ldn-service.form.pattern.announce-relationship.description": "This pattern is used to announce a relationship between two resources.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-relationship.description": "This pattern is used to announce a relationship between two resources.",
+  "ldn-service.form.pattern.announce-relationship.description": "Tento vzor se používá k oznámení vztahu mezi dvěma zdroji.",
   // "ldn-service.form.pattern.announce-relationship.category": "Announcements",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-relationship.category": "Announcements",
+  "ldn-service.form.pattern.announce-relationship.category": "Oznámení",
 
   // "ldn-service.form.pattern.announce-review.label": "Announce Review",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-review.label": "Announce Review",
+  "ldn-service.form.pattern.announce-review.label": "Oznámit recenzi",
   // "ldn-service.form.pattern.announce-review.description": "This pattern is used to announce the existence of a review, referencing the reviewed resource.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-review.description": "This pattern is used to announce the existence of a review, referencing the reviewed resource.",
+  "ldn-service.form.pattern.announce-review.description": "Tento vzor se používá k oznámení existence recenze s odkazem na recenzovaný zdroj.",
   // "ldn-service.form.pattern.announce-review.category": "Announcements",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-review.category": "Announcements",
+  "ldn-service.form.pattern.announce-review.category": "Oznámení",
 
   // "ldn-service.form.pattern.announce-service-result.label": "Announce Service Result",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-service-result.label": "Announce Service Result",
+  "ldn-service.form.pattern.announce-service-result.label": "Oznámit výsledek služby",
   // "ldn-service.form.pattern.announce-service-result.description": "This pattern is used to announce the existence of a 'service result', referencing the relevant resource.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-service-result.description": "This pattern is used to announce the existence of a 'service result', referencing the relevant resource.",
+  "ldn-service.form.pattern.announce-service-result.description": "Tento vzor se používá k oznámení existence ‚výsledku služby‘ s odkazem na příslušný zdroj.",
   // "ldn-service.form.pattern.announce-service-result.category": "Announcements",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.announce-service-result.category": "Announcements",
+  "ldn-service.form.pattern.announce-service-result.category": "Oznámení",
 
   // "ldn-service.form.pattern.request-endorsement.label": "Request Endorsement",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.request-endorsement.label": "Request Endorsement",
+  "ldn-service.form.pattern.request-endorsement.label": "Žádat o doporučení",
   // "ldn-service.form.pattern.request-endorsement.description": "This pattern is used to request endorsement of a resource owned by the origin system.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.request-endorsement.description": "This pattern is used to request endorsement of a resource owned by the origin system.",
+  "ldn-service.form.pattern.request-endorsement.description": "Tento vzor se používá k vyžádání doporučení pro zdroj vlastněný zdrojovým systémem.",
   // "ldn-service.form.pattern.request-endorsement.category": "Requests",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.request-endorsement.category": "Requests",
+  "ldn-service.form.pattern.request-endorsement.category": "Žádosti",
 
   // "ldn-service.form.pattern.request-ingest.label": "Request Ingest",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.request-ingest.label": "Request Ingest",
+  "ldn-service.form.pattern.request-ingest.label": "Požádat o převzetí",
   // "ldn-service.form.pattern.request-ingest.description": "This pattern is used to request that the target system ingest a resource.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.request-ingest.description": "This pattern is used to request that the target system ingest a resource.",
+  "ldn-service.form.pattern.request-ingest.description": "Tento vzor se používá k požadavku, aby cílový systém převzal zdroj.",
   // "ldn-service.form.pattern.request-ingest.category": "Requests",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.request-ingest.category": "Requests",
+  "ldn-service.form.pattern.request-ingest.category": "Žádosti",
 
   // "ldn-service.form.pattern.request-review.label": "Request Review",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.request-review.label": "Request Review",
+  "ldn-service.form.pattern.request-review.label": "Požádat o recenzi",
   // "ldn-service.form.pattern.request-review.description": "This pattern is used to request a review of a resource owned by the origin system.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.request-review.description": "This pattern is used to request a review of a resource owned by the origin system.",
+  "ldn-service.form.pattern.request-review.description": "Tento vzor se používá k požadavku na recenzi zdroje vlastněného zdrojovým systémem.",
   // "ldn-service.form.pattern.request-review.category": "Requests",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.request-review.category": "Requests",
+  "ldn-service.form.pattern.request-review.category": "Žádosti",
 
   // "ldn-service.form.pattern.undo-offer.label": "Undo Offer",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.undo-offer.label": "Undo Offer",
+  "ldn-service.form.pattern.undo-offer.label": "Zrušit nabídku",
   // "ldn-service.form.pattern.undo-offer.description": "This pattern is used to undo (retract) an offer previously made.",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.undo-offer.description": "This pattern is used to undo (retract) an offer previously made.",
+  "ldn-service.form.pattern.undo-offer.description": "Tento vzor se používá ke zrušení (stažení) dříve učiněné nabídky.",
   // "ldn-service.form.pattern.undo-offer.category": "Undo",
-  // TODO New key - Add a translation
-  "ldn-service.form.pattern.undo-offer.category": "Undo",
+  "ldn-service.form.pattern.undo-offer.category": "Zrušení",
 
   // "ldn-new-service.form.label.placeholder.selectedItemFilter": "No Item Filter Selected",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.placeholder.selectedItemFilter": "No Item Filter Selected",
+  "ldn-new-service.form.label.placeholder.selectedItemFilter": "Není vybrán žádný filtr záznamů",
   // "ldn-new-service.form.label.ItemFilter": "Item Filter",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.ItemFilter": "Item Filter",
+  "ldn-new-service.form.label.ItemFilter": "Filtr záznamů",
   // "ldn-new-service.form.label.automatic": "Automatic",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.automatic": "Automatic",
+  "ldn-new-service.form.label.automatic": "Automaticky",
   // "ldn-new-service.form.error.name": "Name is required",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.error.name": "Name is required",
+  "ldn-new-service.form.error.name": "Název je povinný",
   // "ldn-new-service.form.error.url": "URL is required",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.error.url": "URL is required",
+  "ldn-new-service.form.error.url": "URL je povinné",
   // "ldn-new-service.form.error.ipRange": "Please enter a valid IP range",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.error.ipRange": "Please enter a valid IP range",
+  "ldn-new-service.form.error.ipRange": "Zadejte platný rozsah IP",
   // "ldn-new-service.form.hint.ipRange": "Please enter a valid IpV4 in both range bounds (note: for single IP, please enter the same value in both fields)",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.hint.ipRange": "Please enter a valid IpV4 in both range bounds (note: for single IP, please enter the same value in both fields)",
+  "ldn-new-service.form.hint.ipRange": "Zadejte platnou adresu IPv4 v obou mezích rozsahu (pozn.: pro jednu IP zadejte stejnou hodnotu do obou polí)",
   // "ldn-new-service.form.error.ldnurl": "LDN URL is required",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.error.ldnurl": "LDN URL is required",
+  "ldn-new-service.form.error.ldnurl": "URL LDN je povinné",
   // "ldn-new-service.form.error.patterns": "At least a pattern is required",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.error.patterns": "At least a pattern is required",
+  "ldn-new-service.form.error.patterns": "Je vyžadován alespoň jeden vzor",
   // "ldn-new-service.form.error.score": "Please enter a valid score (between 0 and 1). Use the “.” as decimal separator",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.error.score": "Please enter a valid score (between 0 and 1). Use the “.” as decimal separator",
+  "ldn-new-service.form.error.score": "Zadejte platné hodnocení (mezi 0 a 1). Jako desetinný oddělovač použijte „.“",
 
   // "ldn-new-service.form.label.inboundPattern": "Supported Pattern",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.inboundPattern": "Supported Pattern",
+  "ldn-new-service.form.label.inboundPattern": "Podporovaný vzor",
   // "ldn-new-service.form.label.addPattern": "+ Add more",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.addPattern": "+ Add more",
+  "ldn-new-service.form.label.addPattern": "+ Přidat další",
   // "ldn-new-service.form.label.removeItemFilter": "Remove",
-  // TODO New key - Add a translation
-  "ldn-new-service.form.label.removeItemFilter": "Remove",
+  "ldn-new-service.form.label.removeItemFilter": "Odebrat",
   // "ldn-register-new-service.breadcrumbs": "New Service",
-  // TODO New key - Add a translation
-  "ldn-register-new-service.breadcrumbs": "New Service",
+  "ldn-register-new-service.breadcrumbs": "Nová služba",
   // "service.overview.delete.body": "Are you sure you want to delete this service?",
-  // TODO New key - Add a translation
-  "service.overview.delete.body": "Are you sure you want to delete this service?",
+  "service.overview.delete.body": "Opravdu chcete tuto službu odstranit?",
   // "service.overview.edit.body": "Do you confirm the changes?",
-  // TODO New key - Add a translation
-  "service.overview.edit.body": "Do you confirm the changes?",
+  "service.overview.edit.body": "Potvrzujete změny?",
   // "service.overview.edit.modal": "Edit Service",
-  // TODO New key - Add a translation
-  "service.overview.edit.modal": "Edit Service",
+  "service.overview.edit.modal": "Upravit službu",
   // "service.detail.update": "Confirm",
-  // TODO New key - Add a translation
-  "service.detail.update": "Confirm",
+  "service.detail.update": "Potvrdit",
   // "service.detail.return": "Cancel",
-  // TODO New key - Add a translation
-  "service.detail.return": "Cancel",
+  "service.detail.return": "Zrušit",
   // "service.overview.reset-form.body": "Are you sure you want to discard the changes and leave?",
-  // TODO New key - Add a translation
-  "service.overview.reset-form.body": "Are you sure you want to discard the changes and leave?",
+  "service.overview.reset-form.body": "Opravdu chcete zahodit změny a odejít?",
   // "service.overview.reset-form.modal": "Discard Changes",
-  // TODO New key - Add a translation
-  "service.overview.reset-form.modal": "Discard Changes",
+  "service.overview.reset-form.modal": "Zahodit změny",
   // "service.overview.reset-form.reset-confirm": "Discard",
-  // TODO New key - Add a translation
-  "service.overview.reset-form.reset-confirm": "Discard",
+  "service.overview.reset-form.reset-confirm": "Zahodit",
   // "admin.registries.services-formats.modify.success.head": "Successful Edit",
-  // TODO New key - Add a translation
-  "admin.registries.services-formats.modify.success.head": "Successful Edit",
+  "admin.registries.services-formats.modify.success.head": "Úspěšná úprava",
   // "admin.registries.services-formats.modify.success.content": "The service has been edited",
-  // TODO New key - Add a translation
-  "admin.registries.services-formats.modify.success.content": "The service has been edited",
+  "admin.registries.services-formats.modify.success.content": "Služba byla upravena",
   // "admin.registries.services-formats.modify.failure.head": "Failed Edit",
-  // TODO New key - Add a translation
-  "admin.registries.services-formats.modify.failure.head": "Failed Edit",
+  "admin.registries.services-formats.modify.failure.head": "Neúspěšná úprava",
   // "admin.registries.services-formats.modify.failure.content": "The service has not been edited",
-  // TODO New key - Add a translation
-  "admin.registries.services-formats.modify.failure.content": "The service has not been edited",
+  "admin.registries.services-formats.modify.failure.content": "Služba nebyla upravena",
   // "ldn-service-notification.created.success.title": "Successful Create",
-  // TODO New key - Add a translation
-  "ldn-service-notification.created.success.title": "Successful Create",
+  "ldn-service-notification.created.success.title": "Úspěšné vytvoření",
   // "ldn-service-notification.created.success.body": "The service has been created",
-  // TODO New key - Add a translation
-  "ldn-service-notification.created.success.body": "The service has been created",
+  "ldn-service-notification.created.success.body": "Služba byla vytvořena",
   // "ldn-service-notification.created.failure.title": "Failed Create",
-  // TODO New key - Add a translation
-  "ldn-service-notification.created.failure.title": "Failed Create",
+  "ldn-service-notification.created.failure.title": "Neúspěšné vytvoření",
   // "ldn-service-notification.created.failure.body": "The service has not been created",
-  // TODO New key - Add a translation
-  "ldn-service-notification.created.failure.body": "The service has not been created",
+  "ldn-service-notification.created.failure.body": "Služba nebyla vytvořena",
   // "ldn-service-notification.created.warning.title": "Please select at least one Inbound Pattern",
-  // TODO New key - Add a translation
-  "ldn-service-notification.created.warning.title": "Please select at least one Inbound Pattern",
+  "ldn-service-notification.created.warning.title": "Vyberte alespoň jeden příchozí vzor",
   // "ldn-enable-service.notification.success.title": "Successful status updated",
-  // TODO New key - Add a translation
-  "ldn-enable-service.notification.success.title": "Successful status updated",
+  "ldn-enable-service.notification.success.title": "Stav úspěšně aktualizován",
   // "ldn-enable-service.notification.success.content": "The service status has been updated",
-  // TODO New key - Add a translation
-  "ldn-enable-service.notification.success.content": "The service status has been updated",
+  "ldn-enable-service.notification.success.content": "Stav služby byl aktualizován",
   // "ldn-service-delete.notification.success.title": "Successful Deletion",
-  // TODO New key - Add a translation
-  "ldn-service-delete.notification.success.title": "Successful Deletion",
+  "ldn-service-delete.notification.success.title": "Úspěšné odstranění",
   // "ldn-service-delete.notification.success.content": "The service has been deleted",
-  // TODO New key - Add a translation
-  "ldn-service-delete.notification.success.content": "The service has been deleted",
+  "ldn-service-delete.notification.success.content": "Služba byla odstraněna",
   // "ldn-service-delete.notification.error.title": "Failed Deletion",
-  // TODO New key - Add a translation
-  "ldn-service-delete.notification.error.title": "Failed Deletion",
+  "ldn-service-delete.notification.error.title": "Neúspěšné odstranění",
   // "ldn-service-delete.notification.error.content": "The service has not been deleted",
-  // TODO New key - Add a translation
-  "ldn-service-delete.notification.error.content": "The service has not been deleted",
+  "ldn-service-delete.notification.error.content": "Služba nebyla odstraněna",
   // "service.overview.reset-form.reset-return": "Cancel",
-  // TODO New key - Add a translation
-  "service.overview.reset-form.reset-return": "Cancel",
+  "service.overview.reset-form.reset-return": "Zrušit",
   // "service.overview.delete": "Delete service",
-  // TODO New key - Add a translation
-  "service.overview.delete": "Delete service",
+  "service.overview.delete": "Odstranit službu",
   // "ldn-edit-service.title": "Edit service",
-  // TODO New key - Add a translation
-  "ldn-edit-service.title": "Edit service",
+  "ldn-edit-service.title": "Upravit službu",
   // "ldn-edit-service.form.label.name": "Name",
-  // TODO New key - Add a translation
-  "ldn-edit-service.form.label.name": "Name",
+  "ldn-edit-service.form.label.name": "Název",
   // "ldn-edit-service.form.label.description": "Description",
-  // TODO New key - Add a translation
-  "ldn-edit-service.form.label.description": "Description",
+  "ldn-edit-service.form.label.description": "Popis",
   // "ldn-edit-service.form.label.url": "Service URL",
-  // TODO New key - Add a translation
-  "ldn-edit-service.form.label.url": "Service URL",
+  "ldn-edit-service.form.label.url": "URL služby",
   // "ldn-edit-service.form.label.ldnUrl": "LDN Inbox URL",
-  // TODO New key - Add a translation
-  "ldn-edit-service.form.label.ldnUrl": "LDN Inbox URL",
+  "ldn-edit-service.form.label.ldnUrl": "URL LDN schránky",
   // "ldn-edit-service.form.label.inboundPattern": "Inbound Pattern",
-  // TODO New key - Add a translation
-  "ldn-edit-service.form.label.inboundPattern": "Inbound Pattern",
+  "ldn-edit-service.form.label.inboundPattern": "Příchozí vzor",
   // "ldn-edit-service.form.label.noInboundPatternSelected": "No Inbound Pattern",
-  // TODO New key - Add a translation
-  "ldn-edit-service.form.label.noInboundPatternSelected": "No Inbound Pattern",
+  "ldn-edit-service.form.label.noInboundPatternSelected": "Žádný příchozí vzor",
   // "ldn-edit-service.form.label.selectedItemFilter": "Selected Item Filter",
-  // TODO New key - Add a translation
-  "ldn-edit-service.form.label.selectedItemFilter": "Selected Item Filter",
+  "ldn-edit-service.form.label.selectedItemFilter": "Vybraný filtr záznamů",
   // "ldn-edit-service.form.label.selectItemFilter": "No Item Filter",
-  // TODO New key - Add a translation
-  "ldn-edit-service.form.label.selectItemFilter": "No Item Filter",
+  "ldn-edit-service.form.label.selectItemFilter": "Žádný filtr záznamů",
   // "ldn-edit-service.form.label.automatic": "Automatic",
-  // TODO New key - Add a translation
-  "ldn-edit-service.form.label.automatic": "Automatic",
+  "ldn-edit-service.form.label.automatic": "Automaticky",
   // "ldn-edit-service.form.label.addInboundPattern": "+ Add more",
-  // TODO New key - Add a translation
-  "ldn-edit-service.form.label.addInboundPattern": "+ Add more",
+  "ldn-edit-service.form.label.addInboundPattern": "+ Přidat další",
   // "ldn-edit-service.form.label.submit": "Save",
-  // TODO New key - Add a translation
-  "ldn-edit-service.form.label.submit": "Save",
+  "ldn-edit-service.form.label.submit": "Uložit",
   // "ldn-edit-service.breadcrumbs": "Edit Service",
-  // TODO New key - Add a translation
-  "ldn-edit-service.breadcrumbs": "Edit Service",
+  "ldn-edit-service.breadcrumbs": "Upravit službu",
   // "ldn-service.control-constaint-select-none": "Select none",
-  // TODO New key - Add a translation
-  "ldn-service.control-constaint-select-none": "Select none",
+  "ldn-service.control-constaint-select-none": "Zrušit výběr",
 
   // "ldn-register-new-service.notification.error.title": "Error",
-  // TODO New key - Add a translation
-  "ldn-register-new-service.notification.error.title": "Error",
+  "ldn-register-new-service.notification.error.title": "Chyba",
   // "ldn-register-new-service.notification.error.content": "An error occurred while creating this process",
-  // TODO New key - Add a translation
-  "ldn-register-new-service.notification.error.content": "An error occurred while creating this process",
+  "ldn-register-new-service.notification.error.content": "Při vytváření tohoto procesu došlo k chybě",
   // "ldn-register-new-service.notification.success.title": "Success",
-  // TODO New key - Add a translation
-  "ldn-register-new-service.notification.success.title": "Success",
+  "ldn-register-new-service.notification.success.title": "Povedlo se",
   // "ldn-register-new-service.notification.success.content": "The process was successfully created",
-  // TODO New key - Add a translation
-  "ldn-register-new-service.notification.success.content": "The process was successfully created",
+  "ldn-register-new-service.notification.success.content": "Proces byl úspěšně vytvořen",
 
   // "submission.sections.notify.info": "The selected service is compatible with the item according to its current status. {{ service.name }}: {{ service.description }}",
-  // TODO New key - Add a translation
-  "submission.sections.notify.info": "The selected service is compatible with the item according to its current status. {{ service.name }}: {{ service.description }}",
+  "submission.sections.notify.info": "Vybraná služba je kompatibilní se záznamem podle jeho aktuálního stavu. {{ service.name }}: {{ service.description }}",
 
   // "item.page.endorsement": "Endorsement",
-  // TODO New key - Add a translation
-  "item.page.endorsement": "Endorsement",
+  "item.page.endorsement": "Doporučení",
 
   // "item.page.places": "Related places",
-  // TODO New key - Add a translation
-  "item.page.places": "Related places",
+  "item.page.places": "Související místa",
 
   // "item.page.review": "Review",
-  // TODO New key - Add a translation
-  "item.page.review": "Review",
+  "item.page.review": "Recenze",
 
   // "item.page.referenced": "Referenced By",
-  // TODO New key - Add a translation
-  "item.page.referenced": "Referenced By",
+  "item.page.referenced": "Odkazováno od",
 
   // "item.page.supplemented": "Supplemented By",
-  // TODO New key - Add a translation
-  "item.page.supplemented": "Supplemented By",
+  "item.page.supplemented": "Doplněno",
 
   // "menu.section.icon.ldn_services": "LDN Services overview",
-  // TODO New key - Add a translation
-  "menu.section.icon.ldn_services": "LDN Services overview",
+  "menu.section.icon.ldn_services": "Přehled LDN služeb",
 
   // "menu.section.services": "LDN Services",
-  // TODO New key - Add a translation
-  "menu.section.services": "LDN Services",
+  "menu.section.services": "LDN služby",
 
   // "menu.section.services_new": "LDN Service",
-  // TODO New key - Add a translation
-  "menu.section.services_new": "LDN Service",
+  "menu.section.services_new": "LDN služba",
 
   // "quality-assurance.topics.description-with-target": "Below you can see all the topics received from the subscriptions to {{source}} in regards to the",
   // TODO New key - Add a translation

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -51,8 +51,7 @@
   "error-page.orcid.generic-error": "Při přihlašování přes ORCID došlo k chybě. Ujistěte se, že jste sdíleli e-mailovou adresu připojenou ke svému účtu ORCID s DSpace. Pokud chyba přetrvává, kontaktujte správce",
 
   // "listelement.badge.access-status": "Access status:",
-  // TODO New key - Add a translation
-  "listelement.badge.access-status": "Access status:",
+  "listelement.badge.access-status": "Stav přístupu:",
 
   // "access-status.embargo.listelement.badge": "Embargo",
   "access-status.embargo.listelement.badge": "Embargo",
@@ -196,14 +195,12 @@
   "admin.registries.bitstream-formats.table.name": "Název",
 
   // "admin.registries.bitstream-formats.table.selected": "Selected bitstream formats",
-  // TODO New key - Add a translation
-  "admin.registries.bitstream-formats.table.selected": "Selected bitstream formats",
+  "admin.registries.bitstream-formats.table.selected": "Vybrané formáty souborů",
 
   // "admin.registries.bitstream-formats.table.id": "ID",
   "admin.registries.bitstream-formats.table.id": "ID",
 
   // "admin.registries.bitstream-formats.table.return": "Back",
-  // TODO Source message changed - Revise the translation
   "admin.registries.bitstream-formats.table.return": "Zpět",
 
   // "admin.registries.bitstream-formats.table.supportLevel.KNOWN": "Known",
@@ -222,12 +219,10 @@
   "admin.registries.bitstream-formats.title": "Registr formátů souboru",
 
   // "admin.registries.bitstream-formats.select": "Select",
-  // TODO New key - Add a translation
-  "admin.registries.bitstream-formats.select": "Select",
+  "admin.registries.bitstream-formats.select": "Vybrat",
 
   // "admin.registries.bitstream-formats.deselect": "Deselect",
-  // TODO New key - Add a translation
-  "admin.registries.bitstream-formats.deselect": "Deselect",
+  "admin.registries.bitstream-formats.deselect": "Zrušit výběr",
 
   // "admin.registries.metadata.breadcrumbs": "Metadata registry",
   "admin.registries.metadata.breadcrumbs": "Registr metadat",
@@ -254,19 +249,16 @@
   "admin.registries.metadata.schemas.no-items": "Žádná schémata metadat k zobrazení.",
 
   // "admin.registries.metadata.schemas.select": "Select",
-  // TODO New key - Add a translation
-  "admin.registries.metadata.schemas.select": "Select",
+  "admin.registries.metadata.schemas.select": "Vybrat",
 
   // "admin.registries.metadata.schemas.deselect": "Deselect",
-  // TODO New key - Add a translation
-  "admin.registries.metadata.schemas.deselect": "Deselect",
+  "admin.registries.metadata.schemas.deselect": "Zrušit výběr",
 
   // "admin.registries.metadata.schemas.table.delete": "Delete selected",
   "admin.registries.metadata.schemas.table.delete": "Smazat vybrané",
 
   // "admin.registries.metadata.schemas.table.selected": "Selected schemas",
-  // TODO New key - Add a translation
-  "admin.registries.metadata.schemas.table.selected": "Selected schemas",
+  "admin.registries.metadata.schemas.table.selected": "Vybraná schémata",
 
   // "admin.registries.metadata.schemas.table.id": "ID",
   "admin.registries.metadata.schemas.table.id": "ID",
@@ -287,12 +279,10 @@
   "admin.registries.schema.description": "Toto je metadatové schéma pro \"{{namespace}}\".",
 
   // "admin.registries.schema.fields.select": "Select",
-  // TODO New key - Add a translation
-  "admin.registries.schema.fields.select": "Select",
+  "admin.registries.schema.fields.select": "Vybrat",
 
   // "admin.registries.schema.fields.deselect": "Deselect",
-  // TODO New key - Add a translation
-  "admin.registries.schema.fields.deselect": "Deselect",
+  "admin.registries.schema.fields.deselect": "Zrušit výběr",
 
   // "admin.registries.schema.fields.head": "Schema metadata fields",
   "admin.registries.schema.fields.head": "Metadatové pole schématu",
@@ -307,11 +297,9 @@
   "admin.registries.schema.fields.table.field": "Pole",
 
   // "admin.registries.schema.fields.table.selected": "Selected metadata fields",
-  // TODO New key - Add a translation
-  "admin.registries.schema.fields.table.selected": "Selected metadata fields",
+  "admin.registries.schema.fields.table.selected": "Vybraná metadatová pole",
 
   // "admin.registries.schema.fields.table.id": "ID",
-  // TODO Source message changed - Revise the translation
   "admin.registries.schema.fields.table.id": "ID",
 
   // "admin.registries.schema.fields.table.scopenote": "Scope Note",
@@ -366,7 +354,6 @@
   "admin.registries.schema.notification.success": "V pořádku",
 
   // "admin.registries.schema.return": "Back",
-  // TODO Source message changed - Revise the translation
   "admin.registries.schema.return": "Zpět",
 
   // "admin.registries.schema.title": "Metadata Schema Registry",
@@ -415,20 +402,16 @@
   "admin.access-control.epeople.title": "Uživatelé",
 
   // "admin.access-control.epeople.edit.breadcrumbs": "New EPerson",
-  // TODO New key - Add a translation
-  "admin.access-control.epeople.edit.breadcrumbs": "New EPerson",
+  "admin.access-control.epeople.edit.breadcrumbs": "Nový uživatel",
 
   // "admin.access-control.epeople.edit.title": "New EPerson",
-  // TODO New key - Add a translation
-  "admin.access-control.epeople.edit.title": "New EPerson",
+  "admin.access-control.epeople.edit.title": "Nový uživatel",
 
   // "admin.access-control.epeople.add.breadcrumbs": "Add EPerson",
-  // TODO New key - Add a translation
-  "admin.access-control.epeople.add.breadcrumbs": "Add EPerson",
+  "admin.access-control.epeople.add.breadcrumbs": "Přidat uživatele",
 
   // "admin.access-control.epeople.add.title": "Add EPerson",
-  // TODO New key - Add a translation
-  "admin.access-control.epeople.add.title": "Add EPerson",
+  "admin.access-control.epeople.add.title": "Přidat uživatele",
 
   // "admin.access-control.epeople.head": "EPeople",
   "admin.access-control.epeople.head": "Uživatelé",
@@ -443,7 +426,6 @@
   "admin.access-control.epeople.search.scope.metadata": "Metadata",
 
   // "admin.access-control.epeople.search.scope.email": "Email (exact)",
-  // TODO Source message changed - Revise the translation
   "admin.access-control.epeople.search.scope.email": "E-mail (přesný)",
 
   // "admin.access-control.epeople.search.button": "Search",
@@ -462,7 +444,6 @@
   "admin.access-control.epeople.table.name": "Jméno",
 
   // "admin.access-control.epeople.table.email": "Email (exact)",
-  // TODO Source message changed - Revise the translation
   "admin.access-control.epeople.table.email": "E-mail (přesný)",
 
   // "admin.access-control.epeople.table.edit": "Edit",
@@ -509,11 +490,9 @@
   "admin.access-control.epeople.form.lastName": "Příjmení",
 
   // "admin.access-control.epeople.form.email": "Email",
-  // TODO Source message changed - Revise the translation
   "admin.access-control.epeople.form.email": "E-mail",
 
   // "admin.access-control.epeople.form.emailHint": "Must be a valid email address",
-  // TODO Source message changed - Revise the translation
   "admin.access-control.epeople.form.emailHint": "Musí to být platná e-mailová adresa",
 
   // "admin.access-control.epeople.form.canLogIn": "Can log in",
@@ -631,7 +610,7 @@
   "admin.access-control.groups.table.edit.buttons.remove": "Odstranit \"{{name}}\"",
 
   // "admin.access-control.groups.no-items": "No groups found with this in their name or this as UUID",
-  "admin.access-control.groups.no-items": "Nebyla nalezena žádná skupina s tímto v návzvu nebo UUID",
+  "admin.access-control.groups.no-items": "Nebyla nalezena žádná skupina s tímto v názvu nebo UUID",
 
   // "admin.access-control.groups.notification.deleted.success": "Successfully deleted group \"{{name}}\"",
   "admin.access-control.groups.notification.deleted.success": "Úspěšně odstraněna skupina \"{{name}}\"",
@@ -827,7 +806,6 @@
   "admin.access-control.groups.form.subgroups-list.no-subgroups-yet": "Ve skupině zatím nejsou žádné podskupiny.",
 
   // "admin.access-control.groups.form.return": "Back",
-  // TODO Source message changed - Revise the translation
   "admin.access-control.groups.form.return": "Zpět",
 
   // "admin.quality-assurance.breadcrumbs": "Quality Assurance",
@@ -1271,12 +1249,10 @@
   "admin.search.item.edit": "Upravit",
 
   // "admin.search.item.make-private": "Make non-discoverable",
-  // TODO Source message changed - Revise the translation
-  "admin.search.item.make-private": "Učinit nedohledatelným",
+  "admin.search.item.make-private": "Skrýt z vyhledávání",
 
   // "admin.search.item.make-public": "Make discoverable",
-  // TODO Source message changed - Revise the translation
-  "admin.search.item.make-public": "Učinit dohledatelným",
+  "admin.search.item.make-public": "Zpřístupnit ve vyhledávání",
 
   // "admin.search.item.move": "Move",
   "admin.search.item.move": "Přesunout",
@@ -1303,7 +1279,7 @@
   "admin.workflow.item.workflow": "Workflow",
 
   // "admin.workflow.item.workspace": "Workspace",
-  "admin.workflow.item.workspace": "Pracovní prostor",
+  "admin.workflow.item.workspace": "Workspace",
 
   // "admin.workflow.item.delete": "Delete",
   "admin.workflow.item.delete": "Smazat",
@@ -1357,7 +1333,6 @@
   "admin.batch-import.page.dropMsgReplace": "Nahraďte přetažením soubor ZIP k importu",
 
   // "admin.metadata-import.page.button.return": "Back",
-  // TODO Source message changed - Revise the translation
   "admin.metadata-import.page.button.return": "Zpět",
 
   // "admin.metadata-import.page.button.proceed": "Proceed",
@@ -1490,7 +1465,7 @@
   "auth.messages.expired": "Vaše relace vypršela. Přihlaste se prosím znovu.",
 
   // "auth.messages.token-refresh-failed": "Refreshing your session token failed. Please log in again.",
-  "auth.messages.token-refresh-failed": "Nepodařilo se obnovit váš přístupový token. Prosím přihlašte se znovu.",
+  "auth.messages.token-refresh-failed": "Nepodařilo se obnovit váš přístupový token. Prosím, přihlašte se znovu.",
 
   // "bitstream.download.page": "Now downloading {{bitstream}}...",
   "bitstream.download.page": "Nyní se stahuje {{bitstream}}...",
@@ -1595,7 +1570,7 @@
   "bitstream-request-a-copy.header": "Vyžádat si kopii souboru",
 
   // "bitstream-request-a-copy.intro": "Enter the following information to request a copy for the following item: ",
-  "bitstream-request-a-copy.intro": "Zadejte následující informace, abyste si vyžádali kopii následující záznamy: ",
+  "bitstream-request-a-copy.intro": "Zadejte následující informace, abyste si vyžádali kopii následujícího záznamu: ",
 
   // "bitstream-request-a-copy.intro.bitstream.one": "Requesting the following file: ",
   "bitstream-request-a-copy.intro.bitstream.one": "Žádám o kopii následujícího souboru: ",
@@ -1682,8 +1657,7 @@
   "browse.comcol.by.srsc": "Podle předmětu",
 
   // "browse.comcol.by.nsi": "By Norwegian Science Index",
-  // TODO New key - Add a translation
-  "browse.comcol.by.nsi": "By Norwegian Science Index",
+  "browse.comcol.by.nsi": "Podle Norwegian Science Index",
 
   // "browse.comcol.by.title": "By Title",
   "browse.comcol.by.title": "Podle názvu",
@@ -1727,8 +1701,7 @@
   "browse.metadata.srsc.tree.description": "Select a subject to add as search filter",
 
   // "browse.metadata.nsi.breadcrumbs": "Browse by Norwegian Science Index",
-  // TODO New key - Add a translation
-  "browse.metadata.nsi.breadcrumbs": "Browse by Norwegian Science Index",
+  "browse.metadata.nsi.breadcrumbs": "Procházet podle Norwegian Science Index",
 
   // "browse.metadata.nsi.tree.description": "Select an index to add as search filter",
   // TODO New key - Add a translation
@@ -1759,8 +1732,7 @@
   "pagination.next.button.disabled.tooltip": "Žádné další stránky výsledků",
 
   // "pagination.page-number-bar": "Control bar for page navigation, relative to element with ID: ",
-  // TODO New key - Add a translation
-  "pagination.page-number-bar": "Control bar for page navigation, relative to element with ID: ",
+  "pagination.page-number-bar": "Ovládací panel pro navigaci mezi stránkami, vzhledem k prvku s ID:",
 
   // "browse.startsWith": ", starting with {{ startsWith }}",
   "browse.startsWith": ", začíná na {{ startsWith }}",
@@ -1775,7 +1747,6 @@
   "browse.startsWith.choose_year.label": "Vyberte rok vydání",
 
   // "browse.startsWith.jump": "Filter results by year or month",
-  // TODO Source message changed - Revise the translation
   "browse.startsWith.jump": "Filtrovat výsledky podle roku nebo měsíce",
 
   // "browse.startsWith.months.april": "April",
@@ -1821,18 +1792,15 @@
   "browse.startsWith.months.september": "Září",
 
   // "browse.startsWith.submit": "Browse",
-  // TODO Source message changed - Revise the translation
   "browse.startsWith.submit": "Procházet",
 
   // "browse.startsWith.type_date": "Filter results by date",
-  // TODO Source message changed - Revise the translation
   "browse.startsWith.type_date": "Filtrovat výsledky podle data",
 
   // "browse.startsWith.type_date.label": "Or type in a date (year-month) and click on the Browse button",
   "browse.startsWith.type_date.label": "Nebo zadejte datum (rok-měsíc) a klikněte na tlačítko Procházet",
 
   // "browse.startsWith.type_text": "Filter results by typing the first few letters",
-  // TODO Source message changed - Revise the translation
   "browse.startsWith.type_text": "Filtrovat výsledky zadáním několika prvních písmen",
 
   // "browse.startsWith.input": "Filter",
@@ -1842,11 +1810,10 @@
   "browse.taxonomy.button": "Procházet",
 
   // "browse.title": "Browsing by {{ field }}{{ startsWith }} {{ value }}",
-  // TODO Source message changed - Revise the translation
   "browse.title": "Procházet {{ collection }} podle {{ field }}{{ startsWith }} {{ value }}",
 
   // "browse.title.page": "Browsing by {{ field }} {{ value }}",
-  "browse.title.page": "Procházet {{ collection }} podle {{ field }}. {{ value }}",
+  "browse.title.page": "Procházet podle {{ field }} {{ value }}",
 
   // "search.browse.item-back": "Back to Results",
   "search.browse.item-back": "Zpět na seznam výsledků",
@@ -1864,12 +1831,10 @@
   "claimed-declined-task-search-result-list-element.title": "Zamítnuto, posláno zpět správci schvalovacího workflow",
 
   // "collection.create.breadcrumbs": "Create collection",
-  // TODO New key - Add a translation
-  "collection.create.breadcrumbs": "Create collection",
+  "collection.create.breadcrumbs": "Vytvořit kolekci",
 
   // "collection.browse.logo": "Browse for a collection logo",
-  // TODO New key - Add a translation
-  "collection.browse.logo": "Browse for a collection logo",
+  "collection.browse.logo": "Vybrat logo kolekce",
 
   // "collection.create.head": "Create a Collection",
   "collection.create.head": "Vytvořit kolekci",
@@ -2004,7 +1969,6 @@
   "collection.edit.notifications.success": "Úspěšně upravena kolekce",
 
   // "collection.edit.return": "Back",
-  // TODO Source message changed - Revise the translation
   "collection.edit.return": "Zpět",
 
   // "collection.edit.tabs.access-control.head": "Access Control",
@@ -2083,8 +2047,7 @@
   "collection.edit.tabs.source.notifications.discarded.content": "Vaše změny byly zahozeny. Pro obnovení změn klikněte na tlačítko 'Vrátit změny'",
 
   // "collection.edit.tabs.source.notifications.discarded.title": "Changes discarded",
-  // TODO Source message changed - Revise the translation
-  "collection.edit.tabs.source.notifications.discarded.title": "Změny vyřazeny",
+  "collection.edit.tabs.source.notifications.discarded.title": "Zahozené změny",
 
   // "collection.edit.tabs.source.notifications.invalid.content": "Your changes were not saved. Please make sure all fields are valid before you save.",
   "collection.edit.tabs.source.notifications.invalid.content": "Vaše změny nebyly uloženy. Před uložením se prosím ujistěte, že jsou všechna pole platná.",
@@ -2168,8 +2131,7 @@
   "collection.listelement.badge": "Kolekce",
 
   // "collection.logo": "Collection logo",
-  // TODO New key - Add a translation
-  "collection.logo": "Collection logo",
+  "collection.logo": "Logo kolekce",
 
   // "collection.page.browse.search.head": "Search",
   // TODO New key - Add a translation
@@ -2179,7 +2141,7 @@
   "collection.page.edit": "Upravit tuto kolekci",
 
   // "collection.page.handle": "Permanent URI for this collection",
-  "collection.page.handle": "Permanentní URI k tomuto záznamu",
+  "collection.page.handle": "Permanentní URI této kolekce",
 
   // "collection.page.license": "License",
   "collection.page.license": "Licence",
@@ -2206,16 +2168,13 @@
   "collection.select.empty": "Žádná kolekce k zobrazení",
 
   // "collection.select.table.selected": "Selected collections",
-  // TODO New key - Add a translation
-  "collection.select.table.selected": "Selected collections",
+  "collection.select.table.selected": "Vybrané kolekce",
 
   // "collection.select.table.select": "Select collection",
-  // TODO New key - Add a translation
-  "collection.select.table.select": "Select collection",
+  "collection.select.table.select": "Vybrat kolekci",
 
   // "collection.select.table.deselect": "Deselect collection",
-  // TODO New key - Add a translation
-  "collection.select.table.deselect": "Deselect collection",
+  "collection.select.table.deselect": "Zrušit výběr kolekce",
 
   // "collection.select.table.title": "Title",
   "collection.select.table.title": "Název",
@@ -2287,7 +2246,7 @@
   "collection.source.controls.harvest.message": "Informace o harvestu:",
 
   // "collection.source.controls.harvest.no-information": "N/A",
-  "collection.source.controls.harvest.no-information": "Není k dispozi",
+  "collection.source.controls.harvest.no-information": "Není k dispozici",
 
   // "collection.source.update.notifications.error.content": "The provided settings have been tested and didn't work.",
   "collection.source.update.notifications.error.content": "Zadané nastavení bylo otestováno a nefungovalo.",
@@ -2308,24 +2267,20 @@
   "communityList.showMore": "Zobrazit více",
 
   // "communityList.expand": "Expand {{ name }}",
-  // TODO New key - Add a translation
-  "communityList.expand": "Expand {{ name }}",
+  "communityList.expand": "Rozbalit {{ name }}",
 
   // "communityList.collapse": "Collapse {{ name }}",
-  // TODO New key - Add a translation
-  "communityList.collapse": "Collapse {{ name }}",
+  "communityList.collapse": "Sbalit {{ name }}",
 
   // "community.browse.logo": "Browse for a community logo",
-  // TODO New key - Add a translation
-  "community.browse.logo": "Browse for a community logo",
+  "community.browse.logo": "Vybrat logo komunity",
 
   // "community.subcoms-cols.breadcrumbs": "Subcommunities and Collections",
   // TODO New key - Add a translation
   "community.subcoms-cols.breadcrumbs": "Subcommunities and Collections",
 
   // "community.create.breadcrumbs": "Create Community",
-  // TODO New key - Add a translation
-  "community.create.breadcrumbs": "Create Community",
+  "community.create.breadcrumbs": "Vytvořit komunitu",
 
   // "community.create.head": "Create a Community",
   "community.create.head": "Vytvořit komunitu",
@@ -2411,11 +2366,9 @@
   "community.edit.notifications.unauthorized": "K provedení této změny nemáte oprávnění",
 
   // "community.edit.notifications.error": "An error occurred while editing the community",
-  // TODO Source message changed - Revise the translation
   "community.edit.notifications.error": "Při úpravě komunity došlo k chybě",
 
   // "community.edit.return": "Back",
-  // TODO Source message changed - Revise the translation
   "community.edit.return": "Zpět",
 
   // "community.edit.tabs.curate.head": "Curate",
@@ -2452,8 +2405,7 @@
   "community.listelement.badge": "Komunita",
 
   // "community.logo": "Community logo",
-  // TODO New key - Add a translation
-  "community.logo": "Community logo",
+  "community.logo": "Logo komunity",
 
   // "comcol-role.edit.no-group": "None",
   "comcol-role.edit.no-group": "Žádná skupina",
@@ -2520,8 +2472,7 @@
   "comcol-role.edit.bitstream_read.name": "Výchozí přístup ke čtení souboru",
 
   // "comcol-role.edit.bitstream_read.description": "E-People and Groups that can read new bitstreams submitted to this collection. Changes to this role are not retroactive. Existing bitstreams in the system will still be viewable by those who had read access at the time of their addition.",
-  // TODO Source message changed - Revise the translation
-  "comcol-role.edit.bitstream_read.description": "Správci komunit mohou vytvářet podkomunity nebo kolekce a spravovat nebo přidělovat správu těmto podkomunitám nebo kolekcím. Kromě toho rozhodují o tom, kdo může odesílat záznamy do libovolných podkolekcí, upravovat metadata záznamů (po odeslání) a přidávat (mapovat) existující záznamy z jiných kolekcí (na základě oprávnění).",
+  "comcol-role.edit.bitstream_read.description": "Lidé a skupiny, kteří mohou číst nové soubory přidané do této kolekce. Změny v této roli nejsou retroaktivní. Existující soubory budou stále zobrazitelné na základě práv nastavených při jejich přidání.",
 
   // "comcol-role.edit.bitstream_read.anonymous-group": "Default read for incoming bitstreams is currently set to Anonymous.",
   "comcol-role.edit.bitstream_read.anonymous-group": "Výchozí čtení pro příchozí soubory je v současné době nastaveno na hodnotu Anonymní.",
@@ -2572,7 +2523,7 @@
   "community.page.edit": "Upravit tuto komunitu",
 
   // "community.page.handle": "Permanent URI for this community",
-  "community.page.handle": "Stálý URI pro tuto komunitu",
+  "community.page.handle": "Trvalé URI",
 
   // "community.page.license": "License",
   "community.page.license": "Licence",
@@ -2596,11 +2547,9 @@
   "community.search.results.head": "Search Results",
 
   // "community.sub-collection-list.head": "Collections in this community",
-  // TODO Source message changed - Revise the translation
   "community.sub-collection-list.head": "Kolekce této komunity",
 
   // "community.sub-community-list.head": "Communities in this Community",
-  // TODO Source message changed - Revise the translation
   "community.sub-community-list.head": "Komunity této komunity",
 
   // "cookies.consent.accept-all": "Accept all",
@@ -2667,12 +2616,10 @@
   "cookies.consent.content-modal.title": "Informace, které shromažďujeme",
 
   // "cookies.consent.app.title.accessibility": "Accessibility Settings",
-  // TODO New key - Add a translation
-  "cookies.consent.app.title.accessibility": "Accessibility Settings",
+  "cookies.consent.app.title.accessibility": "Nastavení přístupnosti",
 
   // "cookies.consent.app.description.accessibility": "Required for saving your accessibility settings locally",
-  // TODO New key - Add a translation
-  "cookies.consent.app.description.accessibility": "Required for saving your accessibility settings locally",
+  "cookies.consent.app.description.accessibility": "Požadováno pro lokální uložení nastavení přístupnosti",
 
   // "cookies.consent.app.title.authentication": "Authentication",
   "cookies.consent.app.title.authentication": "Ověřování",
@@ -2772,7 +2719,6 @@
   "curation.form.submit.error.head": "Spuštění úlohy správy se nezdařilo.",
 
   // "curation.form.submit.error.content": "An error occurred when trying to start the curation task.",
-  // TODO Source message changed - Revise the translation
   "curation.form.submit.error.content": "Při pokusu o spuštění úlohy správy došlo k chybě.",
 
   // "curation.form.submit.error.invalid-handle": "Couldn't determine the handle for this object",
@@ -2800,19 +2746,16 @@
   "deny-request-copy.intro": "Tato zpráva bude zaslána žadateli o kopii",
 
   // "deny-request-copy.success": "Successfully denied item request",
-  "deny-request-copy.success": "Úspěšně zamítnuta žádost o kopii záznamy",
+  "deny-request-copy.success": "Úspěšně zamítnuta žádost o kopii záznamu",
 
   // "dynamic-list.load-more": "Load more",
-  // TODO New key - Add a translation
-  "dynamic-list.load-more": "Load more",
+  "dynamic-list.load-more": "Načíst další",
 
   // "dropdown.clear": "Clear selection",
-  // TODO New key - Add a translation
-  "dropdown.clear": "Clear selection",
+  "dropdown.clear": "Vymazat výběr",
 
   // "dropdown.clear.tooltip": "Clear the selected option",
-  // TODO New key - Add a translation
-  "dropdown.clear.tooltip": "Clear the selected option",
+  "dropdown.clear.tooltip": "Vymazat vybranou možnost",
 
   // "dso.name.untitled": "Untitled",
   "dso.name.untitled": "Bez názvu",
@@ -2983,7 +2926,7 @@
   "confirmation-modal.delete-eperson.header": "Odstranit uživatele \"{{ dsoName }}\"",
 
   // "confirmation-modal.delete-eperson.info": "Are you sure you want to delete EPerson \"{{ dsoName }}\"",
-  "confirmation-modal.delete-eperson.info": "Určitě chcete odstranit uživatele \"{{ dsoName }}}\"",
+  "confirmation-modal.delete-eperson.info": "Určitě chcete odstranit uživatele \"{{ dsoName }}\"",
 
   // "confirmation-modal.delete-eperson.cancel": "Cancel",
   "confirmation-modal.delete-eperson.cancel": "Zrušit",
@@ -3073,8 +3016,7 @@
   "error.recent-submissions": "Chyba při načítání nedávných příspěvků",
 
   // "error.profile-groups": "Error retrieving profile groups",
-  // TODO New key - Add a translation
-  "error.profile-groups": "Error retrieving profile groups",
+  "error.profile-groups": "Chyba při načítání skupin profilů",
 
   // "error.search-results": "Error fetching search results",
   "error.search-results": "Chyba při načítání výsledků vyhledávání",
@@ -3144,8 +3086,7 @@
   "feed.description": "Synchronizační kanál",
 
   // "file-download-link.restricted": "Restricted bitstream",
-  // TODO New key - Add a translation
-  "file-download-link.restricted": "Restricted bitstream",
+  "file-download-link.restricted": "Soubor s omezeným přístupem",
 
   // "file-download-link.secure-access": "Restricted bitstream available via secure access token",
   // TODO New key - Add a translation
@@ -3158,8 +3099,7 @@
   "footer.copyright": "copyright © 2002-{{ year }}",
 
   // "footer.link.accessibility": "Accessibility settings",
-  // TODO New key - Add a translation
-  "footer.link.accessibility": "Accessibility settings",
+  "footer.link.accessibility": "Nastavení přístupnosti",
 
   // "footer.link.dspace": "DSpace software",
   "footer.link.dspace": "DSpace software",
@@ -3187,7 +3127,6 @@
   "forgot-email.form.header": "Zapomenuté heslo",
 
   // "forgot-email.form.info": "Enter the email address associated with the account.",
-  // TODO Source message changed - Revise the translation
   "forgot-email.form.info": "Zadejte e-mailovou adresu přidruženou k účtu.",
 
   // "forgot-email.form.email": "Email Address *",
@@ -3200,27 +3139,22 @@
   "forgot-email.form.email.error.not-email-form": "Vyplňte prosím platnou e-mailovou adresu",
 
   // "forgot-email.form.email.hint": "An email will be sent to this address with a further instructions.",
-  // TODO Source message changed - Revise the translation
   "forgot-email.form.email.hint": "Na tuto adresu bude zaslán e-mail s dalšími pokyny.",
 
   // "forgot-email.form.submit": "Reset password",
-  // TODO Source message changed - Revise the translation
   "forgot-email.form.submit": "Obnovit heslo",
 
   // "forgot-email.form.success.head": "Password reset email sent",
-  // TODO Source message changed - Revise the translation
   "forgot-email.form.success.head": "E-mail pro obnovení hesla odeslán",
 
   // "forgot-email.form.success.content": "An email has been sent to {{ email }} containing a special URL and further instructions.",
   "forgot-email.form.success.content": "Na adresu {{ email }} byl odeslán e-mail obsahující speciální URL a další instrukce.",
 
   // "forgot-email.form.error.head": "Error when trying to reset password",
-  // TODO Source message changed - Revise the translation
   "forgot-email.form.error.head": "Chyba při pokusu o obnovení hesla",
 
   // "forgot-email.form.error.content": "An error occurred when attempting to reset the password for the account associated with the following email address: {{ email }}",
-  // TODO New key - Add a translation
-  "forgot-email.form.error.content": "An error occurred when attempting to reset the password for the account associated with the following email address: {{ email }}",
+  "forgot-email.form.error.content": "Při pokusu o obnovení hesla k účtu přiřazenému k následující e-mailové adrese došlo k chybě: {{ email }}",
 
   // "forgot-password.title": "Forgot Password",
   "forgot-password.title": "Zapomenuté heslo",
@@ -3229,7 +3163,6 @@
   "forgot-password.form.head": "Zapomenuté heslo",
 
   // "forgot-password.form.info": "Enter a new password in the box below, and confirm it by typing it again into the second box.",
-  // TODO Source message changed - Revise the translation
   "forgot-password.form.info": "Zadejte nové heslo do níže uvedeného pole a potvrďte jej opětovným zadáním do druhého pole.",
 
   // "forgot-password.form.card.security": "Security",
@@ -3248,7 +3181,6 @@
   "forgot-password.form.label.passwordrepeat": "Zadejte znovu pro ověření",
 
   // "forgot-password.form.error.empty-password": "Please enter a password in the boxes above.",
-  // TODO Source message changed - Revise the translation
   "forgot-password.form.error.empty-password": "Zadejte prosím heslo do níže uvedeného pole.",
 
   // "forgot-password.form.error.matching-passwords": "The passwords do not match.",
@@ -3360,19 +3292,16 @@
   "form.search-help": "Klikněte zde pro vyhledání existující korespondence",
 
   // "form.submit": "Save",
-  // TODO Source message changed - Revise the translation
   "form.submit": "Uložit",
 
   // "form.create": "Create",
   "form.create": "Vytvořit",
 
   // "form.number-picker.decrement": "Decrement {{field}}",
-  // TODO New key - Add a translation
-  "form.number-picker.decrement": "Decrement {{field}}",
+  "form.number-picker.decrement": "Snížit {{field}}",
 
   // "form.number-picker.increment": "Increment {{field}}",
-  // TODO New key - Add a translation
-  "form.number-picker.increment": "Increment {{field}}",
+  "form.number-picker.increment": "Zvýšit {{field}}",
 
   // "form.repeatable.sort.tip": "Drop the item in the new position",
   "form.repeatable.sort.tip": "Přetáhněte záznam na novou pozici",
@@ -3511,14 +3440,13 @@
   "health-page.section.solrOaiCore.title": "Solr: oai core",
 
   // "health-page.section.solrSearchCore.title": "Solr: search core",
-  // TODO New key - Add a translation
   "health-page.section.solrSearchCore.title": "Solr: search core",
 
   // "health-page.section.solrStatisticsCore.title": "Solr: statistics core",
   "health-page.section.solrStatisticsCore.title": "Solr: statistics core",
 
   // "health-page.section-info.app.title": "Application Backend",
-  "health-page.section-info.app.title": "Application Backend",
+  "health-page.section-info.app.title": "Aplikační server",
 
   // "health-page.section-info.java.title": "Java",
   "health-page.section-info.java.title": "Java",
@@ -3560,80 +3488,61 @@
   "home.top-level-communities.help": "Vyberte komunitu a procházejte její kolekce.",
 
   // "info.accessibility-settings.breadcrumbs": "Accessibility settings",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.breadcrumbs": "Accessibility settings",
+  "info.accessibility-settings.breadcrumbs": "Nastavení přístupnosti",
 
   // "info.accessibility-settings.cookie-warning": "Saving the accessibility settings is currently not possible. Either log in to save the settings in user data, or accept the 'Accessibility Settings' cookie using the 'Cookie Settings' menu at the bottom of the page. Once the cookie has been accepted, you can reload the page to remove this message.",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.cookie-warning": "Saving the accessibility settings is currently not possible. Either log in to save the settings in user data, or accept the 'Accessibility Settings' cookie using the 'Cookie Settings' menu at the bottom of the page. Once the cookie has been accepted, you can reload the page to remove this message.",
+  "info.accessibility-settings.cookie-warning": "Uložení nastavení přístupnosti momentálně není možné. Přihlaste se pro uložení nastavení do uživatelských dat nebo přijměte cookie 'Nastavení přístupnosti' pomocí menu 'Nastavení cookies' ve spodní části stránky. Po přijetí cookie můžete stránku znovu načíst pro odstranění této zprávy.",
 
   // "info.accessibility-settings.disableNotificationTimeOut.label": "Automatically close notifications after time out",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.disableNotificationTimeOut.label": "Automatically close notifications after time out",
+  "info.accessibility-settings.disableNotificationTimeOut.label": "Automaticky zavřít upozornění po vypršení času",
 
   // "info.accessibility-settings.disableNotificationTimeOut.hint": "When this toggle is activated, notifications will close automatically after the time out passes. When deactivated, notifications will remain open untill manually closed.",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.disableNotificationTimeOut.hint": "When this toggle is activated, notifications will close automatically after the time out passes. When deactivated, notifications will remain open untill manually closed.",
+  "info.accessibility-settings.disableNotificationTimeOut.hint": "Když je tento přepínač aktivován, upozornění se automaticky zavřou po uplynutí času. Pokud je deaktivován, upozornění zůstanou otevřená, dokud je ručně nezavřete.",
 
   // "info.accessibility-settings.failed-notification": "Failed to save accessibility settings",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.failed-notification": "Failed to save accessibility settings",
+  "info.accessibility-settings.failed-notification": "Nepodařilo se uložit nastavení přístupnosti",
 
   // "info.accessibility-settings.invalid-form-notification": "Did not save. The form contains invalid values.",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.invalid-form-notification": "Did not save. The form contains invalid values.",
+  "info.accessibility-settings.invalid-form-notification": "Uložení selhalo. Formulář obsahuje neplatné hodnoty.",
 
   // "info.accessibility-settings.liveRegionTimeOut.label": "ARIA Live region time out (in seconds)",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.liveRegionTimeOut.label": "ARIA Live region time out (in seconds)",
+  "info.accessibility-settings.liveRegionTimeOut.label": "Časový limit ARIA Live region (v sekundách)",
 
   // "info.accessibility-settings.liveRegionTimeOut.hint": "The duration after which a message in the ARIA live region disappears. ARIA live regions are not visible on the page, but provide announcements of notifications (or other actions) to screen readers.",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.liveRegionTimeOut.hint": "The duration after which a message in the ARIA live region disappears. ARIA live regions are not visible on the page, but provide announcements of notifications (or other actions) to screen readers.",
+  "info.accessibility-settings.liveRegionTimeOut.hint": "Doba, po kterou zpráva v ARIA Live region zůstává viditelná. ARIA Live regiony nejsou viditelné na stránce, ale poskytují oznámení pro čtečky obrazovky.",
 
   // "info.accessibility-settings.liveRegionTimeOut.invalid": "Live region time out must be greater than 0",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.liveRegionTimeOut.invalid": "Live region time out must be greater than 0",
+  "info.accessibility-settings.liveRegionTimeOut.invalid": "Časový limit ARIA Live region musí být větší než 0",
 
   // "info.accessibility-settings.notificationTimeOut.label": "Notification time out (in seconds)",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.notificationTimeOut.label": "Notification time out (in seconds)",
+  "info.accessibility-settings.notificationTimeOut.label": "Časový limit upozornění (v sekundách)",
 
   // "info.accessibility-settings.notificationTimeOut.hint": "The duration after which a notification disappears.",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.notificationTimeOut.hint": "The duration after which a notification disappears.",
+  "info.accessibility-settings.notificationTimeOut.hint": "Doba, po které upozornění zmizí.",
 
   // "info.accessibility-settings.notificationTimeOut.invalid": "Notification time out must be greater than 0",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.notificationTimeOut.invalid": "Notification time out must be greater than 0",
+  "info.accessibility-settings.notificationTimeOut.invalid": "Časový limit upozornění musí být větší než 0",
 
   // "info.accessibility-settings.save-notification.cookie": "Successfully saved settings locally.",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.save-notification.cookie": "Successfully saved settings locally.",
+  "info.accessibility-settings.save-notification.cookie": "Nastavení úspěšně uloženo lokálně.",
 
   // "info.accessibility-settings.save-notification.metadata": "Successfully saved settings on the user profile.",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.save-notification.metadata": "Successfully saved settings on the user profile.",
+  "info.accessibility-settings.save-notification.metadata": "Nastavení úspěšně uloženo v uživatelském profilu.",
 
   // "info.accessibility-settings.reset-failed": "Failed to reset. Either log in or accept the 'Accessibility Settings' cookie.",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.reset-failed": "Failed to reset. Either log in or accept the 'Accessibility Settings' cookie.",
+  "info.accessibility-settings.reset-failed": "Nepodařilo se resetovat. Přihlaste se nebo přijměte cookie 'Nastavení přístupnosti'.",
 
   // "info.accessibility-settings.reset-notification": "Successfully reset settings.",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.reset-notification": "Successfully reset settings.",
+  "info.accessibility-settings.reset-notification": "Nastavení bylo úspěšně resetováno.",
 
   // "info.accessibility-settings.reset": "Reset accessibility settings",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.reset": "Reset accessibility settings",
+  "info.accessibility-settings.reset": "Resetovat nastavení přístupnosti",
 
   // "info.accessibility-settings.submit": "Save accessibility settings",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.submit": "Save accessibility settings",
+  "info.accessibility-settings.submit": "Uložit nastavení přístupnosti",
 
   // "info.accessibility-settings.title": "Accessibility settings",
-  // TODO New key - Add a translation
-  "info.accessibility-settings.title": "Accessibility settings",
+  "info.accessibility-settings.title": "Nastavení přístupnosti",
 
   // "info.end-user-agreement.accept": "I have read and I agree to the End User Agreement",
   "info.end-user-agreement.accept": "Přečetl/a jsem si a souhlasím se smlouvou s koncovým uživatelem",
@@ -3739,11 +3648,9 @@
   "item.edit.authorizations.title": "Upravit politiky záznamu",
 
   // "item.badge.status": "Item status:",
-  // TODO New key - Add a translation
-  "item.badge.status": "Item status:",
+  "item.badge.status": "Stav položky:",
 
   // "item.badge.private": "Non-discoverable",
-  // TODO Source message changed - Revise the translation
   "item.badge.private": "Nedohledatelné",
 
   // "item.badge.withdrawn": "Withdrawn",
@@ -3753,7 +3660,6 @@
   "item.bitstreams.upload.bundle": "Svazek",
 
   // "item.bitstreams.upload.bundle.placeholder": "Select a bundle or input new bundle name",
-  // TODO Source message changed - Revise the translation
   "item.bitstreams.upload.bundle.placeholder": "Vyberte svazek nebo zadejte nový název svazku",
 
   // "item.bitstreams.upload.bundle.new": "Create bundle",
@@ -3793,18 +3699,16 @@
   "item.edit.bitstreams.bundle.load.all": "Načíst všechny ({{ total }})",
 
   // "item.edit.bitstreams.bundle.load.more": "Load more",
-  "item.edit.bitstreams.bundle.load.more": "Načíst více",
+  "item.edit.bitstreams.bundle.load.more": "Načíst další",
 
   // "item.edit.bitstreams.bundle.name": "BUNDLE: {{ name }}",
   "item.edit.bitstreams.bundle.name": "Svazek: {{ name }}",
 
   // "item.edit.bitstreams.bundle.table.aria-label": "Bitstreams in the  {{ bundle }} Bundle",
-  // TODO New key - Add a translation
-  "item.edit.bitstreams.bundle.table.aria-label": "Bitstreams in the  {{ bundle }} Bundle",
+  "item.edit.bitstreams.bundle.table.aria-label": "Soubory v balíčku {{ bundle }}",
 
   // "item.edit.bitstreams.bundle.tooltip": "You can move a bitstream to a different page by dropping it on the page number.",
-  // TODO New key - Add a translation
-  "item.edit.bitstreams.bundle.tooltip": "You can move a bitstream to a different page by dropping it on the page number.",
+  "item.edit.bitstreams.bundle.tooltip": "Soubor lze přesunout na jinou stránku přetažením na číslo stránky.",
 
   // "item.edit.bitstreams.discard-button": "Discard",
   "item.edit.bitstreams.discard-button": "Zahodit",
@@ -3825,31 +3729,25 @@
   "item.edit.bitstreams.edit.buttons.undo": "Vrátit změny",
 
   // "item.edit.bitstreams.edit.live.cancel": "{{ bitstream }} was returned to position {{ toIndex }} and is no longer selected.",
-  // TODO New key - Add a translation
-  "item.edit.bitstreams.edit.live.cancel": "{{ bitstream }} was returned to position {{ toIndex }} and is no longer selected.",
+  "item.edit.bitstreams.edit.live.cancel": "{{ bitstream }} byl vrácen na pozici {{ toIndex }} a již není vybrán.",
 
   // "item.edit.bitstreams.edit.live.clear": "{{ bitstream }} is no longer selected.",
-  // TODO New key - Add a translation
-  "item.edit.bitstreams.edit.live.clear": "{{ bitstream }} is no longer selected.",
+  "item.edit.bitstreams.edit.live.clear": "{{ bitstream }} již není vybrán.",
 
   // "item.edit.bitstreams.edit.live.loading": "Waiting for move to complete.",
-  // TODO New key - Add a translation
-  "item.edit.bitstreams.edit.live.loading": "Waiting for move to complete.",
+  "item.edit.bitstreams.edit.live.loading": "Čeká se na dokončení přesunu.",
 
   // "item.edit.bitstreams.edit.live.select": "{{ bitstream }} is selected.",
-  // TODO New key - Add a translation
-  "item.edit.bitstreams.edit.live.select": "{{ bitstream }} is selected.",
+  "item.edit.bitstreams.edit.live.select": "{{ bitstream }} je vybrán.",
 
   // "item.edit.bitstreams.edit.live.move": "{{ bitstream }} is now in position {{ toIndex }}.",
-  // TODO New key - Add a translation
-  "item.edit.bitstreams.edit.live.move": "{{ bitstream }} is now in position {{ toIndex }}.",
+  "item.edit.bitstreams.edit.live.move": "{{ bitstream }} je nyní na pozici {{ toIndex }}.",
 
   // "item.edit.bitstreams.empty": "This item doesn't contain any bitstreams. Click the upload button to create one.",
   "item.edit.bitstreams.empty": "Tento záznam neobsahuje žádné soubory. Klikněte na tlačítko pro nahrání a nějaký vytvořte.",
 
   // "item.edit.bitstreams.info-alert": "Bitstreams can be reordered within their bundles by holding the drag handle and moving the mouse. Alternatively, bitstreams can be moved using the keyboard in the following way: Select the bitstream by pressing enter when the bitstream's drag handle is in focus. Move the bitstream up or down using the arrow keys. Press enter again to confirm the current position of the bitstream.",
-  // TODO New key - Add a translation
-  "item.edit.bitstreams.info-alert": "Bitstreams can be reordered within their bundles by holding the drag handle and moving the mouse. Alternatively, bitstreams can be moved using the keyboard in the following way: Select the bitstream by pressing enter when the bitstream's drag handle is in focus. Move the bitstream up or down using the arrow keys. Press enter again to confirm the current position of the bitstream.",
+  "item.edit.bitstreams.info-alert": "Soubory lze přeskupovat v jejich balíčcích podržením uchopovacího bodu a pohybem myši. Alternativně lze soubor přesunout pomocí klávesnice: Vyberte soubor stisknutím Enter, když je uchopovací bod souboru v popředí. Přesuňte soubor nahoru nebo dolů pomocí šipek. Stiskněte Enter znovu pro potvrzení aktuální pozice souboru.",
 
   // "item.edit.bitstreams.headers.actions": "Actions",
   "item.edit.bitstreams.headers.actions": "Akce",
@@ -3906,8 +3804,7 @@
   "item.edit.bitstreams.upload-button": "Nahrát",
 
   // "item.edit.bitstreams.load-more.link": "Load more",
-  // TODO New key - Add a translation
-  "item.edit.bitstreams.load-more.link": "Load more",
+  "item.edit.bitstreams.load-more.link": "Načíst další",
 
   // "item.edit.delete.cancel": "Cancel",
   "item.edit.delete.cancel": "Zrušit",
@@ -4066,12 +3963,10 @@
   "item.edit.metadata.discard-button": "Vyřadit",
 
   // "item.edit.metadata.edit.language": "Edit language",
-  // TODO New key - Add a translation
-  "item.edit.metadata.edit.language": "Edit language",
+  "item.edit.metadata.edit.language": "Upravit jazyk",
 
   // "item.edit.metadata.edit.value": "Edit value",
-  // TODO New key - Add a translation
-  "item.edit.metadata.edit.value": "Edit value",
+  "item.edit.metadata.edit.value": "Upravit hodnotu",
 
   // "item.edit.metadata.edit.authority.key": "Edit authority key",
   // TODO New key - Add a translation
@@ -4122,8 +4017,7 @@
   "item.edit.metadata.headers.value": "Hodnota",
 
   // "item.edit.metadata.metadatafield": "Edit field",
-  // TODO New key - Add a translation
-  "item.edit.metadata.metadatafield": "Edit field",
+  "item.edit.metadata.metadatafield": "Upravit pole",
 
   // "item.edit.metadata.metadatafield.error": "An error occurred validating the metadata field",
   "item.edit.metadata.metadatafield.error": "Při ověřování metadatového pole se vyskytla chyba",
@@ -4135,7 +4029,6 @@
   "item.edit.metadata.notifications.discarded.content": "Vaše změny byly zahozeny. Pro obnovení změn klikněte na tlačítko 'Vrátit změny'",
 
   // "item.edit.metadata.notifications.discarded.title": "Changes discarded",
-  // TODO Source message changed - Revise the translation
   "item.edit.metadata.notifications.discarded.title": "Zahozené změny",
 
   // "item.edit.metadata.notifications.error.title": "An error occurred",
@@ -4151,7 +4044,6 @@
   "item.edit.metadata.notifications.outdated.content": "Záznam, na kterém právě pracujete, byl změněn jiným uživatelem. Vaše aktuální změny byly zahozeny, aby se zabránilo konfliktům",
 
   // "item.edit.metadata.notifications.outdated.title": "Changes outdated",
-  // TODO Source message changed - Revise the translation
   "item.edit.metadata.notifications.outdated.title": "Změny jsou zastaralé",
 
   // "item.edit.metadata.notifications.saved.content": "Your changes to this item's metadata were saved.",
@@ -4191,7 +4083,6 @@
   "item.edit.modify.overview.value": "Hodnota",
 
   // "item.edit.move.cancel": "Back",
-  // TODO Source message changed - Revise the translation
   "item.edit.move.cancel": "Zpět",
 
   // "item.edit.move.save-button": "Save",
@@ -4216,8 +4107,7 @@
   "item.edit.move.inheritpolicies.description": "Zdědit výchozí politiky cílové kolekce",
 
   // "item.edit.move.inheritpolicies.tooltip": "Warning: When enabled, the read access policy for the item and any files associated with the item will be replaced by the default read access policy of the collection. This cannot be undone.",
-  // TODO New key - Add a translation
-  "item.edit.move.inheritpolicies.tooltip": "Warning: When enabled, the read access policy for the item and any files associated with the item will be replaced by the default read access policy of the collection. This cannot be undone.",
+  "item.edit.move.inheritpolicies.tooltip": "Upozornění: Pokud je povoleno, bude politika čtení pro položku a všechny soubory s ní spojené nahrazena výchozí politikou čtení sbírky. Tuto akci nelze vrátit zpět.",
 
   // "item.edit.move.move": "Move",
   "item.edit.move.move": "Přesunout",
@@ -4238,44 +4128,36 @@
   "item.edit.private.cancel": "Zrušit",
 
   // "item.edit.private.confirm": "Make it non-discoverable",
-  // TODO Source message changed - Revise the translation
   "item.edit.private.confirm": "Učinit nedohledatelným",
 
   // "item.edit.private.description": "Are you sure this item should be made non-discoverable in the archive?",
-  // TODO Source message changed - Revise the translation
   "item.edit.private.description": "Jste si jisti, že by tento záznam neměl být v archivu objeven?",
 
   // "item.edit.private.error": "An error occurred while making the item non-discoverable",
-  // TODO Source message changed - Revise the translation
   "item.edit.private.error": "Při změně stavu záznamu na nedohledatelný došlo k chybě",
 
   // "item.edit.private.header": "Make item non-discoverable: {{ id }}",
   "item.edit.private.header": "Změnit stav záznamu na nedohledatelný: {{ id }}",
 
   // "item.edit.private.success": "The item is now non-discoverable",
-  // TODO Source message changed - Revise the translation
   "item.edit.private.success": "Záznam je nyní nedohledatelný",
 
   // "item.edit.public.cancel": "Cancel",
   "item.edit.public.cancel": "Zrušit",
 
   // "item.edit.public.confirm": "Make it discoverable",
-  // TODO Source message changed - Revise the translation
   "item.edit.public.confirm": "Učinit dohledatelným",
 
   // "item.edit.public.description": "Are you sure this item should be made discoverable in the archive?",
-  // TODO Source message changed - Revise the translation
   "item.edit.public.description": "Jste si jisti, že by tento záznam měl být v archivu dohledatelný?",
 
   // "item.edit.public.error": "An error occurred while making the item discoverable",
-  // TODO Source message changed - Revise the translation
-  "item.edit.public.error": "Při změně záznamu na dohledatelnou došlo k chybě",
+  "item.edit.public.error": "Při změně záznamu na dohledatelný došlo k chybě",
 
   // "item.edit.public.header": "Make item discoverable: {{ id }}",
   "item.edit.public.header": "Učinit záznam dohledatelným: {{ id }}",
 
   // "item.edit.public.success": "The item is now discoverable",
-  // TODO Source message changed - Revise the translation
   "item.edit.public.success": "Záznam je nyní dohledatelný",
 
   // "item.edit.reinstate.cancel": "Cancel",
@@ -4339,7 +4221,7 @@
   "item.edit.relationships.save-button": "Uložit",
 
   // "item.edit.relationships.no-entity-type": "Add 'dspace.entity.type' metadata to enable relationships for this item",
-  "item.edit.relationships.no-entity-type": "Přidat metadata 'dspace.entity.type' pro povolení vztahů pro tuto záznam",
+  "item.edit.relationships.no-entity-type": "Přidat metadata 'dspace.entity.type' pro povolení vztahů pro tento záznam",
 
   // "item.edit.return": "Back",
   "item.edit.return": "Zpět",
@@ -4402,19 +4284,15 @@
   "item.edit.tabs.status.buttons.move.label": "Přesunout záznam do jiné kolekce",
 
   // "item.edit.tabs.status.buttons.private.button": "Make it non-discoverable...",
-  // TODO Source message changed - Revise the translation
   "item.edit.tabs.status.buttons.private.button": "Učinit nedohledatelným...",
 
   // "item.edit.tabs.status.buttons.private.label": "Make item non-discoverable",
-  // TODO Source message changed - Revise the translation
   "item.edit.tabs.status.buttons.private.label": "Učinit záznam nedohledatelným",
 
   // "item.edit.tabs.status.buttons.public.button": "Make it discoverable...",
-  // TODO Source message changed - Revise the translation
   "item.edit.tabs.status.buttons.public.button": "Učinit dohledatelným...",
 
   // "item.edit.tabs.status.buttons.public.label": "Make item discoverable",
-  // TODO Source message changed - Revise the translation
   "item.edit.tabs.status.buttons.public.label": "Učinit záznam dohledatelným",
 
   // "item.edit.tabs.status.buttons.reinstate.button": "Reinstate...",
@@ -4562,7 +4440,7 @@
   "item.page.dcterms.spatial": "Geospatial point",
 
   // "item.search.results.head": "Item Search Results",
-  "item.search.results.head": "Výsleky vyhledávání",
+  "item.search.results.head": "Výsledky vyhledávání",
 
   // "item.search.title": "Item Search",
   "item.search.title": "Hledat",
@@ -4699,7 +4577,7 @@
   "item.page.journal.search.title": "Články v tomto časopise",
 
   // "item.page.link.full": "Full item page",
-  "item.page.link.full": "Zobrazit úplný záznam",
+  "item.page.link.full": "Zobrazit celý záznam",
 
   // "item.page.link.simple": "Simple item page",
   "item.page.link.simple": "Zobrazit minimální záznam",
@@ -4772,7 +4650,6 @@
   "item.page.reinstate": "Request reinstatement",
 
   // "item.page.version.hasDraft": "A new version cannot be created because there is an in-progress submission in the version history",
-  // TODO Source message changed - Revise the translation
   "item.page.version.hasDraft": "Nová verze nemůže být vytvořena, protože v historii verzí už další rozpracovaná verze existuje.",
 
   // "item.page.claim.button": "Claim",
@@ -4839,19 +4716,15 @@
   "item.preview.oaire.citation.endPage": "Citation end page",
 
   // "item.preview.dc.relation.hasversion": "Has version",
-  // TODO New key - Add a translation
-  "item.preview.dc.relation.hasversion": "Has version",
+  "item.preview.dc.relation.hasversion": "Má verzi",
 
   // "item.preview.dc.relation.ispartofseries": "Is part of series",
-  // TODO New key - Add a translation
-  "item.preview.dc.relation.ispartofseries": "Is part of series",
+  "item.preview.dc.relation.ispartofseries": "Je součástí série",
 
   // "item.preview.dc.rights": "Rights",
-  // TODO New key - Add a translation
-  "item.preview.dc.rights": "Rights",
+  "item.preview.dc.rights": "Práva",
 
   // "item.preview.dc.identifier.other": "Other Identifier",
-  // TODO Source message changed - Revise the translation
   "item.preview.dc.identifier.other": "Další identifikátor:",
 
   // "item.preview.dc.relation.issn": "ISSN",
@@ -4966,16 +4839,13 @@
   "item.select.empty": "Žádné záznamy k zobrazení",
 
   // "item.select.table.selected": "Selected items",
-  // TODO New key - Add a translation
-  "item.select.table.selected": "Selected items",
+  "item.select.table.selected": "Vybrané položky",
 
   // "item.select.table.select": "Select item",
-  // TODO New key - Add a translation
-  "item.select.table.select": "Select item",
+  "item.select.table.select": "Vybrat položku",
 
   // "item.select.table.deselect": "Deselect item",
-  // TODO New key - Add a translation
-  "item.select.table.deselect": "Deselect item",
+  "item.select.table.deselect": "Zrušit výběr položky",
 
   // "item.select.table.author": "Author",
   "item.select.table.author": "Autor",
@@ -4993,7 +4863,6 @@
   "item.version.history.head": "Historie verzí",
 
   // "item.version.history.return": "Back",
-  // TODO Source message changed - Revise the translation
   "item.version.history.return": "Zpět",
 
   // "item.version.history.selected": "Selected version",
@@ -5045,7 +4914,6 @@
   "item.version.history.table.action.deleteVersion": "Smazat verzi",
 
   // "item.version.history.table.action.hasDraft": "A new version cannot be created because there is an in-progress submission in the version history",
-  // TODO Source message changed - Revise the translation
   "item.version.history.table.action.hasDraft": "Nová verze nemůže být vytvořena, protože v historii verzí už další rozpracovaná verze existuje.",
 
   // "item.version.notice": "This is not the latest version of this item. The latest version can be found <a href='{{destination}}'>here</a>.",
@@ -5159,7 +5027,6 @@
   "item.version.create.notification.failure": "Nová verze nebyla vytvořena",
 
   // "item.version.create.notification.inProgress": "A new version cannot be created because there is an in-progress submission in the version history",
-  // TODO Source message changed - Revise the translation
   "item.version.create.notification.inProgress": "Nová verze nemůže být vytvořena, protože v historii verzí už další rozpracovaná verze existuje.",
 
   // "item.version.delete.modal.header": "Delete version",
@@ -5199,12 +5066,10 @@
   "itemtemplate.edit.metadata.discard-button": "Vyřadit",
 
   // "itemtemplate.edit.metadata.edit.language": "Edit language",
-  // TODO New key - Add a translation
-  "itemtemplate.edit.metadata.edit.language": "Edit language",
+  "itemtemplate.edit.metadata.edit.language": "Upravit jazyk",
 
   // "itemtemplate.edit.metadata.edit.value": "Edit value",
-  // TODO New key - Add a translation
-  "itemtemplate.edit.metadata.edit.value": "Edit value",
+  "itemtemplate.edit.metadata.edit.value": "Upravit hodnotu",
 
   // "itemtemplate.edit.metadata.edit.buttons.confirm": "Confirm",
   "itemtemplate.edit.metadata.edit.buttons.confirm": "Potvrdit",
@@ -5240,8 +5105,7 @@
   "itemtemplate.edit.metadata.headers.value": "Hodnota",
 
   // "itemtemplate.edit.metadata.metadatafield": "Edit field",
-  // TODO New key - Add a translation
-  "itemtemplate.edit.metadata.metadatafield": "Edit field",
+  "itemtemplate.edit.metadata.metadatafield": "Upravit pole",
 
   // "itemtemplate.edit.metadata.metadatafield.error": "An error occurred validating the metadata field",
   "itemtemplate.edit.metadata.metadatafield.error": "Při ověřování metadatového pole se vyskytla chyba",
@@ -5514,8 +5378,7 @@
   "logout.title": "Odhlášení",
 
   // "menu.header.nav.description": "Admin navigation bar",
-  // TODO New key - Add a translation
-  "menu.header.nav.description": "Admin navigation bar",
+  "menu.header.nav.description": "Navigační lišta administrátora",
 
   // "menu.header.admin": "Management",
   "menu.header.admin": "Admin",
@@ -5584,8 +5447,7 @@
   "menu.section.browse_global_by_srsc": "Podle předmětové kategorie",
 
   // "menu.section.browse_global_by_nsi": "By Norwegian Science Index",
-  // TODO New key - Add a translation
-  "menu.section.browse_global_by_nsi": "By Norwegian Science Index",
+  "menu.section.browse_global_by_nsi": "Podle Norwegian Science Index",
 
   // "menu.section.browse_global_by_title": "By Title",
   "menu.section.browse_global_by_title": "Podle názvu",
@@ -5868,26 +5730,22 @@
   "mydspace.results.no-title": "Žádný název",
 
   // "mydspace.results.no-uri": "No URI",
-  // TODO Source message changed - Revise the translation
-  "mydspace.results.no-uri": "Žádné Uri",
+  "mydspace.results.no-uri": "Žádné URI",
 
   // "mydspace.search-form.placeholder": "Search in MyDSpace...",
   "mydspace.search-form.placeholder": "Hledat v mém dspace...",
 
   // "mydspace.show.workflow": "Workflow tasks",
-  // TODO Source message changed - Revise the translation
   "mydspace.show.workflow": "Úlohy workflow",
 
   // "mydspace.show.workspace": "Your submissions",
-  // TODO Source message changed - Revise the translation
   "mydspace.show.workspace": "Vaše záznamy",
 
   // "mydspace.show.supervisedWorkspace": "Supervised items",
   "mydspace.show.supervisedWorkspace": "Záznamy pod dohledem",
 
   // "mydspace.status": "My DSpace status:",
-  // TODO New key - Add a translation
-  "mydspace.status": "My DSpace status:",
+  "mydspace.status": "Stav mého DSpace:",
 
   // "mydspace.status.mydspaceArchived": "Archived",
   "mydspace.status.mydspaceArchived": "Archivováno",
@@ -5899,11 +5757,10 @@
   "mydspace.status.mydspaceWaitingController": "Čeká na kontrolu",
 
   // "mydspace.status.mydspaceWorkflow": "Workflow",
-  // TODO New key - Add a translation
   "mydspace.status.mydspaceWorkflow": "Workflow",
 
   // "mydspace.status.mydspaceWorkspace": "Workspace",
-  "mydspace.status.mydspaceWorkspace": "Pracovní prostor",
+  "mydspace.status.mydspaceWorkspace": "Workspace",
 
   // "mydspace.title": "MyDSpace",
   "mydspace.title": "Můj DSpace",
@@ -5924,8 +5781,7 @@
   "mydspace.view-btn": "Zobrazit",
 
   // "nav.expandable-navbar-section-suffix": "(submenu)",
-  // TODO New key - Add a translation
-  "nav.expandable-navbar-section-suffix": "(submenu)",
+  "nav.expandable-navbar-section-suffix": "(podnabídka)",
 
   // "notification.suggestion": "We found <b>{{count}} publications</b> in the {{source}} that seems to be related to your profile.<br>",
   // TODO New key - Add a translation
@@ -5991,8 +5847,7 @@
   "nav.user.description": "Panel uživatelského profilu ",
 
   // "listelement.badge.dso-type": "Item type:",
-  // TODO New key - Add a translation
-  "listelement.badge.dso-type": "Item type:",
+  "listelement.badge.dso-type": "Typ položky:",
 
   // "none.listelement.badge": "Item",
   "none.listelement.badge": "Záznam",
@@ -6321,8 +6176,7 @@
   "orgunit.page.ror": "ROR Identifier",
 
   // "orgunit.search.results.head": "Organizational Unit Search Results",
-  // TODO New key - Add a translation
-  "orgunit.search.results.head": "Organizational Unit Search Results",
+  "orgunit.search.results.head": "Výsledky hledání organizační jednotky",
 
   // "pagination.options.description": "Pagination options",
   "pagination.options.description": "Možnosti stránkování",
@@ -6395,26 +6249,21 @@
   "process.new.select-parameters": "Parametry",
 
   // "process.new.select-parameter": "Select parameter",
-  // TODO New key - Add a translation
-  "process.new.select-parameter": "Select parameter",
+  "process.new.select-parameter": "Vyberte parametr",
 
   // "process.new.add-parameter": "Add a parameter...",
-  // TODO New key - Add a translation
-  "process.new.add-parameter": "Add a parameter...",
+  "process.new.add-parameter": "Přidat parametr...",
 
   // "process.new.delete-parameter": "Delete parameter",
-  // TODO New key - Add a translation
-  "process.new.delete-parameter": "Delete parameter",
+  "process.new.delete-parameter": "Odstranit parametr",
 
   // "process.new.parameter.label": "Parameter value",
-  // TODO New key - Add a translation
-  "process.new.parameter.label": "Parameter value",
+  "process.new.parameter.label": "Hodnota parametru",
 
   // "process.new.cancel": "Cancel",
   "process.new.cancel": "Zrušit",
 
   // "process.new.submit": "Save",
-  // TODO Source message changed - Revise the translation
   "process.new.submit": "Uložit",
 
   // "process.new.select-script": "Script",
@@ -6614,8 +6463,7 @@
   "process.overview.delete": "Smazat {{count}} procesů",
 
   // "process.overview.delete-process": "Delete process",
-  // TODO New key - Add a translation
-  "process.overview.delete-process": "Delete process",
+  "process.overview.delete-process": "Odstranit proces",
 
   // "process.overview.delete.clear": "Clear delete selection",
   "process.overview.delete.clear": "Zrušit výběr mazání",
@@ -6630,8 +6478,7 @@
   "process.overview.delete.header": "Smazat procesy",
 
   // "process.overview.unknown.user": "Unknown",
-  // TODO New key - Add a translation
-  "process.overview.unknown.user": "Unknown",
+  "process.overview.unknown.user": "Neznámý",
 
   // "process.bulk.delete.error.head": "Error on deleteing process",
   "process.bulk.delete.error.head": "Chyba při mazání procesu",
@@ -6646,16 +6493,13 @@
   "profile.breadcrumbs": "Aktualizovat profil",
 
   // "profile.card.accessibility.content": "Accessibility settings can be configured on the accessibility settings page.",
-  // TODO New key - Add a translation
-  "profile.card.accessibility.content": "Accessibility settings can be configured on the accessibility settings page.",
+  "profile.card.accessibility.content": "Nastavení přístupnosti lze upravit na stránce nastavení přístupnosti.",
 
   // "profile.card.accessibility.header": "Accessibility",
-  // TODO New key - Add a translation
-  "profile.card.accessibility.header": "Accessibility",
+  "profile.card.accessibility.header": "Přístupnost",
 
   // "profile.card.accessibility.link": "Go to Accessibility Settings Page",
-  // TODO New key - Add a translation
-  "profile.card.accessibility.link": "Go to Accessibility Settings Page",
+  "profile.card.accessibility.link": "Přejít na stránku nastavení přístupnosti",
 
   // "profile.card.identify": "Identify",
   "profile.card.identify": "Identifikace",
@@ -6664,7 +6508,6 @@
   "profile.card.security": "Zabezpečení",
 
   // "profile.form.submit": "Save",
-  // TODO Source message changed - Revise the translation
   "profile.form.submit": "Uložit",
 
   // "profile.groups.head": "Authorization groups you belong to",
@@ -6710,7 +6553,6 @@
   "profile.security.form.error.matching-passwords": "Hesla se neshodují.",
 
   // "profile.security.form.info": "Optionally, you can enter a new password in the box below, and confirm it by typing it again into the second box.",
-  // TODO Source message changed - Revise the translation
   "profile.security.form.info": "Volitelně můžete zadat nové heslo do políčka níže a potvrdit je opětovným zadáním do druhého políčka.",
 
   // "profile.security.form.label.password": "Password",
@@ -6762,7 +6604,7 @@
   "project.page.expectedcompletion": "Předpokládané dokončení",
 
   // "project.page.funder": "Funders",
-  "project.page.funder": "Poskytovatelé finací",
+  "project.page.funder": "Poskytovatelé financí",
 
   // "project.page.id": "ID",
   "project.page.id": "ID",
@@ -6984,7 +6826,7 @@
   "register-page.create-profile.identification.first-name": "Křestní jméno *",
 
   // "register-page.create-profile.identification.first-name.error": "Please fill in a First Name",
-  "register-page.create-profile.identification.first-name.error": "Vyplňte prosím křesní jméno",
+  "register-page.create-profile.identification.first-name.error": "Vyplňte prosím křestní jméno",
 
   // "register-page.create-profile.identification.last-name": "Last Name *",
   "register-page.create-profile.identification.last-name": "Příjmení *",
@@ -7002,7 +6844,6 @@
   "register-page.create-profile.security.header": "Zabezpečení",
 
   // "register-page.create-profile.security.info": "Please enter a password in the box below, and confirm it by typing it again into the second box.",
-  // TODO Source message changed - Revise the translation
   "register-page.create-profile.security.info": "Zadejte prosím heslo do níže uvedeného pole a potvrďte jej opětovným zadáním do druhého pole.",
 
   // "register-page.create-profile.security.label.password": "Password *",
@@ -7066,8 +6907,7 @@
   "register-page.registration.error.head": "Chyba při pokusu o registraci e-mailu",
 
   // "register-page.registration.error.content": "An error occurred when registering the following email address: {{ email }}",
-  // TODO New key - Add a translation
-  "register-page.registration.error.content": "An error occurred when registering the following email address: {{ email }}",
+  "register-page.registration.error.content": "Došlo k chybě při registraci následující e-mailové adresy: {{ email }}",
 
   // "register-page.registration.error.recaptcha": "Error when trying to authenticate with recaptcha",
   "register-page.registration.error.recaptcha": "Chyba při pokusu o ověření pomocí recaptcha",
@@ -7312,8 +7152,7 @@
   "resource-policies.form.name.label": "Název",
 
   // "resource-policies.form.name.hint": "Max 30 characters",
-  // TODO New key - Add a translation
-  "resource-policies.form.name.hint": "Max 30 characters",
+  "resource-policies.form.name.hint": "Maximálně 30 znaků",
 
   // "resource-policies.form.policy-type.label": "Select the policy type",
   "resource-policies.form.policy-type.label": "vyberte typ politiky",
@@ -7346,20 +7185,16 @@
   "resource-policies.table.headers.group": "Skupina",
 
   // "resource-policies.table.headers.select-all": "Select all",
-  // TODO New key - Add a translation
-  "resource-policies.table.headers.select-all": "Select all",
+  "resource-policies.table.headers.select-all": "Vybrat vše",
 
   // "resource-policies.table.headers.deselect-all": "Deselect all",
-  // TODO New key - Add a translation
-  "resource-policies.table.headers.deselect-all": "Deselect all",
+  "resource-policies.table.headers.deselect-all": "Zrušit výběr všeho",
 
   // "resource-policies.table.headers.select": "Select",
-  // TODO New key - Add a translation
-  "resource-policies.table.headers.select": "Select",
+  "resource-policies.table.headers.select": "Vybrat",
 
   // "resource-policies.table.headers.deselect": "Deselect",
-  // TODO New key - Add a translation
-  "resource-policies.table.headers.deselect": "Deselect",
+  "resource-policies.table.headers.deselect": "Zrušit výběr",
 
   // "resource-policies.table.headers.id": "ID",
   "resource-policies.table.headers.id": "ID",
@@ -7386,8 +7221,7 @@
   "resource-policies.table.headers.title.for.collection": "Politiky kolekce",
 
   // "root.skip-to-content": "Skip to main content",
-  // TODO New key - Add a translation
-  "root.skip-to-content": "Skip to main content",
+  "root.skip-to-content": "Přejít k hlavnímu obsahu",
 
   // "search.description": "",
   "search.description": "",
@@ -7405,8 +7239,7 @@
   "search.search-form.placeholder": "Hledat v repozitáři...",
 
   // "search.filters.remove": "Remove filter of type {{ type }} with value {{ value }}",
-  // TODO New key - Add a translation
-  "search.filters.remove": "Remove filter of type {{ type }} with value {{ value }}",
+  "search.filters.remove": "Odstranit filtr typu {{ type }} s hodnotou {{ value }}",
 
   // "search.filters.applied.f.title": "Title",
   // TODO New key - Add a translation
@@ -7425,7 +7258,6 @@
   "search.filters.applied.f.dateSubmitted": "Datum vložení",
 
   // "search.filters.applied.f.discoverable": "Non-discoverable",
-  // TODO Source message changed - Revise the translation
   "search.filters.applied.f.discoverable": "Nedohledatelné",
 
   // "search.filters.applied.f.entityType": "Item Type",
@@ -7461,7 +7293,7 @@
   "search.filters.applied.f.jobTitle": "Název pracovní pozice",
 
   // "search.filters.applied.f.birthDate.max": "End birth date",
-  "search.filters.applied.f.birthDate.max": "Datum narozdení do",
+  "search.filters.applied.f.birthDate.max": "Datum narození do",
 
   // "search.filters.applied.f.birthDate.min": "Start birth date",
   "search.filters.applied.f.birthDate.min": "Datum narození od",
@@ -7547,12 +7379,10 @@
   "search.filters.filter.creativeDatePublished.label": "Hledat datum zveřejnění",
 
   // "search.filters.filter.creativeDatePublished.min.label": "Start",
-  // TODO New key - Add a translation
-  "search.filters.filter.creativeDatePublished.min.label": "Start",
+  "search.filters.filter.creativeDatePublished.min.label": "Začátek",
 
   // "search.filters.filter.creativeDatePublished.max.label": "End",
-  // TODO New key - Add a translation
-  "search.filters.filter.creativeDatePublished.max.label": "End",
+  "search.filters.filter.creativeDatePublished.max.label": "Konec",
 
   // "search.filters.filter.creativeWorkEditor.head": "Editor",
   "search.filters.filter.creativeWorkEditor.head": "Editor",
@@ -7585,14 +7415,12 @@
   "search.filters.filter.dateIssued.head": "Datum",
 
   // "search.filters.filter.dateIssued.max.placeholder": "Maximum Date",
-  // TODO Source message changed - Revise the translation
   "search.filters.filter.dateIssued.max.placeholder": "Maximální datum",
 
   // "search.filters.filter.dateIssued.max.label": "End",
   "search.filters.filter.dateIssued.max.label": "Konec",
 
   // "search.filters.filter.dateIssued.min.placeholder": "Minimum Date",
-  // TODO Source message changed - Revise the translation
   "search.filters.filter.dateIssued.min.placeholder": "Minimální Datum",
 
   // "search.filters.filter.dateIssued.min.label": "Start",
@@ -7608,7 +7436,6 @@
   "search.filters.filter.dateSubmitted.label": "Hledat datum vložení",
 
   // "search.filters.filter.discoverable.head": "Non-discoverable",
-  // TODO Source message changed - Revise the translation
   "search.filters.filter.discoverable.head": "Nedohledatelné",
 
   // "search.filters.filter.withdrawn.head": "Withdrawn",
@@ -7782,12 +7609,10 @@
   "search.filters.filter.funding.placeholder": "Funding",
 
   // "search.filters.filter.supervisedBy.head": "Supervised By",
-  // TODO New key - Add a translation
-  "search.filters.filter.supervisedBy.head": "Supervised By",
+  "search.filters.filter.supervisedBy.head": "Dohlížející autorita:",
 
   // "search.filters.filter.supervisedBy.placeholder": "Supervised By",
-  // TODO New key - Add a translation
-  "search.filters.filter.supervisedBy.placeholder": "Supervised By",
+  "search.filters.filter.supervisedBy.placeholder": "Dohlížející autorita:",
 
   // "search.filters.filter.supervisedBy.label": "Search Supervised By",
   "search.filters.filter.supervisedBy.label": "Hledat dohlížející autoritu",
@@ -7846,23 +7671,18 @@
   "search.filters.discoverable.false": "Ano",
 
   // "search.filters.namedresourcetype.Archived": "Archived",
-  // TODO New key - Add a translation
-  "search.filters.namedresourcetype.Archived": "Archived",
+  "search.filters.namedresourcetype.Archived": "Archivováno",
 
   // "search.filters.namedresourcetype.Validation": "Validation",
-  // TODO New key - Add a translation
-  "search.filters.namedresourcetype.Validation": "Validation",
+  "search.filters.namedresourcetype.Validation": "Ověřování",
 
   // "search.filters.namedresourcetype.Waiting for Controller": "Waiting for reviewer",
-  // TODO New key - Add a translation
-  "search.filters.namedresourcetype.Waiting for Controller": "Waiting for reviewer",
+  "search.filters.namedresourcetype.Waiting for Controller": "Čeká na kontrolu",
 
   // "search.filters.namedresourcetype.Workflow": "Workflow",
-  // TODO New key - Add a translation
   "search.filters.namedresourcetype.Workflow": "Workflow",
 
   // "search.filters.namedresourcetype.Workspace": "Workspace",
-  // TODO New key - Add a translation
   "search.filters.namedresourcetype.Workspace": "Workspace",
 
   // "search.filters.withdrawn.true": "Yes",
@@ -7872,8 +7692,7 @@
   "search.filters.withdrawn.false": "Ne",
 
   // "search.filters.head": "Filters",
-  // TODO Source message changed - Revise the translation
-  "search.filters.head": "Zúžit hledání",
+  "search.filters.head": "Filtry",
 
   // "search.filters.reset": "Reset filters",
   "search.filters.reset": "Resetovat filtry",
@@ -7913,7 +7732,6 @@
   "search.form.search": "Hledat",
 
   // "search.form.search_dspace": "All repository",
-  // TODO Source message changed - Revise the translation
   "search.form.search_dspace": "Celý repozitář",
 
   // "search.form.scope.all": "All of DSpace",
@@ -8002,12 +7820,10 @@
   "search.view-switch.show-geospatialMap": "Show as map",
 
   // "selectable-list-item-control.deselect": "Deselect item",
-  // TODO New key - Add a translation
-  "selectable-list-item-control.deselect": "Deselect item",
+  "selectable-list-item-control.deselect": "Zrušit výběr položky",
 
   // "selectable-list-item-control.select": "Select item",
-  // TODO New key - Add a translation
-  "selectable-list-item-control.select": "Select item",
+  "selectable-list-item-control.select": "Vybrat položku",
 
   // "sorting.ASC": "Ascending",
   "sorting.ASC": "Vzestupně",
@@ -8025,7 +7841,6 @@
   "sorting.score.ASC": "Nejméně relevantní",
 
   // "sorting.score.DESC": "Most Relevant",
-  // TODO Source message changed - Revise the translation
   "sorting.score.DESC": "Nejvíce relevantní",
 
   // "sorting.dc.date.issued.ASC": "Date Issued Ascending",
@@ -8047,28 +7862,22 @@
   "sorting.lastModified.DESC": "Naposledy upraveno sestupně",
 
   // "sorting.person.familyName.ASC": "Surname Ascending",
-  // TODO New key - Add a translation
-  "sorting.person.familyName.ASC": "Surname Ascending",
+  "sorting.person.familyName.ASC": "Příjmení vzestupně",
 
   // "sorting.person.familyName.DESC": "Surname Descending",
-  // TODO New key - Add a translation
-  "sorting.person.familyName.DESC": "Surname Descending",
+  "sorting.person.familyName.DESC": "Příjmení sestupně",
 
   // "sorting.person.givenName.ASC": "Name Ascending",
-  // TODO New key - Add a translation
-  "sorting.person.givenName.ASC": "Name Ascending",
+  "sorting.person.givenName.ASC": "Jméno vzestupně",
 
   // "sorting.person.givenName.DESC": "Name Descending",
-  // TODO New key - Add a translation
-  "sorting.person.givenName.DESC": "Name Descending",
+  "sorting.person.givenName.DESC": "Jméno sestupně",
 
   // "sorting.person.birthDate.ASC": "Birth Date Ascending",
-  // TODO New key - Add a translation
-  "sorting.person.birthDate.ASC": "Birth Date Ascending",
+  "sorting.person.birthDate.ASC": "Datum narození vzestupně",
 
   // "sorting.person.birthDate.DESC": "Birth Date Descending",
-  // TODO New key - Add a translation
-  "sorting.person.birthDate.DESC": "Birth Date Descending",
+  "sorting.person.birthDate.DESC": "Datum narození sestupně",
 
   // "statistics.title": "Statistics",
   "statistics.title": "Statistiky",
@@ -8092,13 +7901,13 @@
   "statistics.table.title.TotalVisitsPerMonth": "Celkový počet návštěv za měsíc",
 
   // "statistics.table.title.TotalDownloads": "File Visits",
-  "statistics.table.title.TotalDownloads": "Návštěvy souborů",
+  "statistics.table.title.TotalDownloads": "Stažení souborů",
 
   // "statistics.table.title.TopCountries": "Top country views",
-  "statistics.table.title.TopCountries": "Nejvíce zobrazení ze státu",
+  "statistics.table.title.TopCountries": "Země s nejvíce zobrazeními",
 
   // "statistics.table.title.TopCities": "Top city views",
-  "statistics.table.title.TopCities": "Nejvíce zobrazení z města",
+  "statistics.table.title.TopCities": "Města s nejvíce zobrazeními",
 
   // "statistics.table.header.views": "Views",
   "statistics.table.header.views": "Zobrazení",
@@ -8116,7 +7925,6 @@
   "submission.general.cancel": "Zrušit",
 
   // "submission.general.cannot_submit": "You don't have permission to make a new submission.",
-  // TODO Source message changed - Revise the translation
   "submission.general.cannot_submit": "Nemáte oprávnění k vytvoření nového příspěvku.",
 
   // "submission.general.deposit": "Deposit",
@@ -8187,7 +7995,7 @@
   "submission.import-external.page.hint": "Zadejte výše uvedený dotaz, abyste našli záznamy z webu, které chcete importovat do systému DSpace.",
 
   // "submission.import-external.back-to-my-dspace": "Back to MyDSpace",
-  "submission.import-external.back-to-my-dspace": "Zpět do Mého DSpace",
+  "submission.import-external.back-to-my-dspace": "Zpět na Můj DSpace",
 
   // "submission.import-external.search.placeholder": "Search the external source",
   "submission.import-external.search.placeholder": "Prohledat externí zdroj",
@@ -8336,7 +8144,7 @@
   "submission.import-external.preview.title.Project": "Náhled projektu",
 
   // "submission.import-external.preview.subtitle": "The metadata below was imported from an external source. It will be pre-filled when you start the submission.",
-  "submission.import-external.preview.subtitle": "Níže uvedená metadata byla importována z externího zdroje. Budou předvyplněna při zahájení odesílání..",
+  "submission.import-external.preview.subtitle": "Níže uvedená metadata byla importována z externího zdroje. Budou předvyplněna při zahájení odesílání.",
 
   // "submission.import-external.preview.button.import": "Start submission",
   "submission.import-external.preview.button.import": "Začít nový příspěvek",
@@ -8571,8 +8379,7 @@
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.JournalIssue": "Lokálně uložená čísla časopisu ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalVolumeOfIssue": "Local Journal Volumes ({{ count }})",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalVolumeOfIssue": "Local Journal Volumes ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalVolumeOfIssue": "Místní svazky časopisů ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalVolumeOfPublication": "Local Journal Volumes ({{ count }})",
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalVolumeOfPublication": "Lokálně uložené ročníky časopisu ({{ count }})",
@@ -8702,14 +8509,13 @@
   "submission.sections.describe.relationship-lookup.title.JournalIssue": "Čísla časopisu",
 
   // "submission.sections.describe.relationship-lookup.title.isJournalVolumeOfIssue": "Journal Volumes",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.title.isJournalVolumeOfIssue": "Journal Volumes",
+  "submission.sections.describe.relationship-lookup.title.isJournalVolumeOfIssue": "Ročníky časopisů",
 
   // "submission.sections.describe.relationship-lookup.title.isJournalVolumeOfPublication": "Journal Volumes",
-  "submission.sections.describe.relationship-lookup.title.isJournalVolumeOfPublication": "Ročníky časopisu",
+  "submission.sections.describe.relationship-lookup.title.isJournalVolumeOfPublication": "Ročníky časopisů",
 
   // "submission.sections.describe.relationship-lookup.title.JournalVolume": "Journal Volumes",
-  "submission.sections.describe.relationship-lookup.title.JournalVolume": "Ročníky časopisu",
+  "submission.sections.describe.relationship-lookup.title.JournalVolume": "Ročníky časopisů",
 
   // "submission.sections.describe.relationship-lookup.title.isJournalOfPublication": "Journals",
   "submission.sections.describe.relationship-lookup.title.isJournalOfPublication": "Časopisy",
@@ -8770,8 +8576,7 @@
   "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalOfPublication": "Vybrané časopisy",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalVolumeOfIssue": "Selected Journal Volume",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalVolumeOfIssue": "Selected Journal Volume",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalVolumeOfIssue": "Vybraný ročník časopisu",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalVolumeOfPublication": "Selected Journal Volume",
   "submission.sections.describe.relationship-lookup.selection-tab.title.isJournalVolumeOfPublication": "Vybraný ročník časopisu",
@@ -8813,7 +8618,7 @@
   "submission.sections.describe.relationship-lookup.selection-tab.title.JournalIssue": "Vybrané číslo časopisu",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.isChildOrgUnitOf": "Selected Organizational Unit",
-  "submission.sections.describe.relationship-lookup.selection-tab.title.isChildOrgUnitOf": "Vybrané organizační jednotka",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.isChildOrgUnitOf": "Vybraná organizační jednotka",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.sherpaJournal": "Search Results",
   "submission.sections.describe.relationship-lookup.selection-tab.title.sherpaJournal": "Výsledky vyhledávání",
@@ -8951,8 +8756,7 @@
   "submission.sections.general.no-collection": "Nebyla nalezena žádná kolekce",
 
   // "submission.sections.general.no-entity": "No entity types found",
-  // TODO New key - Add a translation
-  "submission.sections.general.no-entity": "No entity types found",
+  "submission.sections.general.no-entity": "Nebyl nalezen žádný typ entity",
 
   // "submission.sections.general.no-sections": "No options available",
   "submission.sections.general.no-sections": "Nejsou k dispozici žádné volby",
@@ -9006,8 +8810,7 @@
   "submission.sections.submit.progressbar.describe.steptwo": "Popsat",
 
   // "submission.sections.submit.progressbar.duplicates": "Potential duplicates",
-  // TODO New key - Add a translation
-  "submission.sections.submit.progressbar.duplicates": "Potential duplicates",
+  "submission.sections.submit.progressbar.duplicates": "Potenciální duplicity",
 
   // "submission.sections.submit.progressbar.identifiers": "Identifiers",
   "submission.sections.submit.progressbar.identifiers": "Identifikátory",
@@ -9319,7 +9122,6 @@
   "submission.workflow.generic.delete": "Smazat",
 
   // "submission.workflow.generic.delete-help": "Select this option to discard this item. You will then be asked to confirm it.",
-  // TODO Source message changed - Revise the translation
   "submission.workflow.generic.delete-help": "Pokud chcete tento záznam vyřadit, zvolte \"Smazat\". Poté budete vyzváni k potvrzení.",
 
   // "submission.workflow.generic.edit": "Edit",
@@ -9380,10 +9182,10 @@
   "submission.workflow.tasks.claimed.reject.submit": "Odmítnout",
 
   // "submission.workflow.tasks.claimed.reject_help": "If you have reviewed the item and found it is <strong>not</strong> suitable for inclusion in the collection, select \"Reject\".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.",
-  "submission.workflow.tasks.claimed.reject_help": "Pokud jste záznam zkontrolovali a zjistili, že <strong>není</strong> vhodný pro zařazení do kolekce, vyberte \"Odmítnout\".  Poté budete vyzváni k zadání zprávy, ve které uvedete, proč je záznam nevhodný, a zda by měl odesílatel něco změnit a znovu odeslat.",
+  "submission.workflow.tasks.claimed.reject_help": "Pokud jste záznam zkontrolovali a zjistili, že <strong>není</strong> vhodný pro zařazení do kolekce, vyberte \"Odmítnout\".  Poté budete vyzváni k zadání zprávy, ve které uvedete, proč je záznam nevhodný, a zda by měl odesílatel něco změnit a znovu předložit.",
 
   // "submission.workflow.tasks.claimed.return": "Return to pool",
-  "submission.workflow.tasks.claimed.return": "Vrátit do fondu",
+  "submission.workflow.tasks.claimed.return": "Vrátit do fronty",
 
   // "submission.workflow.tasks.claimed.return_help": "Return the task to the pool so that another user may perform the task.",
   "submission.workflow.tasks.claimed.return_help": "Vrátit úlohu do fondu, aby ji mohl provést jiný uživatel.",
@@ -9453,11 +9255,10 @@
   "subscriptions.frequency.W": "Týdenní frekvence",
 
   // "subscriptions.tooltip": "Subscribe",
-  "subscriptions.tooltip": "Potvrdit",
+  "subscriptions.tooltip": "Odebírat",
 
   // "subscriptions.unsubscribe": "Unsubscribe",
-  // TODO New key - Add a translation
-  "subscriptions.unsubscribe": "Unsubscribe",
+  "subscriptions.unsubscribe": "Odhlásit odběr",
 
   // "subscriptions.modal.title": "Subscriptions",
   "subscriptions.modal.title": "Notifikace",
@@ -9499,13 +9300,13 @@
   "subscriptions.modal.update.success": "Notifikace {{ type }} byla aktualizována.",
 
   // "subscriptions.modal.create.error": "An error occurs during the subscription creation",
-  "subscriptions.modal.create.error": "Během nastavování notifikce došlo k chybě.",
+  "subscriptions.modal.create.error": "Během nastavování notifikace došlo k chybě.",
 
   // "subscriptions.modal.delete.error": "An error occurs during the subscription delete",
-  "subscriptions.modal.delete.error": "Během rušení notifikce došlo k chybě.",
+  "subscriptions.modal.delete.error": "Během rušení notifikace došlo k chybě.",
 
   // "subscriptions.modal.update.error": "An error occurs during the subscription update",
-  "subscriptions.modal.update.error": "Během aktualizace notifikce došlo k chybě.",
+  "subscriptions.modal.update.error": "Během aktualizace notifikace došlo k chybě.",
 
   // "subscriptions.table.dso": "Subject",
   "subscriptions.table.dso": "Předmět",
@@ -9565,7 +9366,7 @@
   "vocabulary-treeview.header": "Hierarchické stromové zobrazení",
 
   // "vocabulary-treeview.load-more": "Load more",
-  "vocabulary-treeview.load-more": "Další",
+  "vocabulary-treeview.load-more": "Načíst další",
 
   // "vocabulary-treeview.search.form.reset": "Reset",
   "vocabulary-treeview.search.form.reset": "Resetovat",
@@ -9574,11 +9375,10 @@
   "vocabulary-treeview.search.form.search": "Hledat",
 
   // "vocabulary-treeview.search.form.search-placeholder": "Filter results by typing the first few letters",
-  // TODO New key - Add a translation
-  "vocabulary-treeview.search.form.search-placeholder": "Filter results by typing the first few letters",
+  "vocabulary-treeview.search.form.search-placeholder": "Filtrovat výsledky zadáním prvních několika písmen",
 
   // "vocabulary-treeview.search.no-result": "There were no items to show",
-  "vocabulary-treeview.search.no-result": "Nebyly zobrazeny žádné záznamy",
+  "vocabulary-treeview.search.no-result": "Nebyly nalezeny žádné položky",
 
   // "vocabulary-treeview.tree.description.nsi": "The Norwegian Science Index",
   "vocabulary-treeview.tree.description.nsi": "Norský vědecký index",
@@ -9683,7 +9483,6 @@
   "workflow-item.send-back.button.cancel": "Zrušit",
 
   // "workflow-item.send-back.button.confirm": "Send back",
-  // TODO Source message changed - Revise the translation
   "workflow-item.send-back.button.confirm": "Odeslat zpět",
 
   // "workflow-item.view.breadcrumbs": "Workflow View",
@@ -10149,12 +9948,10 @@
   "person.orcid.registry.auth": "ORCID oprávnění",
 
   // "person.orcid-tooltip.authenticated": "{{orcid}}",
-  // TODO New key - Add a translation
   "person.orcid-tooltip.authenticated": "{{orcid}}",
 
   // "person.orcid-tooltip.not-authenticated": "{{orcid}} (unconfirmed)",
-  // TODO New key - Add a translation
-  "person.orcid-tooltip.not-authenticated": "{{orcid}} (unconfirmed)",
+  "person.orcid-tooltip.not-authenticated": "{{orcid}} (nepotvrzeno)",
 
   // "home.recent-submissions.head": "Recent Submissions",
   "home.recent-submissions.head": "Nedávné příspěvky",
@@ -10169,7 +9966,7 @@
   "system-wide-alert-banner.countdown.prefix": "V",
 
   // "system-wide-alert-banner.countdown.days": "{{days}} day(s),",
-  "system-wide-alert-banner.countdown.days": "{{days}} den(dny),",
+  "system-wide-alert-banner.countdown.days": "{{days}} dní,",
 
   // "system-wide-alert-banner.countdown.hours": "{{hours}} hour(s) and",
   "system-wide-alert-banner.countdown.hours": "{{hours}} hodina(y) a",
@@ -10208,11 +10005,10 @@
   "system-wide-alert.form.label.countdownTo.enable": "Povolit odpočet",
 
   // "system-wide-alert.form.label.countdownTo.hint": "Hint: Set a countdown timer. When enabled, a date can be set in the future and the system-wide alert banner will perform a countdown to the set date. When this timer ends, it will disappear from the alert. The server will NOT be automatically stopped.",
-  "system-wide-alert.form.label.countdownTo.hint": "Nápověda: Nastavte odpočítávací měřič. Je-li to povoleno, lze datum nastavit i v budoucnosti a systémový upozornění bude uvádět odpočítávání do nastaveného data. Ve chvíli, kdy skončí odpočítávání, zmizí i odpočítávač z upozornění. Server NEBUDE automaticky zastaven.",
+  "system-wide-alert.form.label.countdownTo.hint": "Nápověda: Nastavte odpočítávací měřič. Je-li to povoleno, lze datum nastavit i v budoucnosti a systémové upozornění bude uvádět odpočítávání do nastaveného data. Ve chvíli, kdy skončí odpočítávání, zmizí i odpočítávač z upozornění. Server NEBUDE automaticky zastaven.",
 
   // "system-wide-alert-form.select-date-by-calendar": "Select date using calendar",
-  // TODO New key - Add a translation
-  "system-wide-alert-form.select-date-by-calendar": "Select date using calendar",
+  "system-wide-alert-form.select-date-by-calendar": "Vyberte datum pomocí kalendáře",
 
   // "system-wide-alert.form.label.preview": "System-wide alert preview",
   "system-wide-alert.form.label.preview": "Náhled systémového upozornění",
@@ -10252,23 +10048,19 @@
   "access-control-item-header-toggle": "Metadata záznamu",
 
   // "access-control-item-toggle.enable": "Enable option to perform changes on the item's metadata",
-  // TODO New key - Add a translation
-  "access-control-item-toggle.enable": "Enable option to perform changes on the item's metadata",
+  "access-control-item-toggle.enable": "Povolit možnost provádět změny v metadatech položky",
 
   // "access-control-item-toggle.disable": "Disable option to perform changes on the item's metadata",
-  // TODO New key - Add a translation
-  "access-control-item-toggle.disable": "Disable option to perform changes on the item's metadata",
+  "access-control-item-toggle.disable": "Zakázat možnost provádět změny v metadatech položky",
 
   // "access-control-bitstream-header-toggle": "Bitstreams",
   "access-control-bitstream-header-toggle": "Soubory",
 
   // "access-control-bitstream-toggle.enable": "Enable option to perform changes on the bitstreams",
-  // TODO New key - Add a translation
-  "access-control-bitstream-toggle.enable": "Enable option to perform changes on the bitstreams",
+  "access-control-bitstream-toggle.enable": "Povolit možnost provádět změny v souborech",
 
   // "access-control-bitstream-toggle.disable": "Disable option to perform changes on the bitstreams",
-  // TODO New key - Add a translation
-  "access-control-bitstream-toggle.disable": "Disable option to perform changes on the bitstreams",
+  "access-control-bitstream-toggle.disable": "Zakázat možnost provádět změny v souborech",
 
   // "access-control-mode": "Mode",
   "access-control-mode": "Mód",
@@ -10289,14 +10081,13 @@
   "access-control-limit-to-specific": "Uplatnit změny pouze na specifikované soubory",
 
   // "access-control-process-all-bitstreams": "Update all the bitstreams in the item",
-  "access-control-process-all-bitstreams": "Aktualozivat všechny soubory u daného záznamu",
+  "access-control-process-all-bitstreams": "Aktualizovat všechny soubory u daného záznamu",
 
   // "access-control-bitstreams-selected": "bitstreams selected",
   "access-control-bitstreams-selected": "vybrány soubory",
 
   // "access-control-bitstreams-select": "Select bitstreams",
-  // TODO New key - Add a translation
-  "access-control-bitstreams-select": "Select bitstreams",
+  "access-control-bitstreams-select": "Vybrat soubory",
 
   // "access-control-cancel": "Cancel",
   "access-control-cancel": "Zrušit",
@@ -10308,8 +10099,7 @@
   "access-control-add-more": "Přidat další",
 
   // "access-control-remove": "Remove access condition",
-  // TODO New key - Add a translation
-  "access-control-remove": "Remove access condition",
+  "access-control-remove": "Odstranit podmínku přístupu",
 
   // "access-control-select-bitstreams-modal.title": "Select bitstreams",
   "access-control-select-bitstreams-modal.title": "Vybrat soubory",
@@ -10339,8 +10129,7 @@
   "access-control-option-end-date-note": "Vyberte datum, do kterého má být typ přístupu aktivován",
 
   // "vocabulary-treeview.search.form.add": "Add",
-  // TODO New key - Add a translation
-  "vocabulary-treeview.search.form.add": "Add",
+  "vocabulary-treeview.search.form.add": "Přidat",
 
   // "admin.notifications.publicationclaim.breadcrumbs": "Publication Claim",
   // TODO New key - Add a translation
@@ -11767,44 +11556,34 @@
   "item.page.cc.license.disclaimer": "Except where otherwised noted, this item's license is described as",
 
   // "browse.search-form.placeholder": "Search the repository",
-  // TODO New key - Add a translation
-  "browse.search-form.placeholder": "Search the repository",
+  "browse.search-form.placeholder": "Hledat v repozitáři",
 
   // "file-download-link.download": "Download ",
-  // TODO New key - Add a translation
-  "file-download-link.download": "Download ",
+  "file-download-link.download": "Stáhnout",
 
   // "register-page.registration.aria.label": "Enter your e-mail address",
-  // TODO New key - Add a translation
-  "register-page.registration.aria.label": "Enter your e-mail address",
+  "register-page.registration.aria.label": "Zadejte svou e-mailovou adresu",
 
   // "forgot-email.form.aria.label": "Enter your e-mail address",
-  // TODO New key - Add a translation
-  "forgot-email.form.aria.label": "Enter your e-mail address",
+  "forgot-email.form.aria.label": "Zadejte svou e-mailovou adresu",
 
   // "search-facet-option.update.announcement": "The page will be reloaded. Filter {{ filter }} is selected.",
-  // TODO New key - Add a translation
-  "search-facet-option.update.announcement": "The page will be reloaded. Filter {{ filter }} is selected.",
+  "search-facet-option.update.announcement": "Stránka bude znovu načtena. Filtr {{ filter }} je vybrán.",
 
   // "live-region.ordering.instructions": "Press spacebar to reorder {{ itemName }}.",
-  // TODO New key - Add a translation
-  "live-region.ordering.instructions": "Press spacebar to reorder {{ itemName }}.",
+  "live-region.ordering.instructions": "Stiskněte mezerník pro přeskupení {{ itemName }}.",
 
   // "live-region.ordering.status": "{{ itemName }}, grabbed. Current position in list: {{ index }} of  {{ length }}. Press up and down arrow keys to change position, SpaceBar to drop, Escape to cancel.",
-  // TODO New key - Add a translation
-  "live-region.ordering.status": "{{ itemName }}, grabbed. Current position in list: {{ index }} of  {{ length }}. Press up and down arrow keys to change position, SpaceBar to drop, Escape to cancel.",
+  "live-region.ordering.status": "{{ itemName }}, uchopeno. Aktuální pozice v seznamu: {{ index }} z {{ length }}. Použijte šipky nahoru/dolů pro změnu pozice, mezerník pro uvolnění, Escape pro zrušení.",
 
   // "live-region.ordering.moved": "{{ itemName }}, moved to position {{ index }} of {{ length }}. Press up and down arrow keys to change position, SpaceBar to drop, Escape to cancel.",
-  // TODO New key - Add a translation
-  "live-region.ordering.moved": "{{ itemName }}, moved to position {{ index }} of {{ length }}. Press up and down arrow keys to change position, SpaceBar to drop, Escape to cancel.",
+  "live-region.ordering.moved": "{{ itemName }}, přesunuto na pozici {{ index }} z {{ length }}. Použijte šipky nahoru/dolů pro změnu pozice, mezerník pro uvolnění, Escape pro zrušení.",
 
   // "live-region.ordering.dropped": "{{ itemName }}, dropped at position {{ index }} of {{ length }}.",
-  // TODO New key - Add a translation
-  "live-region.ordering.dropped": "{{ itemName }}, dropped at position {{ index }} of {{ length }}.",
+  "live-region.ordering.dropped": "{{ itemName }}, uvolněno na pozici {{ index }} z {{ length }}.",
 
   // "dynamic-form-array.sortable-list.label": "Sortable list",
-  // TODO New key - Add a translation
-  "dynamic-form-array.sortable-list.label": "Sortable list",
+  "dynamic-form-array.sortable-list.label": "Seznam, který lze třídit",
 
   // "external-login.component.or": "or",
   // TODO New key - Add a translation
@@ -12007,8 +11786,7 @@
   "embargo.listelement.badge": "Embargo until {{ date }}",
 
   // "metadata-export-search.submit.error.limit-exceeded": "Only the first {{limit}} items will be exported",
-  // TODO New key - Add a translation
-  "metadata-export-search.submit.error.limit-exceeded": "Only the first {{limit}} items will be exported",
+  "metadata-export-search.submit.error.limit-exceeded": "Budou exportovány pouze první {{limit}} položky",
 
   // "file-download-link.request-copy": "Request a copy of ",
   // TODO New key - Add a translation

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -1603,12 +1603,10 @@
   "browse.metadata.map.count.items": "záznamů", "No more pages of results",
 
   // "pagination.next.button": "Next",
-  // TODO New key - Add a translation
-  "pagination.next.button": "Next",
+  "pagination.next.button": "Další",
 
   // "pagination.previous.button": "Previous",
-  // TODO New key - Add a translation
-  "pagination.previous.button": "Previous",
+  "pagination.previous.button": "Předchozí",
 
   // "pagination.next.button.disabled.tooltip": "No more pages of results",
   "pagination.next.button.disabled.tooltip": "Žádné další stránky výsledků",
@@ -2415,8 +2413,7 @@
   "community.search.results.head": "Výsledky vyhledávání",
 
   // "community.sub-collection-list.head": "Collections in this community",
-  // TODO New key - Add a translation
-  "community.sub-collection-list.head": "Collections in this community",
+  "community.sub-collection-list.head": "Kolekce této komunity",
 
   // "community.sub-community-list.head": "Communities in this Community",
   "community.sub-community-list.head": "Komunity této komunity",
@@ -2461,8 +2458,7 @@
   "cookies.consent.content-notice.learnMore": "Přizpůsobit",
 
   // "cookies.consent.content-notice.description": "We collect and process your personal information for the following purposes: {purposes}",
-  // TODO New key - Add a translation
-  "cookies.consent.content-notice.description": "We collect and process your personal information for the following purposes: {purposes}",
+  "cookies.consent.content-notice.description": "Shromažďujeme a zpracováváme vaše osobní údaje pro tyto účely: {purposes}",
 
   // "cookies.consent.content-notice.learnMore": "Customize",
   // TODO Source message changed - Revise the translation
@@ -2481,12 +2477,10 @@
   "cookies.consent.content-modal.no-privacy-policy.text": "",upnosti",
 
   // "cookies.consent.content-modal.title": "Information that we collect",
-  // TODO New key - Add a translation
-  "cookies.consent.content-modal.title": "Information that we collect",
+  "cookies.consent.content-modal.title": "Informace, které shromažďujeme",
 
   // "cookies.consent.app.title.accessibility": "Accessibility Settings",
-  // TODO New key - Add a translation
-  "cookies.consent.app.title.accessibility": "Accessibility Settings",
+  "cookies.consent.app.title.accessibility": "Nastavení přístupnosti",
 
   // "cookies.consent.app.description.accessibility": "Required for saving your accessibility settings locally",
   "cookies.consent.app.description.accessibility": "Požadováno pro lokální uložení nastavení přístupnosti",
@@ -2513,19 +2507,15 @@
   "cookies.consent.app.title.acknowledgement": "Potvrzení",
 
   // "cookies.consent.app.description.acknowledgement": "Required for saving your acknowledgements and consents",
-  // TODO New key - Add a translation
-  "cookies.consent.app.description.acknowledgement": "Required for saving your acknowledgements and consents",
+  "cookies.consent.app.description.acknowledgement": "Vyžadováno pro uložení vašich potvrzení a souhlasů",
 
   // "cookies.consent.app.title.google-analytics": "Google Analytics",
-  // TODO New key - Add a translation
   "cookies.consent.app.title.google-analytics": "Google Analytics",
 
   // "cookies.consent.app.description.google-analytics": "Allows us to track statistical data",
-  // TODO New key - Add a translation
-  "cookies.consent.app.description.google-analytics": "Allows us to track statistical data",
+  "cookies.consent.app.description.google-analytics": "Umožňuje nám sledovat statistická data",
 
   // "cookies.consent.app.title.google-recaptcha": "Google reCaptcha",
-  // TODO New key - Add a translation
   "cookies.consent.app.title.google-recaptcha": "Google reCaptcha",
 
   // "cookies.consent.app.description.google-recaptcha": "We use google reCAPTCHA service during registration and password recovery",
@@ -2544,12 +2534,10 @@
   "cookies.consent.purpose.statistical": "Statistický",
 
   // "cookies.consent.purpose.registration-password-recovery": "Registration and Password recovery",
-  // TODO New key - Add a translation
-  "cookies.consent.purpose.registration-password-recovery": "Registration and Password recovery",
+  "cookies.consent.purpose.registration-password-recovery": "Registrace a obnovení hesla",
 
   // "cookies.consent.purpose.sharing": "Sharing",
-  // TODO New key - Add a translation
-  "cookies.consent.purpose.sharing": "Sharing",
+  "cookies.consent.purpose.sharing": "Sdílení",
 
   // "curation-task.task.citationpage.label": "Generate Citation Page",
   "curation-task.task.citationpage.label": "Vytvořit stránku s citacemi",
@@ -2702,36 +2690,28 @@
   "dso-selector.results-could-not-be-retrieved": "Něco se nepovedlo, zkuste, prosím, načíst znovu ↻",
 
   // "dso-selector.set-scope.community.head": "Select a search scope",
-  // TODO New key - Add a translation
-  "dso-selector.set-scope.community.head": "Select a search scope",
+  "dso-selector.set-scope.community.head": "Vyberte rozsah vyhledávání",
 
   // "dso-selector.set-scope.community.button": "Search all of DSpace",
-  // TODO New key - Add a translation
-  "dso-selector.set-scope.community.button": "Search all of DSpace",
+  "dso-selector.set-scope.community.button": "Hledat v celém DSpace",
 
   // "dso-selector.set-scope.community.or-divider": "or",
-  // TODO New key - Add a translation
-  "dso-selector.set-scope.community.or-divider": "or",
+  "dso-selector.set-scope.community.or-divider": "nebo",
 
   // "dso-selector.set-scope.community.input-header": "Search for a community or collection",
-  // TODO New key - Add a translation
-  "dso-selector.set-scope.community.input-header": "Search for a community or collection",
+  "dso-selector.set-scope.community.input-header": "Hledat komunitu nebo kolekci",
 
   // "dso-selector.claim.item.head": "Profile tips",
-  // TODO New key - Add a translation
-  "dso-selector.claim.item.head": "Profile tips",
+  "dso-selector.claim.item.head": "Tipy pro profil",
 
   // "dso-selector.claim.item.body": "These are existing profiles that may be related to you. If you recognize yourself in one of these profiles, select it and on the detail page, among the options, choose to claim it. Otherwise you can create a new profile from scratch using the button below.",
-  // TODO New key - Add a translation
-  "dso-selector.claim.item.body": "These are existing profiles that may be related to you. If you recognize yourself in one of these profiles, select it and on the detail page, among the options, choose to claim it. Otherwise you can create a new profile from scratch using the button below.",
+  "dso-selector.claim.item.body": "Níže vidíte existující profily, které s vámi mohou souviset. Pokud se v některém z nich poznáváte, vyberte jej a na stránce detailu mezi možnostmi zvolte převzetí profilu. Jinak můžete pomocí tlačítka níže vytvořit nový profil od začátku.",
 
   // "dso-selector.claim.item.not-mine-label": "None of these are mine",
-  // TODO New key - Add a translation
-  "dso-selector.claim.item.not-mine-label": "None of these are mine",
+  "dso-selector.claim.item.not-mine-label": "Žádný z nich není můj",
 
   // "dso-selector.claim.item.create-from-scratch": "Create a new one",
-  // TODO New key - Add a translation
-  "dso-selector.claim.item.create-from-scratch": "Create a new one",
+  "dso-selector.claim.item.create-from-scratch": "Vytvořit nový",
 
   // "dso-selector.results-could-not-be-retrieved": "Something went wrong, please refresh again ↻",
   // TODO Source message changed - Revise the translation
@@ -2855,20 +2835,16 @@
   "confirmation-modal.review-account-info.save": "Uložit",
 
   // "error.bitstream": "Error fetching bitstream",
-  // TODO New key - Add a translation
-  "error.bitstream": "Error fetching bitstream",
+  "error.bitstream": "Chyba při načítání souboru",
 
   // "error.browse-by": "Error fetching items",
-  // TODO New key - Add a translation
-  "error.browse-by": "Error fetching items",
+  "error.browse-by": "Chyba při načítání záznamů",
 
   // "error.collection": "Error fetching collection",
-  // TODO New key - Add a translation
-  "error.collection": "Error fetching collection",
+  "error.collection": "Chyba při načítání kolekce",
 
   // "error.collections": "Error fetching collections",
-  // TODO New key - Add a translation
-  "error.collections": "Error fetching collections",
+  "error.collections": "Chyba při načítání kolekcí",
 
   // "error.community": "Error fetching community",
   "error.community": "Chyba při načítání komunity",
@@ -2997,24 +2973,19 @@
   "footer.link.coar-notify-support": "COAR Notify",
 
   // "forgot-email.form.header": "Forgot Password",
-  // TODO New key - Add a translation
-  "forgot-email.form.header": "Forgot Password",
+  "forgot-email.form.header": "Zapomenuté heslo",
 
   // "forgot-email.form.info": "Enter the email address associated with the account.",
-  // TODO New key - Add a translation
-  "forgot-email.form.info": "Enter the email address associated with the account.",
+  "forgot-email.form.info": "Zadejte e-mailovou adresu přiřazenou k účtu.",
 
   // "forgot-email.form.email": "Email Address *",
-  // TODO New key - Add a translation
-  "forgot-email.form.email": "Email Address *",
+  "forgot-email.form.email": "E-mailová adresa *",
 
   // "forgot-email.form.email.error.required": "Please fill in an email address",
-  // TODO New key - Add a translation
-  "forgot-email.form.email.error.required": "Please fill in an email address",
+  "forgot-email.form.email.error.required": "Vyplňte prosím e-mailovou adresu",
 
   // "forgot-email.form.email.error.not-email-form": "Please fill in a valid email address",
-  // TODO New key - Add a translation
-  "forgot-email.form.email.error.not-email-form": "Please fill in a valid email address",
+  "forgot-email.form.email.error.not-email-form": "Zadejte prosím platnou e-mailovou adresu",
 
   // "forgot-email.form.email.hint": "An email will be sent to this address with a further instructions.",
   "forgot-email.form.email.hint": "Na tuto adresu bude zaslán e-mail s dalšími pokyny.",
@@ -3207,8 +3178,7 @@
   "grant-deny-request-copy.email.permissions.label": "Změnit na otevřený přístup",
 
   // "grant-deny-request-copy.email.send": "Send",
-  // TODO New key - Add a translation
-  "grant-deny-request-copy.email.send": "Send",
+  "grant-deny-request-copy.email.send": "Odeslat",
 
   // "grant-deny-request-copy.email.subject": "Subject",
   "grant-deny-request-copy.email.subject": "Předmět",
@@ -3248,8 +3218,7 @@
   "grant-request-copy.header": "Žádost o kopii dokumentu",
 
   // "grant-request-copy.intro.attachment": "A message will be sent to the applicant of the request. The requested document(s) will be attached.",
-  // TODO New key - Add a translation
-  "grant-request-copy.intro.attachment": "A message will be sent to the applicant of the request. The requested document(s) will be attached.",
+  "grant-request-copy.intro.attachment": "Žadateli bude odeslána zpráva. Požadované dokumenty budou přiloženy.",
 
   // "grant-request-copy.intro.link": "A message will be sent to the applicant of the request. A secure link providing access to the requested document(s) will be attached. The link will provide access for the duration of time selected in the \"Access Period\" menu below.",
   "grant-request-copy.intro.link": "A message will be sent to the applicant of the request. A secure link providing access to the requested document(s) will be attached. The link will provide access for the duration of time selected in the \"Access Period\" menu below.",
@@ -3280,16 +3249,13 @@
   "grant-request-copy.access-period.FOREVER": "Navždy",
 
   // "health.breadcrumbs": "Health",
-  // TODO New key - Add a translation
-  "health.breadcrumbs": "Health",
+  "health.breadcrumbs": "Stav systému",
 
   // "health-page.heading": "Health",
-  // TODO New key - Add a translation
-  "health-page.heading": "Health",
+  "health-page.heading": "Stav systému",
 
   // "health-page.info-tab": "Info",
-  // TODO New key - Add a translation
-  "health-page.info-tab": "Info",
+  "health-page.info-tab": "Informace",
 
   // "health-page.status-tab": "Status",
   "health-page.status-tab": "Stav",
@@ -3301,12 +3267,10 @@
   "grant-request-copy.access-period.+3MONTHS": "3 měsíce",
 
   // "health-page.section.db.title": "Database",
-  // TODO New key - Add a translation
-  "health-page.section.db.title": "Database",
+  "health-page.section.db.title": "Databáze",
 
   // "health-page.section.geoIp.title": "GeoIp",
-  // TODO New key - Add a translation
-  "health-page.section.geoIp.title": "GeoIp",
+  "health-page.section.geoIp.title": "GeoIP",
 
   // "health-page.section.solrAuthorityCore.title": "Solr: authority core",
   "health-page.section.solrAuthorityCore.title": "Solr: authority core",
@@ -3516,32 +3480,25 @@
   "item.edit.authorizations.heading": "Pomocí tohoto editoru můžete zobrazit a měnit politiky záznamu a také měnit politiky jednotlivých součástí záznamu: svazků a souborů. Stručně řečeno, záznam je kontejnerem svazků a svazky jsou kontejnery souborů. Kontejnery mají obvykle zásady ADD/REMOVE/READ/WRITE, zatímco soubory mají pouze zásady READ/WRITE.",
 
   // "item.edit.authorizations.title": "Edit item's Policies",
-  // TODO New key - Add a translation
-  "item.edit.authorizations.title": "Edit item's Policies",
+  "item.edit.authorizations.title": "Upravit politiky záznamu",
 
   // "item.badge.status": "Item status:",
-  // TODO New key - Add a translation
-  "item.badge.status": "Item status:",
+  "item.badge.status": "Stav záznamu:",
 
   // "item.badge.private": "Non-discoverable",
-  // TODO New key - Add a translation
-  "item.badge.private": "Non-discoverable",
+  "item.badge.private": "Nevyhledatelný",
 
   // "item.badge.withdrawn": "Withdrawn",
-  // TODO New key - Add a translation
-  "item.badge.withdrawn": "Withdrawn",
+  "item.badge.withdrawn": "Stažený",
 
   // "item.bitstreams.upload.bundle": "Bundle",
-  // TODO New key - Add a translation
-  "item.bitstreams.upload.bundle": "Bundle",
+  "item.bitstreams.upload.bundle": "Svazek",
 
   // "item.bitstreams.upload.bundle.placeholder": "Select a bundle or input new bundle name",
-  // TODO New key - Add a translation
-  "item.bitstreams.upload.bundle.placeholder": "Select a bundle or input new bundle name",
+  "item.bitstreams.upload.bundle.placeholder": "Vyberte svazek nebo zadejte název nového svazku",
 
   // "item.bitstreams.upload.bundle.new": "Create bundle",
-  // TODO New key - Add a translation
-  "item.bitstreams.upload.bundle.new": "Create bundle",
+  "item.bitstreams.upload.bundle.new": "Vytvořit svazek",
 
   // "item.bitstreams.upload.bundles.empty": "This item doesn't contain any bundles to upload a bitstream to.",
   "item.bitstreams.upload.bundles.empty": "Tento záznam neobsahuje žádné svazky, do kterých by bylo možné nahrát soubor.",
@@ -3871,20 +3828,16 @@
   "item.edit.metadata.edit.buttons.undo": "Vrátit změny",
 
   // "item.edit.metadata.edit.buttons.unedit": "Stop editing",
-  // TODO New key - Add a translation
-  "item.edit.metadata.edit.buttons.unedit": "Stop editing",
+  "item.edit.metadata.edit.buttons.unedit": "Ukončit úpravy",
 
   // "item.edit.metadata.edit.buttons.virtual": "This is a virtual metadata value, i.e. a value inherited from a related entity. It can’t be modified directly. Add or remove the corresponding relationship in the \"Relationships\" tab",
-  // TODO New key - Add a translation
-  "item.edit.metadata.edit.buttons.virtual": "This is a virtual metadata value, i.e. a value inherited from a related entity. It can’t be modified directly. Add or remove the corresponding relationship in the \"Relationships\" tab",
+  "item.edit.metadata.edit.buttons.virtual": "Toto je virtuální hodnota metadat, tj. hodnota zděděná z přidružené entity. Nelze ji upravit přímo. Přidejte nebo odeberte odpovídající vztah na kartě \"Vztahy\".",
 
   // "item.edit.metadata.empty": "The item currently doesn't contain any metadata. Click Add to start adding a metadata value.",
-  // TODO New key - Add a translation
-  "item.edit.metadata.empty": "The item currently doesn't contain any metadata. Click Add to start adding a metadata value.",
+  "item.edit.metadata.empty": "Záznam zatím neobsahuje žádná metadata. Klikněte na Přidat pro vytvoření nové hodnoty metadat.",
 
   // "item.edit.metadata.headers.edit": "Edit",
-  // TODO New key - Add a translation
-  "item.edit.metadata.headers.edit": "Edit",
+  "item.edit.metadata.headers.edit": "Upravit",
 
   // "item.edit.metadata.headers.field": "Field",
   "item.edit.metadata.headers.field": "Pole",
@@ -3968,20 +3921,16 @@
   "item.edit.move.discard-button": "Vyřadit",
 
   // "item.edit.move.description": "Select the collection you wish to move this item to. To narrow down the list of displayed collections, you can enter a search query in the box.",
-  // TODO New key - Add a translation
-  "item.edit.move.description": "Select the collection you wish to move this item to. To narrow down the list of displayed collections, you can enter a search query in the box.",
+  "item.edit.move.description": "Vyberte kolekci, do které chcete tento záznam přesunout. Pro zúžení seznamu zobrazených kolekcí můžete do pole zadat vyhledávací dotaz.",
 
   // "item.edit.move.error": "An error occurred when attempting to move the item",
-  // TODO New key - Add a translation
-  "item.edit.move.error": "An error occurred when attempting to move the item",
+  "item.edit.move.error": "Při pokusu o přesun záznamu došlo k chybě",
 
   // "item.edit.move.head": "Move item: {{id}}",
-  // TODO New key - Add a translation
-  "item.edit.move.head": "Move item: {{id}}",
+  "item.edit.move.head": "Přesunout záznam: {{id}}",
 
   // "item.edit.move.inheritpolicies.checkbox": "Inherit policies",
-  // TODO New key - Add a translation
-  "item.edit.move.inheritpolicies.checkbox": "Inherit policies",
+  "item.edit.move.inheritpolicies.checkbox": "Zdědit politiky",
 
   // "item.edit.move.inheritpolicies.description": "Inherit the default policies of the destination collection",
   "item.edit.move.inheritpolicies.description": "Zdědit výchozí politiky cílové kolekce",
@@ -4254,39 +4203,34 @@
   "item.page.description": "Popis",
 
   // "item.page.org-unit": "Organizational Unit",
-  // TODO New key - Add a translation
-  "item.page.org-unit": "Organizational Unit",
+  "item.page.org-unit": "Organizační jednotka",
 
   // "item.page.org-units": "Organizational Units",
   "item.page.org-units": "Organizační jednotky",
 
   // "item.page.project": "Research Project",
-  // TODO New key - Add a translation
-  "item.page.project": "Research Project",
+  "item.page.project": "Výzkumný projekt",
 
   // "item.page.projects": "Research Projects",
   "item.page.projects": "Výzkumné projekty",
 
   // "item.page.publication": "Publications",
-  // TODO New key - Add a translation
-  "item.page.publication": "Publications",
+  "item.page.publication": "Publikace",
 
   // "item.page.publications": "Publications",
   "item.page.publications": "Publikace",
 
   // "item.page.article": "Article",
-  // TODO New key - Add a translation
-  "item.page.article": "Article",
+  "item.page.article": "Článek",
 
   // "item.page.articles": "Articles",
   "item.page.articles": "Články",
 
   // "item.page.journal": "Journal",
-  "item.page.journal": "Časopisu",
+  "item.page.journal": "Časopis",
 
   // "item.page.journals": "Journals",
-  // TODO New key - Add a translation
-  "item.page.journals": "Journals",
+  "item.page.journals": "Časopisy",
 
   // "item.page.journal-issue": "Journal Issue",
   "item.page.journal-issue": "Číslo časopisu",
@@ -4367,47 +4311,37 @@
   "workflow-item.search.result.list.element.supervised.remove-tooltip": "Odebrat dohlížející autoritu",
 
   // "confidence.indicator.help-text.accepted": "This authority value has been confirmed as accurate by an interactive user",
-  // TODO New key - Add a translation
-  "confidence.indicator.help-text.accepted": "This authority value has been confirmed as accurate by an interactive user",
+  "confidence.indicator.help-text.accepted": "Tato autoritní hodnota byla potvrzena uživatelem jako správná",
 
   // "confidence.indicator.help-text.uncertain": "Value is singular and valid but has not been seen and accepted by a human so it is still uncertain",
-  // TODO New key - Add a translation
-  "confidence.indicator.help-text.uncertain": "Value is singular and valid but has not been seen and accepted by a human so it is still uncertain",
+  "confidence.indicator.help-text.uncertain": "Hodnota je jediná a platná, ale dosud nebyla ověřena člověkem, proto je stále nejistá",
 
   // "confidence.indicator.help-text.ambiguous": "There are multiple matching authority values of equal validity",
-  // TODO New key - Add a translation
-  "confidence.indicator.help-text.ambiguous": "There are multiple matching authority values of equal validity",
+  "confidence.indicator.help-text.ambiguous": "Existuje více odpovídajících autoritních hodnot se stejnou platností",
 
   // "confidence.indicator.help-text.notfound": "There are no matching answers in the authority",
-  // TODO New key - Add a translation
-  "confidence.indicator.help-text.notfound": "There are no matching answers in the authority",
+  "confidence.indicator.help-text.notfound": "V autoritě nejsou žádné odpovídající odpovědi",
 
   // "confidence.indicator.help-text.failed": "The authority encountered an internal failure",
-  // TODO New key - Add a translation
-  "confidence.indicator.help-text.failed": "The authority encountered an internal failure",
+  "confidence.indicator.help-text.failed": "Autoritní služba narazila na interní chybu",
 
   // "confidence.indicator.help-text.rejected": "The authority recommends this submission be rejected",
-  // TODO New key - Add a translation
-  "confidence.indicator.help-text.rejected": "The authority recommends this submission be rejected",
+  "confidence.indicator.help-text.rejected": "Autorita doporučuje tento vklad zamítnout",
 
   // "confidence.indicator.help-text.novalue": "No reasonable confidence value was returned from the authority",
-  // TODO New key - Add a translation
-  "confidence.indicator.help-text.novalue": "No reasonable confidence value was returned from the authority",
+  "confidence.indicator.help-text.novalue": "Autorita nevrátila žádnou rozumnou hodnotu jistoty",
 
   // "confidence.indicator.help-text.unset": "Confidence was never recorded for this value",
-  // TODO New key - Add a translation
-  "confidence.indicator.help-text.unset": "Confidence was never recorded for this value",
+  "confidence.indicator.help-text.unset": "Pro tuto hodnotu nebyla jistota nikdy zaznamenána",
 
   // "confidence.indicator.help-text.unknown": "Unknown confidence value",
-  // TODO New key - Add a translation
-  "confidence.indicator.help-text.unknown": "Unknown confidence value",
+  "confidence.indicator.help-text.unknown": "Neznámá hodnota jistoty",
 
   // "item.page.abstract": "Abstract",
   "item.page.abstract": "Abstrakt",
 
   // "item.page.author": "Author",
-  // TODO New key - Add a translation
-  "item.page.author": "Author",
+  "item.page.author": "Autor",
 
   // "item.page.authors": "Authors",
   "item.page.authors": "Autoři",
@@ -4621,8 +4555,7 @@
   "item.preview.person.identifier.orcid": "ORCID:",
 
   // "item.preview.person.affiliation.name": "Affiliations:",
-  // TODO New key - Add a translation
-  "item.preview.person.affiliation.name": "Affiliations:",
+  "item.preview.person.affiliation.name": "Afiliace:",
 
   // "item.preview.project.funder.name": "Funder:",
   "item.preview.project.funder.name": "Financující subjekt:",
@@ -4631,8 +4564,7 @@
   "item.preview.project.funder.identifier": "Identifikátor financujícího subjektu:",
 
   // "item.preview.project.investigator": "Project Investigator",
-  // TODO New key - Add a translation
-  "item.preview.project.investigator": "Project Investigator",
+  "item.preview.project.investigator": "Řešitel projektu",
 
   // "item.preview.oaire.awardNumber": "Funding ID:",
   "item.preview.oaire.awardNumber": "Identifikátor zdroje financování:",
@@ -4650,48 +4582,37 @@
   "item.preview.oairecerif.identifier.url": "URL",
 
   // "item.preview.organization.address.addressCountry": "Country",
-  // TODO New key - Add a translation
-  "item.preview.organization.address.addressCountry": "Country",
+  "item.preview.organization.address.addressCountry": "Země",
 
   // "item.preview.organization.foundingDate": "Founding Date",
-  // TODO New key - Add a translation
-  "item.preview.organization.foundingDate": "Founding Date",
+  "item.preview.organization.foundingDate": "Datum založení",
 
   // "item.preview.organization.identifier.crossrefid": "Crossref ID",
-  // TODO New key - Add a translation
   "item.preview.organization.identifier.crossrefid": "Crossref ID",
 
   // "item.preview.organization.identifier.isni": "ISNI",
-  // TODO New key - Add a translation
   "item.preview.organization.identifier.isni": "ISNI",
 
   // "item.preview.organization.identifier.ror": "ROR ID",
-  // TODO New key - Add a translation
   "item.preview.organization.identifier.ror": "ROR ID",
 
   // "item.preview.organization.legalName": "Legal Name",
-  // TODO New key - Add a translation
-  "item.preview.organization.legalName": "Legal Name",
+  "item.preview.organization.legalName": "Právní název",
 
   // "item.preview.dspace.entity.type": "Entity Type:",
-  // TODO New key - Add a translation
-  "item.preview.dspace.entity.type": "Entity Type:",
+  "item.preview.dspace.entity.type": "Typ entity:",
 
   // "item.preview.creativework.publisher": "Publisher",
-  // TODO New key - Add a translation
-  "item.preview.creativework.publisher": "Publisher",
+  "item.preview.creativework.publisher": "Vydavatel",
 
   // "item.preview.creativeworkseries.issn": "ISSN",
-  // TODO New key - Add a translation
   "item.preview.creativeworkseries.issn": "ISSN",
 
   // "item.preview.dc.identifier.issn": "ISSN",
-  // TODO New key - Add a translation
   "item.preview.dc.identifier.issn": "ISSN",
 
   // "item.preview.dc.identifier.openalex": "OpenAlex Identifier",
-  // TODO New key - Add a translation
-  "item.preview.dc.identifier.openalex": "OpenAlex Identifier",
+  "item.preview.dc.identifier.openalex": "Identifikátor OpenAlex",
 
   // "item.preview.dc.description": "Description",
   // TODO Source message changed - Revise the translation
@@ -4788,16 +4709,13 @@
   "item.version.create.modal.header": "Nová verze",
 
   // "item.qa.withdrawn.modal.header": "Request withdrawal",
-  // TODO New key - Add a translation
-  "item.qa.withdrawn.modal.header": "Request withdrawal",
+  "item.qa.withdrawn.modal.header": "Žádost o stažení",
 
   // "item.qa.reinstate.modal.header": "Request reinstate",
-  // TODO New key - Add a translation
-  "item.qa.reinstate.modal.header": "Request reinstate",
+  "item.qa.reinstate.modal.header": "Žádost o obnovení",
 
   // "item.qa.reinstate.create.modal.header": "New version",
-  // TODO New key - Add a translation
-  "item.qa.reinstate.create.modal.header": "New version",
+  "item.qa.reinstate.create.modal.header": "Nová verze",
 
   // "item.version.create.modal.text": "Create a new version for this item",
   "item.version.create.modal.text": "Vytvořit novou verzi pro tento záznam",
@@ -4812,16 +4730,13 @@
   "item.version.create.modal.button.confirm.tooltip": "Vytvořit novou verzi",
 
   // "item.qa.withdrawn-reinstate.modal.button.confirm.tooltip": "Send request",
-  // TODO New key - Add a translation
-  "item.qa.withdrawn-reinstate.modal.button.confirm.tooltip": "Send request",
+  "item.qa.withdrawn-reinstate.modal.button.confirm.tooltip": "Odeslat žádost",
 
   // "qa-withdrown.create.modal.button.confirm": "Withdraw",
-  // TODO New key - Add a translation
-  "qa-withdrown.create.modal.button.confirm": "Withdraw",
+  "qa-withdrown.create.modal.button.confirm": "Stáhnout",
 
   // "qa-reinstate.create.modal.button.confirm": "Reinstate",
-  // TODO New key - Add a translation
-  "qa-reinstate.create.modal.button.confirm": "Reinstate",
+  "qa-reinstate.create.modal.button.confirm": "Obnovit",
 
   // "item.version.create.modal.button.cancel": "Cancel",
   "item.version.create.modal.button.cancel": "Zrušit",
@@ -4833,53 +4748,43 @@
   "item.version.create.modal.button.cancel.tooltip": "Nevytvářet novou verzi",
 
   // "item.qa.withdrawn-reinstate.create.modal.button.cancel.tooltip": "Do not send request",
-  // TODO New key - Add a translation
-  "item.qa.withdrawn-reinstate.create.modal.button.cancel.tooltip": "Do not send request",
+  "item.qa.withdrawn-reinstate.create.modal.button.cancel.tooltip": "Neodesílat žádost",
 
   // "item.version.create.modal.form.summary.label": "Summary",
   "item.version.create.modal.form.summary.label": "Souhrn",
 
   // "qa-withdrawn.create.modal.form.summary.label": "You are requesting to withdraw this item",
-  // TODO New key - Add a translation
-  "qa-withdrawn.create.modal.form.summary.label": "You are requesting to withdraw this item",
+  "qa-withdrawn.create.modal.form.summary.label": "Žádáte o stažení tohoto záznamu",
 
   // "qa-withdrawn.create.modal.form.summary2.label": "Please enter the reason for the withdrawal",
-  // TODO New key - Add a translation
-  "qa-withdrawn.create.modal.form.summary2.label": "Please enter the reason for the withdrawal",
+  "qa-withdrawn.create.modal.form.summary2.label": "Uveďte prosím důvod stažení",
 
   // "qa-reinstate.create.modal.form.summary.label": "You are requesting to reinstate this item",
-  // TODO New key - Add a translation
-  "qa-reinstate.create.modal.form.summary.label": "You are requesting to reinstate this item",
+  "qa-reinstate.create.modal.form.summary.label": "Žádáte o obnovení tohoto záznamu",
 
   // "qa-reinstate.create.modal.form.summary2.label": "Please enter the reason for the reinstatment",
-  // TODO New key - Add a translation
-  "qa-reinstate.create.modal.form.summary2.label": "Please enter the reason for the reinstatment",
+  "qa-reinstate.create.modal.form.summary2.label": "Uveďte prosím důvod obnovení",
 
   // "item.version.create.modal.form.summary.placeholder": "Insert the summary for the new version",
   "item.version.create.modal.form.summary.placeholder": "Vložit souhrn nové verze",
 
   // "qa-withdrown.modal.form.summary.placeholder": "Enter the reason for the withdrawal",
-  // TODO New key - Add a translation
-  "qa-withdrown.modal.form.summary.placeholder": "Enter the reason for the withdrawal",
+  "qa-withdrown.modal.form.summary.placeholder": "Zadejte důvod stažení",
 
   // "qa-reinstate.modal.form.summary.placeholder": "Enter the reason for the reinstatement",
-  // TODO New key - Add a translation
-  "qa-reinstate.modal.form.summary.placeholder": "Enter the reason for the reinstatement",
+  "qa-reinstate.modal.form.summary.placeholder": "Zadejte důvod obnovení",
 
   // "item.version.create.modal.submitted.header": "Creating new version...",
   "item.version.create.modal.submitted.header": "Vytváření nové verze...",
 
   // "item.qa.withdrawn.modal.submitted.header": "Sending withdrawn request...",
-  // TODO New key - Add a translation
-  "item.qa.withdrawn.modal.submitted.header": "Sending withdrawn request...",
+  "item.qa.withdrawn.modal.submitted.header": "Odesílání žádosti o stažení...",
 
   // "correction-type.manage-relation.action.notification.reinstate": "Reinstate request sent.",
-  // TODO New key - Add a translation
-  "correction-type.manage-relation.action.notification.reinstate": "Reinstate request sent.",
+  "correction-type.manage-relation.action.notification.reinstate": "Žádost o obnovení odeslána.",
 
   // "correction-type.manage-relation.action.notification.withdrawn": "Withdraw request sent.",
-  // TODO New key - Add a translation
-  "correction-type.manage-relation.action.notification.withdrawn": "Withdraw request sent.",
+  "correction-type.manage-relation.action.notification.withdrawn": "Žádost o stažení odeslána.",
 
   // "item.version.create.modal.submitted.text": "The new version is being created. This may take some time if the item has a lot of relationships.",
   "item.version.create.modal.submitted.text": "Vytváří se nová verze. To může nějakou dobu trvat, pokud má záznam mnoho vztahů.",
@@ -5212,8 +5117,7 @@
   "login.form.password": "Heslo",
 
   // "login.form.saml": "Log in with SAML",
-  // TODO New key - Add a translation
-  "login.form.saml": "Log in with SAML",
+  "login.form.saml": "Přihlásit se pomocí SAML",
 
   // "login.form.shibboleth": "Log in with Shibboleth",
   "login.form.shibboleth": "Přihlásit se pomocí Shibboleth",
@@ -5264,16 +5168,13 @@
   "menu.section.access_control_people": "Lidé",
 
   // "menu.section.reports": "Reports",
-  // TODO New key - Add a translation
-  "menu.section.reports": "Reports",
+  "menu.section.reports": "Zprávy",
 
   // "menu.section.reports.collections": "Filtered Collections",
-  // TODO New key - Add a translation
-  "menu.section.reports.collections": "Filtered Collections",
+  "menu.section.reports.collections": "Filtrované kolekce",
 
   // "menu.section.reports.queries": "Metadata Query",
-  // TODO New key - Add a translation
-  "menu.section.reports.queries": "Metadata Query",
+  "menu.section.reports.queries": "Dotazy na metadata",
 
   // "menu.section.admin_search": "Admin Search",
   "menu.section.admin_search": "Administrátorské vyhledávání",
@@ -5315,8 +5216,7 @@
   "menu.section.browse_global_communities_and_collections": "Komunity & kolekce",
 
   // "menu.section.browse_global_geospatial_map": "By Geolocation (Map)",
-  // TODO New key - Add a translation
-  "menu.section.browse_global_geospatial_map": "By Geolocation (Map)",
+  "menu.section.browse_global_geospatial_map": "Podle geolokace (mapa)",
 
   // "menu.section.control_panel": "Control Panel",
   "menu.section.control_panel": "Ovládací panel",
@@ -5358,8 +5258,7 @@
   "menu.section.icon.access_control": "Sekce menu Řízení přístupu",
 
   // "menu.section.icon.reports": "Reports menu section",
-  // TODO New key - Add a translation
-  "menu.section.icon.reports": "Reports menu section",
+  "menu.section.icon.reports": "Sekce menu Zprávy",
 
   // "menu.section.icon.admin_search": "Admin search menu section",
   "menu.section.icon.admin_search": "Sekce menu Administrátorské vyhledávání",
@@ -5395,8 +5294,7 @@
   "menu.section.icon.unpin": "Odepnout postranní panel",
 
   // "menu.section.icon.notifications": "Notifications menu section",
-  // TODO New key - Add a translation
-  "menu.section.icon.notifications": "Notifications menu section",
+  "menu.section.icon.notifications": "Sekce menu Oznámení",
 
   // "menu.section.import": "Import",
   "menu.section.import": "Importovat",
@@ -5426,16 +5324,13 @@
   "menu.section.new_process": "Proces",
 
   // "menu.section.notifications": "Notifications",
-  // TODO New key - Add a translation
-  "menu.section.notifications": "Notifications",
+  "menu.section.notifications": "Oznámení",
 
   // "menu.section.quality-assurance": "Quality Assurance",
-  // TODO New key - Add a translation
-  "menu.section.quality-assurance": "Quality Assurance",
+  "menu.section.quality-assurance": "Kontrola kvality",
 
   // "menu.section.notifications_publication-claim": "Publication Claim",
-  // TODO New key - Add a translation
-  "menu.section.notifications_publication-claim": "Publication Claim",
+  "menu.section.notifications_publication-claim": "Nárokování publikace",
 
   // "menu.section.pin": "Pin sidebar",
   "menu.section.pin": "Připnout postranní panel",
@@ -5468,8 +5363,7 @@
   "menu.section.toggle.access_control": "Přepnout sekci Řízení přístupu",
 
   // "menu.section.toggle.reports": "Toggle Reports section",
-  // TODO New key - Add a translation
-  "menu.section.toggle.reports": "Toggle Reports section",
+  "menu.section.toggle.reports": "Přepnout sekci Zprávy",
 
   // "menu.section.toggle.control_panel": "Toggle Control Panel section",
   "menu.section.toggle.control_panel": "Přepnout sekci ovládacího panelu",
@@ -5643,16 +5537,13 @@
   "nav.expandable-navbar-section-suffix": "(podnabídka)",
 
   // "notification.suggestion": "We found <b>{{count}} publications</b> in the {{source}} that seems to be related to your profile.<br>",
-  // TODO New key - Add a translation
-  "notification.suggestion": "We found <b>{{count}} publications</b> in the {{source}} that seems to be related to your profile.<br>",
+  "notification.suggestion": "Našli jsme <b>{{count}} publikací</b> ve zdroji {{source}}, které se zdají souviset s vaším profilem.<br>",
 
   // "notification.suggestion.review": "review the suggestions",
-  // TODO New key - Add a translation
-  "notification.suggestion.review": "review the suggestions",
+  "notification.suggestion.review": "zkontrolujte doporučení",
 
   // "notification.suggestion.please": "Please",
-  // TODO New key - Add a translation
-  "notification.suggestion.please": "Please",
+  "notification.suggestion.please": "Prosím",
 
   // "nav.browse.header": "All of DSpace",
   "nav.browse.header": "Celý repozitář",
@@ -5712,292 +5603,220 @@
   "none.listelement.badge": "Záznam",
 
   // "publication-claim.title": "Publication claim",
-  // TODO New key - Add a translation
-  "publication-claim.title": "Publication claim",
+  "publication-claim.title": "Nárokování publikace",
 
   // "publication-claim.source.description": "Below you can see all the sources.",
-  // TODO New key - Add a translation
-  "publication-claim.source.description": "Below you can see all the sources.",
+  "publication-claim.source.description": "Níže jsou zobrazeny všechny zdroje.",
 
   // "quality-assurance.title": "Quality Assurance",
-  // TODO New key - Add a translation
-  "quality-assurance.title": "Quality Assurance",
+  "quality-assurance.title": "Kontrola kvality",
 
   // "quality-assurance.topics.description": "Below you can see all the topics received from the subscriptions to {{source}}.",
-  // TODO New key - Add a translation
-  "quality-assurance.topics.description": "Below you can see all the topics received from the subscriptions to {{source}}.",
+  "quality-assurance.topics.description": "Níže vidíte všechna témata přijatá z odběrů u {{source}}.",
 
   // "quality-assurance.source.description": "Below you can see all the notification's sources.",
-  // TODO New key - Add a translation
-  "quality-assurance.source.description": "Below you can see all the notification's sources.",
+  "quality-assurance.source.description": "Níže vidíte všechny zdroje oznámení.",
 
   // "quality-assurance.topics": "Current Topics",
-  // TODO New key - Add a translation
-  "quality-assurance.topics": "Current Topics",
+  "quality-assurance.topics": "Aktuální témata",
 
   // "quality-assurance.source": "Current Sources",
-  // TODO New key - Add a translation
-  "quality-assurance.source": "Current Sources",
+  "quality-assurance.source": "Aktuální zdroje",
 
   // "quality-assurance.table.topic": "Topic",
-  // TODO New key - Add a translation
-  "quality-assurance.table.topic": "Topic",
+  "quality-assurance.table.topic": "Téma",
 
   // "quality-assurance.table.source": "Source",
-  // TODO New key - Add a translation
-  "quality-assurance.table.source": "Source",
+  "quality-assurance.table.source": "Zdroj",
 
   // "quality-assurance.table.last-event": "Last Event",
-  // TODO New key - Add a translation
-  "quality-assurance.table.last-event": "Last Event",
+  "quality-assurance.table.last-event": "Poslední událost",
 
   // "quality-assurance.table.actions": "Actions",
-  // TODO New key - Add a translation
-  "quality-assurance.table.actions": "Actions",
+  "quality-assurance.table.actions": "Akce",
 
   // "quality-assurance.source-list.button.detail": "Show topics for {{param}}",
-  // TODO New key - Add a translation
-  "quality-assurance.source-list.button.detail": "Show topics for {{param}}",
+  "quality-assurance.source-list.button.detail": "Zobrazit témata pro {{param}}",
 
   // "quality-assurance.topics-list.button.detail": "Show suggestions for {{param}}",
-  // TODO New key - Add a translation
-  "quality-assurance.topics-list.button.detail": "Show suggestions for {{param}}",
+  "quality-assurance.topics-list.button.detail": "Zobrazit doporučení pro {{param}}",
 
   // "quality-assurance.noTopics": "No topics found.",
-  // TODO New key - Add a translation
-  "quality-assurance.noTopics": "No topics found.",
+  "quality-assurance.noTopics": "Nebyla nalezena žádná témata.",
 
   // "quality-assurance.noSource": "No sources found.",
-  // TODO New key - Add a translation
-  "quality-assurance.noSource": "No sources found.",
+  "quality-assurance.noSource": "Nebyly nalezeny žádné zdroje.",
 
   // "notifications.events.title": "Quality Assurance Suggestions",
-  // TODO New key - Add a translation
-  "notifications.events.title": "Quality Assurance Suggestions",
+  "notifications.events.title": "Doporučení pro kontrolu kvality",
 
   // "quality-assurance.topic.error.service.retrieve": "An error occurred while loading the Quality Assurance topics",
-  // TODO New key - Add a translation
-  "quality-assurance.topic.error.service.retrieve": "An error occurred while loading the Quality Assurance topics",
+  "quality-assurance.topic.error.service.retrieve": "Při načítání témat kontroly kvality došlo k chybě",
 
   // "quality-assurance.source.error.service.retrieve": "An error occurred while loading the Quality Assurance source",
-  // TODO New key - Add a translation
-  "quality-assurance.source.error.service.retrieve": "An error occurred while loading the Quality Assurance source",
+  "quality-assurance.source.error.service.retrieve": "Při načítání zdrojů kontroly kvality došlo k chybě",
 
   // "quality-assurance.loading": "Loading ...",
-  // TODO New key - Add a translation
-  "quality-assurance.loading": "Loading ...",
+  "quality-assurance.loading": "Načítání ...",
 
   // "quality-assurance.events.topic": "Topic:",
-  // TODO New key - Add a translation
-  "quality-assurance.events.topic": "Topic:",
+  "quality-assurance.events.topic": "Téma:",
 
   // "quality-assurance.noEvents": "No suggestions found.",
-  // TODO New key - Add a translation
-  "quality-assurance.noEvents": "No suggestions found.",
+  "quality-assurance.noEvents": "Nebyla nalezena žádná doporučení.",
 
   // "quality-assurance.event.table.trust": "Trust",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.trust": "Trust",
+  "quality-assurance.event.table.trust": "Důvěra",
 
   // "quality-assurance.event.table.publication": "Publication",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.publication": "Publication",
+  "quality-assurance.event.table.publication": "Publikace",
 
   // "quality-assurance.event.table.details": "Details",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.details": "Details",
+  "quality-assurance.event.table.details": "Podrobnosti",
 
   // "quality-assurance.event.table.project-details": "Project details",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.project-details": "Project details",
+  "quality-assurance.event.table.project-details": "Podrobnosti o projektu",
 
   // "quality-assurance.event.table.reasons": "Reasons",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.reasons": "Reasons",
+  "quality-assurance.event.table.reasons": "Důvody",
 
   // "quality-assurance.event.table.actions": "Actions",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.actions": "Actions",
+  "quality-assurance.event.table.actions": "Akce",
 
   // "quality-assurance.event.action.accept": "Accept suggestion",
-  // TODO New key - Add a translation
-  "quality-assurance.event.action.accept": "Accept suggestion",
+  "quality-assurance.event.action.accept": "Přijmout doporučení",
 
   // "quality-assurance.event.action.ignore": "Ignore suggestion",
-  // TODO New key - Add a translation
-  "quality-assurance.event.action.ignore": "Ignore suggestion",
+  "quality-assurance.event.action.ignore": "Ignorovat doporučení",
 
   // "quality-assurance.event.action.undo": "Delete",
-  // TODO New key - Add a translation
-  "quality-assurance.event.action.undo": "Delete",
+  "quality-assurance.event.action.undo": "Smazat",
 
   // "quality-assurance.event.action.reject": "Reject suggestion",
-  // TODO New key - Add a translation
-  "quality-assurance.event.action.reject": "Reject suggestion",
+  "quality-assurance.event.action.reject": "Odmítnout doporučení",
 
   // "quality-assurance.event.action.import": "Import project and accept suggestion",
-  // TODO New key - Add a translation
-  "quality-assurance.event.action.import": "Import project and accept suggestion",
+  "quality-assurance.event.action.import": "Importovat projekt a přijmout doporučení",
 
   // "quality-assurance.event.table.pidtype": "PID Type:",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.pidtype": "PID Type:",
+  "quality-assurance.event.table.pidtype": "Typ PID:",
 
   // "quality-assurance.event.table.pidvalue": "PID Value:",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.pidvalue": "PID Value:",
+  "quality-assurance.event.table.pidvalue": "Hodnota PID:",
 
   // "quality-assurance.event.table.subjectValue": "Subject Value:",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.subjectValue": "Subject Value:",
+  "quality-assurance.event.table.subjectValue": "Hodnota předmětu:",
 
   // "quality-assurance.event.table.abstract": "Abstract:",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.abstract": "Abstract:",
+  "quality-assurance.event.table.abstract": "Abstrakt:",
 
   // "quality-assurance.event.table.suggestedProject": "OpenAIRE Suggested Project data",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.suggestedProject": "OpenAIRE Suggested Project data",
+  "quality-assurance.event.table.suggestedProject": "Navržená data projektu OpenAIRE",
 
   // "quality-assurance.event.table.project": "Project title:",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.project": "Project title:",
+  "quality-assurance.event.table.project": "Název projektu:",
 
   // "quality-assurance.event.table.acronym": "Acronym:",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.acronym": "Acronym:",
+  "quality-assurance.event.table.acronym": "Zkratka:",
 
   // "quality-assurance.event.table.code": "Code:",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.code": "Code:",
+  "quality-assurance.event.table.code": "Kód:",
 
   // "quality-assurance.event.table.funder": "Funder:",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.funder": "Funder:",
+  "quality-assurance.event.table.funder": "Poskytovatel financí:",
 
   // "quality-assurance.event.table.fundingProgram": "Funding program:",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.fundingProgram": "Funding program:",
+  "quality-assurance.event.table.fundingProgram": "Finanční program:",
 
   // "quality-assurance.event.table.jurisdiction": "Jurisdiction:",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.jurisdiction": "Jurisdiction:",
+  "quality-assurance.event.table.jurisdiction": "Příslušnost:",
 
   // "quality-assurance.events.back": "Back to topics",
-  // TODO New key - Add a translation
-  "quality-assurance.events.back": "Back to topics",
+  "quality-assurance.events.back": "Zpět na témata",
 
   // "quality-assurance.events.back-to-sources": "Back to sources",
-  // TODO New key - Add a translation
-  "quality-assurance.events.back-to-sources": "Back to sources",
+  "quality-assurance.events.back-to-sources": "Zpět na zdroje",
 
   // "quality-assurance.event.table.less": "Show less",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.less": "Show less",
+  "quality-assurance.event.table.less": "Zobrazit méně",
 
   // "quality-assurance.event.table.more": "Show more",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.more": "Show more",
+  "quality-assurance.event.table.more": "Zobrazit více",
 
   // "quality-assurance.event.project.found": "Bound to the local record:",
-  // TODO New key - Add a translation
-  "quality-assurance.event.project.found": "Bound to the local record:",
+  "quality-assurance.event.project.found": "Propojeno s místním záznamem:",
 
   // "quality-assurance.event.project.notFound": "No local record found",
-  // TODO New key - Add a translation
-  "quality-assurance.event.project.notFound": "No local record found",
+  "quality-assurance.event.project.notFound": "Nebyl nalezen žádný místní záznam",
 
   // "quality-assurance.event.sure": "Are you sure?",
-  // TODO New key - Add a translation
-  "quality-assurance.event.sure": "Are you sure?",
+  "quality-assurance.event.sure": "Jste si jisti?",
 
   // "quality-assurance.event.ignore.description": "This operation can't be undone. Ignore this suggestion?",
-  // TODO New key - Add a translation
-  "quality-assurance.event.ignore.description": "This operation can't be undone. Ignore this suggestion?",
+  "quality-assurance.event.ignore.description": "Tuto operaci nelze vrátit. Ignorovat toto doporučení?",
 
   // "quality-assurance.event.undo.description": "This operation can't be undone!",
-  // TODO New key - Add a translation
-  "quality-assurance.event.undo.description": "This operation can't be undone!",
+  "quality-assurance.event.undo.description": "Tuto operaci nelze vrátit!",
 
   // "quality-assurance.event.reject.description": "This operation can't be undone. Reject this suggestion?",
-  // TODO New key - Add a translation
-  "quality-assurance.event.reject.description": "This operation can't be undone. Reject this suggestion?",
+  "quality-assurance.event.reject.description": "Tuto operaci nelze vrátit. Odmítnout toto doporučení?",
 
   // "quality-assurance.event.accept.description": "No DSpace project selected. A new project will be created based on the suggestion data.",
-  // TODO New key - Add a translation
-  "quality-assurance.event.accept.description": "No DSpace project selected. A new project will be created based on the suggestion data.",
+  "quality-assurance.event.accept.description": "Nebyl vybrán žádný projekt DSpace. Nový projekt bude vytvořen na základě údajů z doporučení.",
 
   // "quality-assurance.event.action.cancel": "Cancel",
-  // TODO New key - Add a translation
-  "quality-assurance.event.action.cancel": "Cancel",
+  "quality-assurance.event.action.cancel": "Zrušit",
 
   // "quality-assurance.event.action.saved": "Your decision has been saved successfully.",
-  // TODO New key - Add a translation
-  "quality-assurance.event.action.saved": "Your decision has been saved successfully.",
+  "quality-assurance.event.action.saved": "Vaše rozhodnutí bylo úspěšně uloženo.",
 
   // "quality-assurance.event.action.error": "An error has occurred. Your decision has not been saved.",
-  // TODO New key - Add a translation
-  "quality-assurance.event.action.error": "An error has occurred. Your decision has not been saved.",
+  "quality-assurance.event.action.error": "Došlo k chybě. Vaše rozhodnutí nebylo uloženo.",
 
   // "quality-assurance.event.modal.project.title": "Choose a project to bound",
-  // TODO New key - Add a translation
-  "quality-assurance.event.modal.project.title": "Choose a project to bound",
+  "quality-assurance.event.modal.project.title": "Zvolte projekt k propojení",
 
   // "quality-assurance.event.modal.project.publication": "Publication:",
-  // TODO New key - Add a translation
-  "quality-assurance.event.modal.project.publication": "Publication:",
+  "quality-assurance.event.modal.project.publication": "Publikace:",
 
   // "quality-assurance.event.modal.project.bountToLocal": "Bound to the local record:",
-  // TODO New key - Add a translation
-  "quality-assurance.event.modal.project.bountToLocal": "Bound to the local record:",
+  "quality-assurance.event.modal.project.bountToLocal": "Propojeno s místním záznamem:",
 
   // "quality-assurance.event.modal.project.select": "Project search",
-  // TODO New key - Add a translation
-  "quality-assurance.event.modal.project.select": "Project search",
+  "quality-assurance.event.modal.project.select": "Vyhledávání projektů",
 
   // "quality-assurance.event.modal.project.search": "Search",
-  // TODO New key - Add a translation
-  "quality-assurance.event.modal.project.search": "Search",
+  "quality-assurance.event.modal.project.search": "Hledat",
 
   // "quality-assurance.event.modal.project.clear": "Clear",
-  // TODO New key - Add a translation
-  "quality-assurance.event.modal.project.clear": "Clear",
+  "quality-assurance.event.modal.project.clear": "Vymazat",
 
   // "quality-assurance.event.modal.project.cancel": "Cancel",
-  // TODO New key - Add a translation
-  "quality-assurance.event.modal.project.cancel": "Cancel",
+  "quality-assurance.event.modal.project.cancel": "Zrušit",
 
   // "quality-assurance.event.modal.project.bound": "Bound project",
-  // TODO New key - Add a translation
-  "quality-assurance.event.modal.project.bound": "Bound project",
+  "quality-assurance.event.modal.project.bound": "Propojený projekt",
 
   // "quality-assurance.event.modal.project.remove": "Remove",
-  // TODO New key - Add a translation
-  "quality-assurance.event.modal.project.remove": "Remove",
+  "quality-assurance.event.modal.project.remove": "Odebrat",
 
   // "quality-assurance.event.modal.project.placeholder": "Enter a project name",
-  // TODO New key - Add a translation
-  "quality-assurance.event.modal.project.placeholder": "Enter a project name",
+  "quality-assurance.event.modal.project.placeholder": "Zadejte název projektu",
 
   // "quality-assurance.event.modal.project.notFound": "No project found.",
-  // TODO New key - Add a translation
-  "quality-assurance.event.modal.project.notFound": "No project found.",
+  "quality-assurance.event.modal.project.notFound": "Nebyl nalezen žádný projekt.",
 
   // "quality-assurance.event.project.bounded": "The project has been linked successfully.",
-  // TODO New key - Add a translation
-  "quality-assurance.event.project.bounded": "The project has been linked successfully.",
+  "quality-assurance.event.project.bounded": "Projekt byl úspěšně propojen.",
 
   // "quality-assurance.event.project.removed": "The project has been successfully unlinked.",
-  // TODO New key - Add a translation
-  "quality-assurance.event.project.removed": "The project has been successfully unlinked.",
+  "quality-assurance.event.project.removed": "Propojení projektu bylo úspěšně zrušeno.",
 
   // "quality-assurance.event.project.error": "An error has occurred. No operation performed.",
-  // TODO New key - Add a translation
-  "quality-assurance.event.project.error": "An error has occurred. No operation performed.",
+  "quality-assurance.event.project.error": "Došlo k chybě. Nebyla provedena žádná operace.",
 
   // "quality-assurance.event.reason": "Reason",
-  // TODO New key - Add a translation
-  "quality-assurance.event.reason": "Reason",
+  "quality-assurance.event.reason": "Důvod",
 
   // "orgunit.listelement.badge": "Organizational Unit",
   "orgunit.listelement.badge": "Organizační jednotka",
@@ -6024,15 +5843,13 @@
   "orgunit.page.id": "ID",
 
   // "orgunit.page.options": "Options",
-  // TODO New key - Add a translation
-  "orgunit.page.options": "Options",
+  "orgunit.page.options": "Možnosti",
 
   // "orgunit.page.titleprefix": "Organizational Unit: ",
   "orgunit.page.titleprefix": "Organizační jednotka: ",
 
   // "orgunit.page.ror": "ROR Identifier",
-  // TODO New key - Add a translation
-  "orgunit.page.ror": "ROR Identifier",
+  "orgunit.page.ror": "Identifikátor ROR",
 
   // "orgunit.search.results.head": "Organizational Unit Search Results",
   "orgunit.search.results.head": "Výsledky hledání organizační jednotky",
@@ -6083,8 +5900,7 @@
   "person.page.link.full": "Zobrazit všechna metadata",
 
   // "person.page.options": "Options",
-  // TODO New key - Add a translation
-  "person.page.options": "Options",
+  "person.page.options": "Možnosti",
 
   // "person.page.orcid": "ORCID",
   "person.page.orcid": "ORCID",
@@ -6249,28 +6065,22 @@
   "process.detail.delete.error": "Při mazání procesu se něco pokazilo",
 
   // "process.detail.refreshing": "Auto-refreshing…",
-  // TODO New key - Add a translation
-  "process.detail.refreshing": "Auto-refreshing…",
+  "process.detail.refreshing": "Automatické obnovování…",
 
   // "process.overview.table.completed.info": "Finish time (UTC)",
-  // TODO New key - Add a translation
-  "process.overview.table.completed.info": "Finish time (UTC)",
+  "process.overview.table.completed.info": "Čas dokončení (UTC)",
 
   // "process.overview.table.completed.title": "Succeeded processes",
-  // TODO New key - Add a translation
-  "process.overview.table.completed.title": "Succeeded processes",
+  "process.overview.table.completed.title": "Úspěšné procesy",
 
   // "process.overview.table.empty": "No matching processes found.",
-  // TODO New key - Add a translation
-  "process.overview.table.empty": "No matching processes found.",
+  "process.overview.table.empty": "Nebyly nalezeny žádné odpovídající procesy.",
 
   // "process.overview.table.failed.info": "Finish time (UTC)",
-  // TODO New key - Add a translation
-  "process.overview.table.failed.info": "Finish time (UTC)",
+  "process.overview.table.failed.info": "Čas dokončení (UTC)",
 
   // "process.overview.table.failed.title": "Failed processes",
-  // TODO New key - Add a translation
-  "process.overview.table.failed.title": "Failed processes",
+  "process.overview.table.failed.title": "Neúspěšné procesy",
 
   // "process.overview.table.finish": "Finish time (UTC)",
   "process.overview.table.finish": "Čas ukončení (UTC)",
@@ -6282,20 +6092,16 @@
   "process.overview.table.name": "Název",
 
   // "process.overview.table.running.info": "Start time (UTC)",
-  // TODO New key - Add a translation
-  "process.overview.table.running.info": "Start time (UTC)",
+  "process.overview.table.running.info": "Čas zahájení (UTC)",
 
   // "process.overview.table.running.title": "Running processes",
-  // TODO New key - Add a translation
-  "process.overview.table.running.title": "Running processes",
+  "process.overview.table.running.title": "Běžící procesy",
 
   // "process.overview.table.scheduled.info": "Creation time (UTC)",
-  // TODO New key - Add a translation
-  "process.overview.table.scheduled.info": "Creation time (UTC)",
+  "process.overview.table.scheduled.info": "Čas vytvoření (UTC)",
 
   // "process.overview.table.scheduled.title": "Scheduled processes",
-  // TODO New key - Add a translation
-  "process.overview.table.scheduled.title": "Scheduled processes",
+  "process.overview.table.scheduled.title": "Naplánované procesy",
 
   // "process.overview.table.start": "Start time (UTC)",
   "process.overview.table.start": "Čas zahájení (UTC)",
@@ -6472,8 +6278,7 @@
   "project.page.keyword": "Klíčová slova",
 
   // "project.page.options": "Options",
-  // TODO New key - Add a translation
-  "project.page.options": "Options",
+  "project.page.options": "Možnosti",
 
   // "project.page.status": "Status",
   "project.page.status": "Status",
@@ -6506,8 +6311,7 @@
   "publication.page.publisher": "Nakladatel",
 
   // "publication.page.options": "Options",
-  // TODO New key - Add a translation
-  "publication.page.options": "Options",
+  "publication.page.options": "Možnosti",
 
   // "publication.page.titleprefix": "Publication: ",
   "publication.page.titleprefix": "Publikace: ",
@@ -6534,139 +6338,105 @@
   "media-viewer.playlist": "Playlist",
 
   // "suggestion.loading": "Loading ...",
-  // TODO New key - Add a translation
-  "suggestion.loading": "Loading ...",
+  "suggestion.loading": "Načítání ...",
 
   // "suggestion.title": "Publication Claim",
-  // TODO New key - Add a translation
-  "suggestion.title": "Publication Claim",
+  "suggestion.title": "Nárokování publikace",
 
   // "suggestion.title.breadcrumbs": "Publication Claim",
-  // TODO New key - Add a translation
-  "suggestion.title.breadcrumbs": "Publication Claim",
+  "suggestion.title.breadcrumbs": "Nárokování publikace",
 
   // "suggestion.targets.description": "Below you can see all the suggestions ",
-  // TODO New key - Add a translation
-  "suggestion.targets.description": "Below you can see all the suggestions ",
+  "suggestion.targets.description": "Níže můžete vidět všechna doporučení ",
 
   // "suggestion.targets": "Current Suggestions",
-  // TODO New key - Add a translation
-  "suggestion.targets": "Current Suggestions",
+  "suggestion.targets": "Aktuální doporučení",
 
   // "suggestion.table.name": "Researcher Name",
-  // TODO New key - Add a translation
-  "suggestion.table.name": "Researcher Name",
+  "suggestion.table.name": "Jméno výzkumníka",
 
   // "suggestion.table.actions": "Actions",
-  // TODO New key - Add a translation
-  "suggestion.table.actions": "Actions",
+  "suggestion.table.actions": "Akce",
 
   // "suggestion.button.review": "Review {{ total }} suggestion(s)",
-  // TODO New key - Add a translation
-  "suggestion.button.review": "Review {{ total }} suggestion(s)",
+  "suggestion.button.review": "Zkontrolovat {{ total }} doporučení",
 
   // "suggestion.button.review.title": "Review {{ total }} suggestion(s) for ",
-  // TODO New key - Add a translation
-  "suggestion.button.review.title": "Review {{ total }} suggestion(s) for ",
+  "suggestion.button.review.title": "Zkontrolovat {{ total }} doporučení pro ",
 
   // "suggestion.noTargets": "No target found.",
-  // TODO New key - Add a translation
-  "suggestion.noTargets": "No target found.",
+  "suggestion.noTargets": "Nebyl nalezen žádný cíl.",
 
   // "suggestion.target.error.service.retrieve": "An error occurred while loading the Suggestion targets",
-  // TODO New key - Add a translation
-  "suggestion.target.error.service.retrieve": "An error occurred while loading the Suggestion targets",
+  "suggestion.target.error.service.retrieve": "Při načítání cílů doporučení došlo k chybě",
 
   // "suggestion.evidence.type": "Type",
-  // TODO New key - Add a translation
-  "suggestion.evidence.type": "Type",
+  "suggestion.evidence.type": "Typ",
 
   // "suggestion.evidence.score": "Score",
-  // TODO New key - Add a translation
-  "suggestion.evidence.score": "Score",
+  "suggestion.evidence.score": "Skóre",
 
   // "suggestion.evidence.notes": "Notes",
-  // TODO New key - Add a translation
-  "suggestion.evidence.notes": "Notes",
+  "suggestion.evidence.notes": "Poznámky",
 
   // "suggestion.approveAndImport": "Approve & import",
-  // TODO New key - Add a translation
-  "suggestion.approveAndImport": "Approve & import",
+  "suggestion.approveAndImport": "Schválit a importovat",
 
   // "suggestion.approveAndImport.success": "The suggestion has been imported successfully. <a href='{{ url }}'>View.</a>",
-  // TODO New key - Add a translation
-  "suggestion.approveAndImport.success": "The suggestion has been imported successfully. <a href='{{ url }}'>View.</a>",
+  "suggestion.approveAndImport.success": "Doporučení bylo úspěšně importováno. <a href='{{ url }}'>Zobrazit.</a>",
 
   // "suggestion.approveAndImport.bulk": "Approve & import Selected",
-  // TODO New key - Add a translation
-  "suggestion.approveAndImport.bulk": "Approve & import Selected",
+  "suggestion.approveAndImport.bulk": "Schválit a importovat vybrané",
 
   // "suggestion.approveAndImport.bulk.success": "{{ count }} suggestions have been imported successfully ",
-  // TODO New key - Add a translation
-  "suggestion.approveAndImport.bulk.success": "{{ count }} suggestions have been imported successfully ",
+  "suggestion.approveAndImport.bulk.success": "{{ count }} doporučení bylo úspěšně importováno ",
 
   // "suggestion.approveAndImport.bulk.error": "{{ count }} suggestions haven't been imported due to unexpected server errors",
-  // TODO New key - Add a translation
-  "suggestion.approveAndImport.bulk.error": "{{ count }} suggestions haven't been imported due to unexpected server errors",
+  "suggestion.approveAndImport.bulk.error": "{{ count }} doporučení nebylo importováno z důvodu neočekávaných chyb serveru",
 
   // "suggestion.ignoreSuggestion": "Ignore Suggestion",
-  // TODO New key - Add a translation
-  "suggestion.ignoreSuggestion": "Ignore Suggestion",
+  "suggestion.ignoreSuggestion": "Ignorovat doporučení",
 
   // "suggestion.ignoreSuggestion.success": "The suggestion has been discarded",
-  // TODO New key - Add a translation
-  "suggestion.ignoreSuggestion.success": "The suggestion has been discarded",
+  "suggestion.ignoreSuggestion.success": "Doporučení bylo zahozeno",
 
   // "suggestion.ignoreSuggestion.bulk": "Ignore Suggestion Selected",
-  // TODO New key - Add a translation
-  "suggestion.ignoreSuggestion.bulk": "Ignore Suggestion Selected",
+  "suggestion.ignoreSuggestion.bulk": "Ignorovat vybraná doporučení",
 
   // "suggestion.ignoreSuggestion.bulk.success": "{{ count }} suggestions have been discarded ",
-  // TODO New key - Add a translation
-  "suggestion.ignoreSuggestion.bulk.success": "{{ count }} suggestions have been discarded ",
+  "suggestion.ignoreSuggestion.bulk.success": "{{ count }} doporučení bylo zahozeno ",
 
   // "suggestion.ignoreSuggestion.bulk.error": "{{ count }} suggestions haven't been discarded due to unexpected server errors",
-  // TODO New key - Add a translation
-  "suggestion.ignoreSuggestion.bulk.error": "{{ count }} suggestions haven't been discarded due to unexpected server errors",
+  "suggestion.ignoreSuggestion.bulk.error": "{{ count }} doporučení nebylo zahozeno z důvodu neočekávaných chyb serveru",
 
   // "suggestion.seeEvidence": "See evidence",
-  // TODO New key - Add a translation
-  "suggestion.seeEvidence": "See evidence",
+  "suggestion.seeEvidence": "Zobrazit podklady",
 
   // "suggestion.hideEvidence": "Hide evidence",
-  // TODO New key - Add a translation
-  "suggestion.hideEvidence": "Hide evidence",
+  "suggestion.hideEvidence": "Skrýt podklady",
 
   // "suggestion.suggestionFor": "Suggestions for",
-  // TODO New key - Add a translation
-  "suggestion.suggestionFor": "Suggestions for",
+  "suggestion.suggestionFor": "Doporučení pro",
 
   // "suggestion.suggestionFor.breadcrumb": "Suggestions for {{ name }}",
-  // TODO New key - Add a translation
-  "suggestion.suggestionFor.breadcrumb": "Suggestions for {{ name }}",
+  "suggestion.suggestionFor.breadcrumb": "Doporučení pro {{ name }}",
 
   // "suggestion.source.openaire": "OpenAIRE Graph",
-  // TODO New key - Add a translation
   "suggestion.source.openaire": "OpenAIRE Graph",
 
   // "suggestion.source.openalex": "OpenAlex",
-  // TODO New key - Add a translation
   "suggestion.source.openalex": "OpenAlex",
 
   // "suggestion.from.source": "from the ",
-  // TODO New key - Add a translation
-  "suggestion.from.source": "from the ",
+  "suggestion.from.source": "ze zdroje ",
 
   // "suggestion.count.missing": "You have no publication claims left",
-  // TODO New key - Add a translation
-  "suggestion.count.missing": "You have no publication claims left",
+  "suggestion.count.missing": "Nemáte žádné další publikace k nárokování.",
 
   // "suggestion.totalScore": "Total Score",
-  // TODO New key - Add a translation
-  "suggestion.totalScore": "Total Score",
+  "suggestion.totalScore": "Celkové skóre",
 
   // "suggestion.type.openaire": "OpenAIRE",
-  // TODO New key - Add a translation
   "suggestion.type.openaire": "OpenAIRE",
 
   // "register-email.title": "New user registration",
@@ -6848,8 +6618,7 @@
   "relationships.Project.isFundingAgencyOfProject.OrgUnit": "Poskytovatel financí",
 
   // "relationships.OrgUnit.isPublicationOfOrgUnit.Publication": "Organisation Publications",
-  // TODO New key - Add a translation
-  "relationships.OrgUnit.isPublicationOfOrgUnit.Publication": "Organisation Publications",
+  "relationships.OrgUnit.isPublicationOfOrgUnit.Publication": "Publikace organizace",
 
   // "relationships.OrgUnit.isPersonOfOrgUnit.Person": "Authors",
   "relationships.OrgUnit.isPersonOfOrgUnit.Person": "Autoři",
@@ -6858,8 +6627,7 @@
   "relationships.OrgUnit.isProjectOfOrgUnit.Project": "Výzkumné projekty",
 
   // "relationships.OrgUnit.isPublicationOfAuthor.Publication": "Authored Publications",
-  // TODO New key - Add a translation
-  "relationships.OrgUnit.isPublicationOfAuthor.Publication": "Authored Publications",
+  "relationships.OrgUnit.isPublicationOfAuthor.Publication": "Autorské publikace",
 
   // "relationships.OrgUnit.isPublicationOfContributor.Publication": "Publications (contributor to)",
   // TODO Source message changed - Revise the translation
@@ -7101,8 +6869,7 @@
   "search.filters.remove": "Odstranit filtr typu {{ type }} s hodnotou {{ value }}",
 
   // "search.filters.applied.f.title": "Title",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.title": "Title",
+  "search.filters.applied.f.title": "Název",
 
   // "search.filters.applied.f.author": "Author",
   "search.filters.applied.f.author": "Autor",
@@ -7126,15 +6893,12 @@
   "search.filters.applied.f.has_content_in_original_bundle": "Má soubory",
 
   // "search.filters.applied.f.original_bundle_filenames": "File name",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.original_bundle_filenames": "File name",
+  "search.filters.applied.f.original_bundle_filenames": "Název souboru",
 
   // "search.filters.applied.f.original_bundle_descriptions": "File description",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.original_bundle_descriptions": "File description",
+  "search.filters.applied.f.original_bundle_descriptions": "Popis souboru",
   // "search.filters.applied.f.has_geospatial_metadata": "Has geographical location",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.has_geospatial_metadata": "Has geographical location",
+  "search.filters.applied.f.has_geospatial_metadata": "Má geografickou polohu",
 
   // "search.filters.applied.f.itemtype": "Type",
   "search.filters.applied.f.itemtype": "Typ",
@@ -7167,42 +6931,34 @@
   "search.filters.applied.operator.equals": "",
 
   // "search.filters.applied.operator.notequals": " not equals",
-  // TODO New key - Add a translation
-  "search.filters.applied.operator.notequals": " not equals",
+  "search.filters.applied.operator.notequals": " není rovno",
 
   // "search.filters.applied.operator.authority": "",
   "search.filters.applied.operator.authority": "",
 
   // "search.filters.applied.operator.notauthority": " not authority",
-  // TODO New key - Add a translation
-  "search.filters.applied.operator.notauthority": " not authority",
+  "search.filters.applied.operator.notauthority": " není autorita",
 
   // "search.filters.applied.operator.contains": " contains",
-  // TODO New key - Add a translation
-  "search.filters.applied.operator.contains": " contains",
+  "search.filters.applied.operator.contains": " obsahuje",
 
   // "search.filters.applied.operator.notcontains": " not contains",
-  // TODO New key - Add a translation
-  "search.filters.applied.operator.notcontains": " not contains",
+  "search.filters.applied.operator.notcontains": " neobsahuje",
 
   // "search.filters.applied.operator.query": "",
   "search.filters.applied.operator.query": "",
 
   // "search.filters.applied.f.point": "Coordinates",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.point": "Coordinates",
+  "search.filters.applied.f.point": "Souřadnice",
 
   // "search.filters.filter.title.head": "Title",
-  // TODO New key - Add a translation
-  "search.filters.filter.title.head": "Title",
+  "search.filters.filter.title.head": "Název",
 
   // "search.filters.filter.title.placeholder": "Title",
-  // TODO New key - Add a translation
-  "search.filters.filter.title.placeholder": "Title",
+  "search.filters.filter.title.placeholder": "Název",
 
   // "search.filters.filter.title.label": "Search Title",
-  // TODO New key - Add a translation
-  "search.filters.filter.title.label": "Search Title",
+  "search.filters.filter.title.label": "Hledat název",
 
   // "search.filters.filter.author.head": "Author",
   "search.filters.filter.author.head": "Autor",
@@ -7313,32 +7069,25 @@
   "search.filters.filter.has_content_in_original_bundle.head": "Má soubory",
 
   // "search.filters.filter.original_bundle_filenames.head": "File name",
-  // TODO New key - Add a translation
-  "search.filters.filter.original_bundle_filenames.head": "File name",
+  "search.filters.filter.original_bundle_filenames.head": "Název souboru",
 
   // "search.filters.filter.has_geospatial_metadata.head": "Has geographical location",
-  // TODO New key - Add a translation
-  "search.filters.filter.has_geospatial_metadata.head": "Has geographical location",
+  "search.filters.filter.has_geospatial_metadata.head": "Má geografickou polohu",
 
   // "search.filters.filter.original_bundle_filenames.placeholder": "File name",
-  // TODO New key - Add a translation
-  "search.filters.filter.original_bundle_filenames.placeholder": "File name",
+  "search.filters.filter.original_bundle_filenames.placeholder": "Název souboru",
 
   // "search.filters.filter.original_bundle_filenames.label": "Search File name",
-  // TODO New key - Add a translation
-  "search.filters.filter.original_bundle_filenames.label": "Search File name",
+  "search.filters.filter.original_bundle_filenames.label": "Hledat název souboru",
 
   // "search.filters.filter.original_bundle_descriptions.head": "File description",
-  // TODO New key - Add a translation
-  "search.filters.filter.original_bundle_descriptions.head": "File description",
+  "search.filters.filter.original_bundle_descriptions.head": "Popis souboru",
 
   // "search.filters.filter.original_bundle_descriptions.placeholder": "File description",
-  // TODO New key - Add a translation
-  "search.filters.filter.original_bundle_descriptions.placeholder": "File description",
+  "search.filters.filter.original_bundle_descriptions.placeholder": "Popis souboru",
 
   // "search.filters.filter.original_bundle_descriptions.label": "Search File description",
-  // TODO New key - Add a translation
-  "search.filters.filter.original_bundle_descriptions.label": "Search File description",
+  "search.filters.filter.original_bundle_descriptions.label": "Hledat popis souboru",
 
   // "search.filters.filter.itemtype.head": "Type",
   "search.filters.filter.itemtype.head": "Typ",
@@ -7413,12 +7162,10 @@
   "search.filters.filter.organizationFoundingDate.label": "Hledat datum založení",
 
   // "search.filters.filter.organizationFoundingDate.min.label": "Start",
-  // TODO New key - Add a translation
-  "search.filters.filter.organizationFoundingDate.min.label": "Start",
+  "search.filters.filter.organizationFoundingDate.min.label": "Začátek",
 
   // "search.filters.filter.organizationFoundingDate.max.label": "End",
-  // TODO New key - Add a translation
-  "search.filters.filter.organizationFoundingDate.max.label": "End",
+  "search.filters.filter.organizationFoundingDate.max.label": "Konec",
 
   // "search.filters.filter.scope.head": "Scope",
   "search.filters.filter.scope.head": "Rozsah",
@@ -7457,12 +7204,10 @@
   "search.filters.filter.show-tree": "Procházet {{ name }} podle",
 
   // "search.filters.filter.funding.head": "Funding",
-  // TODO New key - Add a translation
-  "search.filters.filter.funding.head": "Funding",
+  "search.filters.filter.funding.head": "Financování",
 
   // "search.filters.filter.funding.placeholder": "Funding",
-  // TODO New key - Add a translation
-  "search.filters.filter.funding.placeholder": "Funding",
+  "search.filters.filter.funding.placeholder": "Financování",
 
   // "search.filters.filter.supervisedBy.head": "Supervised By",
   "search.filters.filter.supervisedBy.head": "Dohlížející autorita:",
@@ -7474,16 +7219,13 @@
   "search.filters.filter.supervisedBy.label": "Hledat dohlížející autoritu",
 
   // "search.filters.filter.access_status.head": "Access type",
-  // TODO New key - Add a translation
-  "search.filters.filter.access_status.head": "Access type",
+  "search.filters.filter.access_status.head": "Typ přístupu",
 
   // "search.filters.filter.access_status.placeholder": "Access type",
-  // TODO New key - Add a translation
-  "search.filters.filter.access_status.placeholder": "Access type",
+  "search.filters.filter.access_status.placeholder": "Typ přístupu",
 
   // "search.filters.filter.access_status.label": "Search by access type",
-  // TODO New key - Add a translation
-  "search.filters.filter.access_status.label": "Search by access type",
+  "search.filters.filter.access_status.label": "Hledat podle typu přístupu",
 
   // "search.filters.entityType.JournalIssue": "Journal Issue",
   "search.filters.entityType.JournalIssue": "Číslo časopisu",
@@ -7495,16 +7237,13 @@
   "search.filters.entityType.OrgUnit": "Organizační jednotka",
 
   // "search.filters.entityType.Person": "Person",
-  // TODO New key - Add a translation
-  "search.filters.entityType.Person": "Person",
+  "search.filters.entityType.Person": "Osoba",
 
   // "search.filters.entityType.Project": "Project",
-  // TODO New key - Add a translation
-  "search.filters.entityType.Project": "Project",
+  "search.filters.entityType.Project": "Projekt",
 
   // "search.filters.entityType.Publication": "Publication",
-  // TODO New key - Add a translation
-  "search.filters.entityType.Publication": "Publication",
+  "search.filters.entityType.Publication": "Publikace",
 
   // "search.filters.has_content_in_original_bundle.true": "Yes",
   "search.filters.has_content_in_original_bundle.true": "Ano",
@@ -7555,32 +7294,25 @@
   "search.filters.search.submit": "Odeslat",
 
   // "search.filters.operator.equals.text": "Equals",
-  // TODO New key - Add a translation
-  "search.filters.operator.equals.text": "Equals",
+  "search.filters.operator.equals.text": "Rovná se",
 
   // "search.filters.operator.notequals.text": "Not Equals",
-  // TODO New key - Add a translation
-  "search.filters.operator.notequals.text": "Not Equals",
+  "search.filters.operator.notequals.text": "Nerovná se",
 
   // "search.filters.operator.authority.text": "Authority",
-  // TODO New key - Add a translation
-  "search.filters.operator.authority.text": "Authority",
+  "search.filters.operator.authority.text": "Autorita",
 
   // "search.filters.operator.notauthority.text": "Not Authority",
-  // TODO New key - Add a translation
-  "search.filters.operator.notauthority.text": "Not Authority",
+  "search.filters.operator.notauthority.text": "Není autorita",
 
   // "search.filters.operator.contains.text": "Contains",
-  // TODO New key - Add a translation
-  "search.filters.operator.contains.text": "Contains",
+  "search.filters.operator.contains.text": "Obsahuje",
 
   // "search.filters.operator.notcontains.text": "Not Contains",
-  // TODO New key - Add a translation
-  "search.filters.operator.notcontains.text": "Not Contains",
+  "search.filters.operator.notcontains.text": "Neobsahuje",
 
   // "search.filters.operator.query.text": "Query",
-  // TODO New key - Add a translation
-  "search.filters.operator.query.text": "Query",
+  "search.filters.operator.query.text": "Dotaz",
 
   // "search.form.search": "Search",
   "search.form.search": "Hledat",
@@ -7604,8 +7336,7 @@
   "search.results.empty": "Vaše vyhledávání nevrátilo žádné výsledky.",
 
   // "search.results.geospatial-map.empty": "No results on this page with geospatial locations",
-  // TODO New key - Add a translation
-  "search.results.geospatial-map.empty": "No results on this page with geospatial locations",
+  "search.results.geospatial-map.empty": "Na této stránce nejsou žádné výsledky s geografickou polohou",
 
   // "search.results.view-result": "View",
   "search.results.view-result": "Zobrazit",
@@ -7638,24 +7369,19 @@
   "search.sidebar.settings.sort-by": "Řadit dle",
 
   // "search.sidebar.advanced-search.title": "Advanced Search",
-  // TODO New key - Add a translation
-  "search.sidebar.advanced-search.title": "Advanced Search",
+  "search.sidebar.advanced-search.title": "Pokročilé vyhledávání",
 
   // "search.sidebar.advanced-search.filter-by": "Filter by",
-  // TODO New key - Add a translation
-  "search.sidebar.advanced-search.filter-by": "Filter by",
+  "search.sidebar.advanced-search.filter-by": "Filtrovat podle",
 
   // "search.sidebar.advanced-search.filters": "Filters",
-  // TODO New key - Add a translation
-  "search.sidebar.advanced-search.filters": "Filters",
+  "search.sidebar.advanced-search.filters": "Filtry",
 
   // "search.sidebar.advanced-search.operators": "Operators",
-  // TODO New key - Add a translation
-  "search.sidebar.advanced-search.operators": "Operators",
+  "search.sidebar.advanced-search.operators": "Operátory",
 
   // "search.sidebar.advanced-search.add": "Add",
-  // TODO New key - Add a translation
-  "search.sidebar.advanced-search.add": "Add",
+  "search.sidebar.advanced-search.add": "Přidat",
 
   // "search.sidebar.settings.title": "Settings",
   "search.sidebar.settings.title": "Nastavení",
@@ -7670,8 +7396,7 @@
   "search.view-switch.show-list": "Zobrazit jako seznam",
 
   // "search.view-switch.show-geospatialMap": "Show as map",
-  // TODO New key - Add a translation
-  "search.view-switch.show-geospatialMap": "Show as map",
+  "search.view-switch.show-geospatialMap": "Zobrazit jako mapu",
 
   // "selectable-list-item-control.deselect": "Deselect item",
   "selectable-list-item-control.deselect": "Zrušit výběr položky",
@@ -7800,8 +7525,7 @@
   "submission.general.discard.submit": "Vyřadit",
 
   // "submission.general.back.submit": "Back",
-  // TODO New key - Add a translation
-  "submission.general.back.submit": "Back",
+  "submission.general.back.submit": "Zpět",
 
   // "submission.general.info.saved": "Saved",
   "submission.general.info.saved": "Uloženo",
@@ -7879,7 +7603,6 @@
   "submission.import-external.source.datacite": "DataCite",
 
   // "submission.import-external.source.dataciteProject": "DataCite",
-  // TODO New key - Add a translation
   "submission.import-external.source.dataciteProject": "DataCite",
 
   // "submission.import-external.source.doi": "DOI",
@@ -7916,16 +7639,13 @@
   "submission.import-external.source.sherpaPublisher": "SHERPA Publishers",
 
   // "submission.import-external.source.openaire": "OpenAIRE Search by Authors",
-  // TODO New key - Add a translation
-  "submission.import-external.source.openaire": "OpenAIRE Search by Authors",
+  "submission.import-external.source.openaire": "OpenAIRE vyhledávání podle autorů",
 
   // "submission.import-external.source.openaireTitle": "OpenAIRE Search by Title",
-  // TODO New key - Add a translation
-  "submission.import-external.source.openaireTitle": "OpenAIRE Search by Title",
+  "submission.import-external.source.openaireTitle": "OpenAIRE vyhledávání podle názvu",
 
   // "submission.import-external.source.openaireFunding": "OpenAIRE Search by Funder",
-  // TODO New key - Add a translation
-  "submission.import-external.source.openaireFunding": "OpenAIRE Search by Funder",
+  "submission.import-external.source.openaireFunding": "OpenAIRE vyhledávání podle poskytovatele financí",
 
   // "submission.import-external.source.orcid": "ORCID",
   "submission.import-external.source.orcid": "ORCID",
@@ -7940,40 +7660,31 @@
   "submission.import-external.source.lcname": "Library of Congress Names",
 
   // "submission.import-external.source.ror": "Research Organization Registry (ROR)",
-  // TODO New key - Add a translation
-  "submission.import-external.source.ror": "Research Organization Registry (ROR)",
+  "submission.import-external.source.ror": "Registr výzkumných organizací (ROR)",
 
   // "submission.import-external.source.openalexPublication": "OpenAlex Search by Title",
-  // TODO New key - Add a translation
-  "submission.import-external.source.openalexPublication": "OpenAlex Search by Title",
+  "submission.import-external.source.openalexPublication": "OpenAlex vyhledávání podle názvu",
 
   // "submission.import-external.source.openalexPublicationByAuthorId": "OpenAlex Search by Author ID",
-  // TODO New key - Add a translation
-  "submission.import-external.source.openalexPublicationByAuthorId": "OpenAlex Search by Author ID",
+  "submission.import-external.source.openalexPublicationByAuthorId": "OpenAlex vyhledávání podle ID autora",
 
   // "submission.import-external.source.openalexPublicationByDOI": "OpenAlex Search by DOI",
-  // TODO New key - Add a translation
-  "submission.import-external.source.openalexPublicationByDOI": "OpenAlex Search by DOI",
+  "submission.import-external.source.openalexPublicationByDOI": "OpenAlex vyhledávání podle DOI",
 
   // "submission.import-external.source.openalexPerson": "OpenAlex Search by name",
-  // TODO New key - Add a translation
-  "submission.import-external.source.openalexPerson": "OpenAlex Search by name",
+  "submission.import-external.source.openalexPerson": "OpenAlex vyhledávání podle jména",
 
   // "submission.import-external.source.openalexJournal": "OpenAlex Journals",
-  // TODO New key - Add a translation
-  "submission.import-external.source.openalexJournal": "OpenAlex Journals",
+  "submission.import-external.source.openalexJournal": "OpenAlex časopisy",
 
   // "submission.import-external.source.openalexInstitution": "OpenAlex Institutions",
-  // TODO New key - Add a translation
-  "submission.import-external.source.openalexInstitution": "OpenAlex Institutions",
+  "submission.import-external.source.openalexInstitution": "OpenAlex instituce",
 
   // "submission.import-external.source.openalexPublisher": "OpenAlex Publishers",
-  // TODO New key - Add a translation
-  "submission.import-external.source.openalexPublisher": "OpenAlex Publishers",
+  "submission.import-external.source.openalexPublisher": "OpenAlex vydavatelé",
 
   // "submission.import-external.source.openalexFunder": "OpenAlex Funders",
-  // TODO New key - Add a translation
-  "submission.import-external.source.openalexFunder": "OpenAlex Funders",
+  "submission.import-external.source.openalexFunder": "OpenAlex poskytovatelé financí",
 
   // "submission.import-external.preview.title": "Item Preview",
   "submission.import-external.preview.title": "Náhled záznamu",
@@ -8099,16 +7810,13 @@
   "submission.sections.describe.relationship-lookup.external-source.import-modal.head.orcid": "Import z ORCID",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaire": "Importing from OpenAIRE",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaire": "Importing from OpenAIRE",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaire": "Import z OpenAIRE",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaireTitle": "Importing from OpenAIRE",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaireTitle": "Importing from OpenAIRE",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaireTitle": "Import z OpenAIRE",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaireFunding": "Importing from OpenAIRE",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaireFunding": "Importing from OpenAIRE",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.head.openaireFunding": "Import z OpenAIRE",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.head.sherpaJournal": "Importing from Sherpa Journal",
   "submission.sections.describe.relationship-lookup.external-source.import-modal.head.sherpaJournal": "Import z Sherpa Journal",
@@ -8159,16 +7867,13 @@
   "submission.sections.describe.relationship-lookup.external-source.import-modal.select": "Vyberte lokální shodu:",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfProject.title": "Import Remote Organization",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfProject.title": "Import Remote Organization",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfProject.title": "Importovat externí organizaci",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfProject.added.local-entity": "Successfully added local organization to the selection",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfProject.added.local-entity": "Successfully added local organization to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfProject.added.local-entity": "Lokální organizace úspěšně přidána do výběru",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfProject.added.new-entity": "Successfully imported and added external organization to the selection",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfProject.added.new-entity": "Successfully imported and added external organization to the selection",
+  "submission.sections.describe.relationship-lookup.external-source.import-modal.isOrgUnitOfProject.added.new-entity": "Externí organizace úspěšně importována a přidána do výběru",
 
   // "submission.sections.describe.relationship-lookup.search-tab.deselect-all": "Deselect all",
   "submission.sections.describe.relationship-lookup.search-tab.deselect-all": "Zrušit výběr všech",
@@ -8270,39 +7975,31 @@
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.scopus": "Scopus ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaire": "OpenAIRE Search by Authors ({{ count }})",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaire": "OpenAIRE Search by Authors ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaire": "OpenAIRE vyhledávání podle autorů ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaireTitle": "OpenAIRE Search by Title ({{ count }})",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaireTitle": "OpenAIRE Search by Title ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaireTitle": "OpenAIRE vyhledávání podle názvu ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaireFunding": "OpenAIRE Search by Funder ({{ count }})",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaireFunding": "OpenAIRE Search by Funder ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openaireFunding": "OpenAIRE vyhledávání podle poskytovatele financí ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.sherpaJournalIssn": "Sherpa Journals by ISSN ({{ count }})",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.sherpaJournalIssn": "Sherpa Journals by ISSN ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.sherpaJournalIssn": "Sherpa časopisy podle ISSN ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexPerson": "OpenAlex ({{ count }})",
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexPerson": "OpenAlex ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexInstitution": "OpenAlex Search by Institution ({{ count }})",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexInstitution": "OpenAlex Search by Institution ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexInstitution": "OpenAlex vyhledávání podle instituce ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexPublisher": "OpenAlex Search by Publisher ({{ count }})",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexPublisher": "OpenAlex Search by Publisher ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexPublisher": "OpenAlex vyhledávání podle vydavatele ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexFunder": "OpenAlex Search by Funder ({{ count }})",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexFunder": "OpenAlex Search by Funder ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.openalexFunder": "OpenAlex vyhledávání podle poskytovatele financí ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.dataciteProject": "DataCite Search by Project ({{ count }})",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.dataciteProject": "DataCite Search by Project ({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.dataciteProject": "DataCite vyhledávání podle projektu ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isFundingAgencyOfPublication": "Search for Funding Agencies",
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.isFundingAgencyOfPublication": "Vyhledat financující agentury",
@@ -8323,8 +8020,7 @@
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.isPublicationOfAuthor": "Publikace autora",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isOrgUnitOfProject": "OrgUnit of the Project",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isOrgUnitOfProject": "OrgUnit of the Project",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isOrgUnitOfProject": "Organizační jednotky projektu",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.isProjectOfPublication": "Project",
   "submission.sections.describe.relationship-lookup.selection-tab.title.isProjectOfPublication": "Projekt",
@@ -8336,8 +8032,7 @@
   "submission.sections.describe.relationship-lookup.title.isFundingAgencyOfProject": "Poskytovatel financí na projekt",
 
   // "submission.sections.describe.relationship-lookup.title.isPersonOfProject": "Person of the Project",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.title.isPersonOfProject": "Person of the Project",
+  "submission.sections.describe.relationship-lookup.title.isPersonOfProject": "Osoba projektu",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.search-form.placeholder": "Search...",
   "submission.sections.describe.relationship-lookup.selection-tab.search-form.placeholder": "Hledat...",
@@ -8346,8 +8041,7 @@
   "submission.sections.describe.relationship-lookup.selection-tab.tab-title": "Aktuální výběr ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.title.Journal": "Journal",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.title.Journal": "Journal",
+  "submission.sections.describe.relationship-lookup.title.Journal": "Časopis",
 
   // "submission.sections.describe.relationship-lookup.title.isJournalIssueOfPublication": "Journal Issues",
   "submission.sections.describe.relationship-lookup.title.isJournalIssueOfPublication": "Čísla časopisu",
@@ -8479,16 +8173,13 @@
   "submission.sections.describe.relationship-lookup.selection-tab.title.orcidv2": "Výsledky vyhledávání",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.openaire": "Search Results",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.selection-tab.title.openaire": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.openaire": "Výsledky vyhledávání",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.openaireTitle": "Search Results",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.selection-tab.title.openaireTitle": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.openaireTitle": "Výsledky vyhledávání",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.openaireFundin": "Search Results",
-  // TODO New key - Add a translation
-  "submission.sections.describe.relationship-lookup.selection-tab.title.openaireFundin": "Search Results",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.openaireFundin": "Výsledky vyhledávání",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.lcname": "Search Results",
   "submission.sections.describe.relationship-lookup.selection-tab.title.lcname": "Výsledky vyhledávání",
@@ -8707,12 +8398,10 @@
   "submission.sections.toggle.aria.close": "Sbalit {{sectionHeader}} sekci",
 
   // "submission.sections.upload.primary.make": "Make {{fileName}} the primary bitstream",
-  // TODO New key - Add a translation
-  "submission.sections.upload.primary.make": "Make {{fileName}} the primary bitstream",
+  "submission.sections.upload.primary.make": "Nastavit {{fileName}} jako primární soubor",
 
   // "submission.sections.upload.primary.remove": "Remove {{fileName}} as the primary bitstream",
-  // TODO New key - Add a translation
-  "submission.sections.upload.primary.remove": "Remove {{fileName}} as the primary bitstream",
+  "submission.sections.upload.primary.remove": "Odebrat {{fileName}} z pozice primárního souboru",
 
   // "submission.sections.upload.delete.confirm.cancel": "Cancel",
   "submission.sections.upload.delete.confirm.cancel": "Zrušit",
@@ -8850,20 +8539,16 @@
   "submission.sections.accesses.form.until-placeholder": "Do",
 
   // "submission.sections.duplicates.none": "No duplicates were detected.",
-  // TODO New key - Add a translation
-  "submission.sections.duplicates.none": "No duplicates were detected.",
+  "submission.sections.duplicates.none": "Nebyly zjištěny žádné duplicity.",
 
   // "submission.sections.duplicates.detected": "Potential duplicates were detected. Please review the list below.",
-  // TODO New key - Add a translation
-  "submission.sections.duplicates.detected": "Potential duplicates were detected. Please review the list below.",
+  "submission.sections.duplicates.detected": "Byly zjištěny možné duplicity. Zkontrolujte prosím níže uvedený seznam.",
 
   // "submission.sections.duplicates.in-workspace": "This item is in workspace",
-  // TODO New key - Add a translation
-  "submission.sections.duplicates.in-workspace": "This item is in workspace",
+  "submission.sections.duplicates.in-workspace": "Tento záznam je v pracovním prostoru",
 
   // "submission.sections.duplicates.in-workflow": "This item is in workflow",
-  // TODO New key - Add a translation
-  "submission.sections.duplicates.in-workflow": "This item is in workflow",
+  "submission.sections.duplicates.in-workflow": "Tento záznam je ve workflow",
 
   // "submission.sections.license.granted-label": "I confirm the license above",
   "submission.sections.license.granted-label": "Potvrzuji výše uvedenou licenci",
@@ -9055,8 +8740,7 @@
   "submission.workflow.tasks.pool.show-detail": "Zobrazit detail",
 
   // "submission.workflow.tasks.duplicates": "potential duplicates were detected for this item. Claim and edit this item to see details.",
-  // TODO New key - Add a translation
-  "submission.workflow.tasks.duplicates": "potential duplicates were detected for this item. Claim and edit this item to see details.",
+  "submission.workflow.tasks.duplicates": "Byly zjištěny možné duplicity tohoto záznamu. Převzít a upravit záznam pro zobrazení detailů.",
 
   // "submission.workspace.generic.view": "View",
   "submission.workspace.generic.view": "Zobrazit",
@@ -9872,8 +9556,7 @@
   "admin.system-wide-alert.title": "Systémová upozornění",
 
   // "discover.filters.head": "Discover",
-  // TODO New key - Add a translation
-  "discover.filters.head": "Discover",
+  "discover.filters.head": "Objevovat",
 
   // "item-access-control-title": "This form allows you to perform changes to the access conditions of the item's metadata or its bitstreams.",
   "item-access-control-title": "Tento formulář umožňuje provést změny typu přístupu k metadatovému záznamu nebo souborům.",
@@ -9987,20 +9670,16 @@
   "coar-notify-support.ldn-inbox.title": "LDN schránka",
 
   // "coar-notify-support.ldn-inbox.content": "For your convenience, our LDN (Linked Data Notifications) InBox is easily accessible at {{ ldnInboxUrl }}. The LDN InBox enables seamless communication and data exchange, ensuring efficient and effective collaboration.",
-  // TODO New key - Add a translation
-  "coar-notify-support.ldn-inbox.content": "For your convenience, our LDN (Linked Data Notifications) InBox is easily accessible at {{ ldnInboxUrl }}. The LDN InBox enables seamless communication and data exchange, ensuring efficient and effective collaboration.",
+  "coar-notify-support.ldn-inbox.content": "Pro vaše pohodlí je naše LDN (Linked Data Notifications) schránka snadno dostupná na {{ ldnInboxUrl }}. LDN schránka umožňuje bezproblémovou komunikaci a výměnu dat, zajišťuje efektivní spolupráci.",
 
   // "coar-notify-support.message-moderation.title": "Message Moderation",
-  // TODO New key - Add a translation
-  "coar-notify-support.message-moderation.title": "Message Moderation",
+  "coar-notify-support.message-moderation.title": "Moderace zpráv",
 
   // "coar-notify-support.message-moderation.content": "To ensure a secure and productive environment, all incoming LDN messages are moderated. If you are planning to exchange information with us, kindly reach out via our dedicated",
-  // TODO New key - Add a translation
-  "coar-notify-support.message-moderation.content": "To ensure a secure and productive environment, all incoming LDN messages are moderated. If you are planning to exchange information with us, kindly reach out via our dedicated",
+  "coar-notify-support.message-moderation.content": "Aby bylo zajištěno bezpečné a produktivní prostředí, všechny příchozí LDN zprávy jsou moderovány. Pokud plánujete s námi vyměňovat informace, kontaktujte nás prosím prostřednictvím našeho",
 
   // "coar-notify-support.message-moderation.feedback-form": " Feedback form.",
-  // TODO New key - Add a translation
-  "coar-notify-support.message-moderation.feedback-form": " Feedback form.",
+  "coar-notify-support.message-moderation.feedback-form": " formuláře zpětné vazby.",
 
   // "service.overview.delete.header": "Delete Service",
   "service.overview.delete.header": "Odstranit službu",
@@ -10312,943 +9991,708 @@
   "menu.section.services_new": "LDN služba",
 
   // "quality-assurance.topics.description-with-target": "Below you can see all the topics received from the subscriptions to {{source}} in regards to the",
-  // TODO New key - Add a translation
-  "quality-assurance.topics.description-with-target": "Below you can see all the topics received from the subscriptions to {{source}} in regards to the",
+  "quality-assurance.topics.description-with-target": "Níže jsou všechna témata získaná z odběrů od {{source}} týkající se ",
   // "quality-assurance.events.description": "Below the list of all the suggestions for the selected topic <b>{{topic}}</b>, related to <b>{{source}}</b>.",
-  // TODO New key - Add a translation
-  "quality-assurance.events.description": "Below the list of all the suggestions for the selected topic <b>{{topic}}</b>, related to <b>{{source}}</b>.",
+  "quality-assurance.events.description": "Níže je seznam všech návrhů pro vybrané téma <b>{{topic}}</b>, souvisejících se <b>{{source}}</b>.",
 
   // "quality-assurance.events.description-with-topic-and-target": "Below the list of all the suggestions for the selected topic <b>{{topic}}</b>, related to <b>{{source}}</b> and ",
-  // TODO New key - Add a translation
-  "quality-assurance.events.description-with-topic-and-target": "Below the list of all the suggestions for the selected topic <b>{{topic}}</b>, related to <b>{{source}}</b> and ",
+  "quality-assurance.events.description-with-topic-and-target": "Níže je seznam všech návrhů pro vybrané téma <b>{{topic}}</b>, souvisejících se <b>{{source}}</b> a ",
 
   // "quality-assurance.event.table.event.message.serviceUrl": "Actor:",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.event.message.serviceUrl": "Actor:",
+  "quality-assurance.event.table.event.message.serviceUrl": "Aktér:",
 
   // "quality-assurance.event.table.event.message.link": "Link:",
-  // TODO New key - Add a translation
-  "quality-assurance.event.table.event.message.link": "Link:",
+  "quality-assurance.event.table.event.message.link": "Odkaz:",
 
   // "service.detail.delete.cancel": "Cancel",
-  // TODO New key - Add a translation
-  "service.detail.delete.cancel": "Cancel",
+  "service.detail.delete.cancel": "Zrušit",
 
   // "service.detail.delete.button": "Delete service",
-  // TODO New key - Add a translation
-  "service.detail.delete.button": "Delete service",
+  "service.detail.delete.button": "Odstranit službu",
 
   // "service.detail.delete.header": "Delete service",
-  // TODO New key - Add a translation
-  "service.detail.delete.header": "Delete service",
+  "service.detail.delete.header": "Odstranit službu",
 
   // "service.detail.delete.body": "Are you sure you want to delete the current service?",
-  // TODO New key - Add a translation
-  "service.detail.delete.body": "Are you sure you want to delete the current service?",
+  "service.detail.delete.body": "Opravdu chcete odstranit tuto službu?",
 
   // "service.detail.delete.confirm": "Delete service",
-  // TODO New key - Add a translation
-  "service.detail.delete.confirm": "Delete service",
+  "service.detail.delete.confirm": "Odstranit službu",
 
   // "service.detail.delete.success": "The service was successfully deleted.",
-  // TODO New key - Add a translation
-  "service.detail.delete.success": "The service was successfully deleted.",
+  "service.detail.delete.success": "Služba byla úspěšně odstraněna.",
 
   // "service.detail.delete.error": "Something went wrong when deleting the service",
-  // TODO New key - Add a translation
-  "service.detail.delete.error": "Something went wrong when deleting the service",
+  "service.detail.delete.error": "Při odstraňování služby se něco pokazilo",
 
   // "service.overview.table.id": "Services ID",
-  // TODO New key - Add a translation
-  "service.overview.table.id": "Services ID",
+  "service.overview.table.id": "ID služeb",
 
   // "service.overview.table.name": "Name",
-  // TODO New key - Add a translation
-  "service.overview.table.name": "Name",
+  "service.overview.table.name": "Název",
 
   // "service.overview.table.start": "Start time (UTC)",
-  // TODO New key - Add a translation
-  "service.overview.table.start": "Start time (UTC)",
+  "service.overview.table.start": "Čas zahájení (UTC)",
 
   // "service.overview.table.status": "Status",
-  // TODO New key - Add a translation
-  "service.overview.table.status": "Status",
+  "service.overview.table.status": "Stav",
 
   // "service.overview.table.user": "User",
-  // TODO New key - Add a translation
-  "service.overview.table.user": "User",
+  "service.overview.table.user": "Uživatel",
 
   // "service.overview.title": "Services Overview",
-  // TODO New key - Add a translation
-  "service.overview.title": "Services Overview",
+  "service.overview.title": "Přehled služeb",
 
   // "service.overview.breadcrumbs": "Services Overview",
-  // TODO New key - Add a translation
-  "service.overview.breadcrumbs": "Services Overview",
+  "service.overview.breadcrumbs": "Přehled služeb",
 
   // "service.overview.table.actions": "Actions",
-  // TODO New key - Add a translation
-  "service.overview.table.actions": "Actions",
+  "service.overview.table.actions": "Akce",
 
   // "service.overview.table.description": "Description",
-  // TODO New key - Add a translation
-  "service.overview.table.description": "Description",
+  "service.overview.table.description": "Popis",
 
   // "submission.sections.submit.progressbar.coarnotify": "COAR Notify",
-  // TODO New key - Add a translation
   "submission.sections.submit.progressbar.coarnotify": "COAR Notify",
 
   // "submission.section.section-coar-notify.control.request-review.label": "You can request a review to one of the following services",
-  // TODO New key - Add a translation
-  "submission.section.section-coar-notify.control.request-review.label": "You can request a review to one of the following services",
+  "submission.section.section-coar-notify.control.request-review.label": "Můžete požádat o recenzi jednu z následujících služeb",
 
   // "submission.section.section-coar-notify.control.request-endorsement.label": "You can request an Endorsement to one of the following overlay journals",
-  // TODO New key - Add a translation
-  "submission.section.section-coar-notify.control.request-endorsement.label": "You can request an Endorsement to one of the following overlay journals",
+  "submission.section.section-coar-notify.control.request-endorsement.label": "Můžete požádat o doporučení jeden z následujících overlay časopisů",
 
   // "submission.section.section-coar-notify.control.request-ingest.label": "You can request to ingest a copy of your submission to one of the following services",
-  // TODO New key - Add a translation
-  "submission.section.section-coar-notify.control.request-ingest.label": "You can request to ingest a copy of your submission to one of the following services",
+  "submission.section.section-coar-notify.control.request-ingest.label": "Můžete požádat o převzetí kopie vašeho příspěvku do jedné z následujících služeb",
 
   // "submission.section.section-coar-notify.dropdown.no-data": "No data available",
-  // TODO New key - Add a translation
-  "submission.section.section-coar-notify.dropdown.no-data": "No data available",
+  "submission.section.section-coar-notify.dropdown.no-data": "Žádná dostupná data",
 
   // "submission.section.section-coar-notify.dropdown.select-none": "Select none",
-  // TODO New key - Add a translation
-  "submission.section.section-coar-notify.dropdown.select-none": "Select none",
+  "submission.section.section-coar-notify.dropdown.select-none": "Zrušit výběr",
 
   // "submission.section.section-coar-notify.small.notification": "Select a service for {{ pattern }} of this item",
-  // TODO New key - Add a translation
-  "submission.section.section-coar-notify.small.notification": "Select a service for {{ pattern }} of this item",
+  "submission.section.section-coar-notify.small.notification": "Vyberte službu pro {{ pattern }} tohoto záznamu",
 
   // "submission.section.section-coar-notify.selection.description": "Selected service's description:",
-  // TODO New key - Add a translation
-  "submission.section.section-coar-notify.selection.description": "Selected service's description:",
+  "submission.section.section-coar-notify.selection.description": "Popis vybrané služby:",
 
   // "submission.section.section-coar-notify.selection.no-description": "No further information is available",
-  // TODO New key - Add a translation
-  "submission.section.section-coar-notify.selection.no-description": "No further information is available",
+  "submission.section.section-coar-notify.selection.no-description": "Nejsou dostupné žádné další informace",
 
   // "submission.section.section-coar-notify.notification.error": "The selected service is not suitable for the current item. Please check the description for details about which record can be managed by this service.",
-  // TODO New key - Add a translation
-  "submission.section.section-coar-notify.notification.error": "The selected service is not suitable for the current item. Please check the description for details about which record can be managed by this service.",
+  "submission.section.section-coar-notify.notification.error": "Vybraná služba není vhodná pro aktuální záznam. Podrobnosti o tom, který záznam může tato služba spravovat, najdete v popisu.",
 
   // "submission.section.section-coar-notify.info.no-pattern": "No configurable patterns found.",
-  // TODO New key - Add a translation
-  "submission.section.section-coar-notify.info.no-pattern": "No configurable patterns found.",
+  "submission.section.section-coar-notify.info.no-pattern": "Nenalezeny žádné konfigurovatelné vzory.",
 
   // "error.validation.coarnotify.invalidfilter": "Invalid filter, try to select another service or none.",
-  // TODO New key - Add a translation
-  "error.validation.coarnotify.invalidfilter": "Invalid filter, try to select another service or none.",
+  "error.validation.coarnotify.invalidfilter": "Neplatný filtr, zkuste vybrat jinou službu nebo žádnou.",
 
   // "request-status-alert-box.accepted": "The requested {{ offerType }} for <a href='{{serviceUrl}}' target='_blank'> {{ serviceName }}  </a> has been taken in charge.",
-  // TODO New key - Add a translation
-  "request-status-alert-box.accepted": "The requested {{ offerType }} for <a href='{{serviceUrl}}' target='_blank'> {{ serviceName }}  </a> has been taken in charge.",
+  "request-status-alert-box.accepted": "Požadovaná {{ offerType }} pro <a href='{{serviceUrl}}' target='_blank'> {{ serviceName }} </a> byla převzata.",
 
   // "request-status-alert-box.rejected": "The requested {{ offerType }} for <a href='{{serviceUrl}}' target='_blank'> {{ serviceName }}  </a> has been rejected.",
-  // TODO New key - Add a translation
-  "request-status-alert-box.rejected": "The requested {{ offerType }} for <a href='{{serviceUrl}}' target='_blank'> {{ serviceName }}  </a> has been rejected.",
+  "request-status-alert-box.rejected": "Požadovaná {{ offerType }} pro <a href='{{serviceUrl}}' target='_blank'> {{ serviceName }} </a> byla zamítnuta.",
 
   // "request-status-alert-box.tentative_rejected": "The requested {{ offerType }} for <a href='{{serviceUrl}}' target='_blank'> {{ serviceName }}  </a> has been tentatively rejected. Revisions are required",
-  // TODO New key - Add a translation
-  "request-status-alert-box.tentative_rejected": "The requested {{ offerType }} for <a href='{{serviceUrl}}' target='_blank'> {{ serviceName }}  </a> has been tentatively rejected. Revisions are required",
+  "request-status-alert-box.tentative_rejected": "Požadovaná {{ offerType }} pro <a href='{{serviceUrl}}' target='_blank'> {{ serviceName }} </a> byla prozatímně zamítnuta. Jsou vyžadovány revize",
 
   // "request-status-alert-box.requested": "The requested {{ offerType }} for <a href='{{serviceUrl}}' target='_blank'> {{ serviceName }}  </a> is pending.",
-  // TODO New key - Add a translation
-  "request-status-alert-box.requested": "The requested {{ offerType }} for <a href='{{serviceUrl}}' target='_blank'> {{ serviceName }}  </a> is pending.",
+  "request-status-alert-box.requested": "Požadovaná {{ offerType }} pro <a href='{{serviceUrl}}' target='_blank'> {{ serviceName }} </a> čeká na vyřízení.",
 
   // "ldn-service-button-mark-inbound-deletion": "Mark supported pattern for deletion",
-  // TODO New key - Add a translation
-  "ldn-service-button-mark-inbound-deletion": "Mark supported pattern for deletion",
+  "ldn-service-button-mark-inbound-deletion": "Označit podporovaný vzor k odstranění",
 
   // "ldn-service-button-unmark-inbound-deletion": "Unmark supported pattern for deletion",
-  // TODO New key - Add a translation
-  "ldn-service-button-unmark-inbound-deletion": "Unmark supported pattern for deletion",
+  "ldn-service-button-unmark-inbound-deletion": "Zrušit označení podporovaného vzoru k odstranění",
 
   // "ldn-service-input-inbound-item-filter-dropdown": "Select Item filter for the pattern",
-  // TODO New key - Add a translation
-  "ldn-service-input-inbound-item-filter-dropdown": "Select Item filter for the pattern",
+  "ldn-service-input-inbound-item-filter-dropdown": "Vyberte filtr záznamu pro vzor",
 
   // "ldn-service-input-inbound-pattern-dropdown": "Select a pattern for service",
-  // TODO New key - Add a translation
-  "ldn-service-input-inbound-pattern-dropdown": "Select a pattern for service",
+  "ldn-service-input-inbound-pattern-dropdown": "Vyberte vzor pro službu",
 
   // "ldn-service-overview-select-delete": "Select service for deletion",
-  // TODO New key - Add a translation
-  "ldn-service-overview-select-delete": "Select service for deletion",
+  "ldn-service-overview-select-delete": "Vyberte službu k odstranění",
 
   // "ldn-service-overview-select-edit": "Edit LDN service",
-  // TODO New key - Add a translation
-  "ldn-service-overview-select-edit": "Edit LDN service",
+  "ldn-service-overview-select-edit": "Upravit LDN službu",
 
   // "ldn-service-overview-close-modal": "Close modal",
-  // TODO New key - Add a translation
-  "ldn-service-overview-close-modal": "Close modal",
+  "ldn-service-overview-close-modal": "Zavřít okno",
 
   // "ldn-service-usesActorEmailId": "Requires actor email in notifications",
-  // TODO New key - Add a translation
-  "ldn-service-usesActorEmailId": "Requires actor email in notifications",
+  "ldn-service-usesActorEmailId": "Vyžaduje e‑mail aktéra v oznámeních",
 
   // "ldn-service-usesActorEmailId-description": "If enabled, initial notifications sent will include the submitter email rather than the repository URL. This is usually the case for endorsement or review services.",
-  // TODO New key - Add a translation
-  "ldn-service-usesActorEmailId-description": "If enabled, initial notifications sent will include the submitter email rather than the repository URL. This is usually the case for endorsement or review services.",
+  "ldn-service-usesActorEmailId-description": "Je-li povoleno, počáteční oznámení budou obsahovat e‑mail odesílatele místo URL repozitáře. To je obvyklé u služeb doporučení nebo recenzí.",
 
   // "a-common-or_statement.label": "Item type is Journal Article or Dataset",
-  // TODO New key - Add a translation
-  "a-common-or_statement.label": "Item type is Journal Article or Dataset",
+  "a-common-or_statement.label": "Typ záznamu je Článek v časopise nebo Datová sada",
 
   // "always_true_filter.label": "Always true",
-  // TODO New key - Add a translation
-  "always_true_filter.label": "Always true",
+  "always_true_filter.label": "Vždy pravda",
 
   // "automatic_processing_collection_filter_16.label": "Automatic processing",
-  // TODO New key - Add a translation
-  "automatic_processing_collection_filter_16.label": "Automatic processing",
+  "automatic_processing_collection_filter_16.label": "Automatické zpracování",
 
   // "dc-identifier-uri-contains-doi_condition.label": "URI contains DOI",
-  // TODO New key - Add a translation
-  "dc-identifier-uri-contains-doi_condition.label": "URI contains DOI",
+  "dc-identifier-uri-contains-doi_condition.label": "URI obsahuje DOI",
 
   // "doi-filter.label": "DOI filter",
-  // TODO New key - Add a translation
-  "doi-filter.label": "DOI filter",
+  "doi-filter.label": "DOI filtr",
 
   // "driver-document-type_condition.label": "Document type equals driver",
-  // TODO New key - Add a translation
-  "driver-document-type_condition.label": "Document type equals driver",
+  "driver-document-type_condition.label": "Typ dokumentu je driver",
 
   // "has-at-least-one-bitstream_condition.label": "Has at least one Bitstream",
-  // TODO New key - Add a translation
-  "has-at-least-one-bitstream_condition.label": "Has at least one Bitstream",
+  "has-at-least-one-bitstream_condition.label": "Má alespoň jeden soubor",
 
   // "has-bitstream_filter.label": "Has Bitstream",
-  // TODO New key - Add a translation
-  "has-bitstream_filter.label": "Has Bitstream",
+  "has-bitstream_filter.label": "Má soubor",
 
   // "has-one-bitstream_condition.label": "Has one Bitstream",
-  // TODO New key - Add a translation
-  "has-one-bitstream_condition.label": "Has one Bitstream",
+  "has-one-bitstream_condition.label": "Má jeden soubor",
 
   // "is-archived_condition.label": "Is archived",
-  // TODO New key - Add a translation
-  "is-archived_condition.label": "Is archived",
+  "is-archived_condition.label": "Je archivován",
 
   // "is-withdrawn_condition.label": "Is withdrawn",
-  // TODO New key - Add a translation
-  "is-withdrawn_condition.label": "Is withdrawn",
+  "is-withdrawn_condition.label": "Je stažen",
 
   // "item-is-public_condition.label": "Item is public",
-  // TODO New key - Add a translation
-  "item-is-public_condition.label": "Item is public",
+  "item-is-public_condition.label": "Záznam je veřejný",
 
   // "journals_ingest_suggestion_collection_filter_18.label": "Journals ingest",
-  // TODO New key - Add a translation
-  "journals_ingest_suggestion_collection_filter_18.label": "Journals ingest",
+  "journals_ingest_suggestion_collection_filter_18.label": "Převzetí časopisů",
 
   // "title-starts-with-pattern_condition.label": "Title starts with pattern",
-  // TODO New key - Add a translation
-  "title-starts-with-pattern_condition.label": "Title starts with pattern",
+  "title-starts-with-pattern_condition.label": "Název začíná vzorem",
 
   // "type-equals-dataset_condition.label": "Type equals Dataset",
-  // TODO New key - Add a translation
-  "type-equals-dataset_condition.label": "Type equals Dataset",
+  "type-equals-dataset_condition.label": "Typ je Datová sada",
 
   // "type-equals-journal-article_condition.label": "Type equals Journal Article",
-  // TODO New key - Add a translation
-  "type-equals-journal-article_condition.label": "Type equals Journal Article",
+  "type-equals-journal-article_condition.label": "Typ je Článek v časopise",
 
   // "ldn.no-filter.label": "None",
-  // TODO New key - Add a translation
-  "ldn.no-filter.label": "None",
+  "ldn.no-filter.label": "Žádný",
 
   // "admin.notify.dashboard": "Dashboard",
-  // TODO New key - Add a translation
-  "admin.notify.dashboard": "Dashboard",
+  "admin.notify.dashboard": "Řídicí panel",
 
   // "menu.section.notify_dashboard": "Dashboard",
-  // TODO New key - Add a translation
-  "menu.section.notify_dashboard": "Dashboard",
+  "menu.section.notify_dashboard": "Řídicí panel",
 
   // "menu.section.coar_notify": "COAR Notify",
-  // TODO New key - Add a translation
   "menu.section.coar_notify": "COAR Notify",
 
   // "admin-notify-dashboard.title": "Notify Dashboard",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.title": "Notify Dashboard",
+  "admin-notify-dashboard.title": "Notify řídicí panel",
 
   // "admin-notify-dashboard.description": "The Notify dashboard monitor the general usage of the COAR Notify protocol across the repository. In the “Metrics” tab are statistics about usage of the COAR Notify protocol. In the “Logs/Inbound” and “Logs/Outbound” tabs it’s possible to search and check the individual status of each LDN message, either received or sent.",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.description": "The Notify dashboard monitor the general usage of the COAR Notify protocol across the repository. In the “Metrics” tab are statistics about usage of the COAR Notify protocol. In the “Logs/Inbound” and “Logs/Outbound” tabs it’s possible to search and check the individual status of each LDN message, either received or sent.",
+  "admin-notify-dashboard.description": "Řídicí panel Notify sleduje celkové používání protokolu COAR Notify v repozitáři. Na kartě \"Metriky\" jsou statistiky o použití protokolu COAR Notify. Na kartách \"Protokoly/Příchozí\" a \"Protokoly/Odchozí\" je možné vyhledávat a kontrolovat individuální stav každé LDN zprávy, přijaté nebo odeslané.",
 
   // "admin-notify-dashboard.metrics": "Metrics",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.metrics": "Metrics",
+  "admin-notify-dashboard.metrics": "Metriky",
 
   // "admin-notify-dashboard.received-ldn": "Number of received LDN",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.received-ldn": "Number of received LDN",
+  "admin-notify-dashboard.received-ldn": "Počet přijatých LDN",
 
   // "admin-notify-dashboard.generated-ldn": "Number of generated LDN",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.generated-ldn": "Number of generated LDN",
+  "admin-notify-dashboard.generated-ldn": "Počet vytvořených LDN",
 
   // "admin-notify-dashboard.NOTIFY.incoming.accepted": "Accepted",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.incoming.accepted": "Accepted",
+  "admin-notify-dashboard.NOTIFY.incoming.accepted": "Přijato",
 
   // "admin-notify-dashboard.NOTIFY.incoming.accepted.description": "Accepted inbound notifications",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.incoming.accepted.description": "Accepted inbound notifications",
+  "admin-notify-dashboard.NOTIFY.incoming.accepted.description": "Přijatá příchozí oznámení",
 
   // "admin-notify-logs.NOTIFY.incoming.accepted": "Currently displaying: Accepted notifications",
-  // TODO New key - Add a translation
-  "admin-notify-logs.NOTIFY.incoming.accepted": "Currently displaying: Accepted notifications",
+  "admin-notify-logs.NOTIFY.incoming.accepted": "Zobrazuje se: Přijatá oznámení",
 
   // "admin-notify-dashboard.NOTIFY.incoming.processed": "Processed LDN",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.incoming.processed": "Processed LDN",
+  "admin-notify-dashboard.NOTIFY.incoming.processed": "Zpracované LDN",
 
   // "admin-notify-dashboard.NOTIFY.incoming.processed.description": "Processed inbound notifications",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.incoming.processed.description": "Processed inbound notifications",
+  "admin-notify-dashboard.NOTIFY.incoming.processed.description": "Zpracovaná příchozí oznámení",
 
   // "admin-notify-logs.NOTIFY.incoming.processed": "Currently displaying: Processed LDN",
-  // TODO New key - Add a translation
-  "admin-notify-logs.NOTIFY.incoming.processed": "Currently displaying: Processed LDN",
+  "admin-notify-logs.NOTIFY.incoming.processed": "Zobrazuje se: Zpracované LDN",
 
   // "admin-notify-logs.NOTIFY.incoming.failure": "Currently displaying: Failed notifications",
-  // TODO New key - Add a translation
-  "admin-notify-logs.NOTIFY.incoming.failure": "Currently displaying: Failed notifications",
+  "admin-notify-logs.NOTIFY.incoming.failure": "Zobrazuje se: Neúspěšná oznámení",
 
   // "admin-notify-dashboard.NOTIFY.incoming.failure": "Failure",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.incoming.failure": "Failure",
+  "admin-notify-dashboard.NOTIFY.incoming.failure": "Chyba",
 
   // "admin-notify-dashboard.NOTIFY.incoming.failure.description": "Failed inbound notifications",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.incoming.failure.description": "Failed inbound notifications",
+  "admin-notify-dashboard.NOTIFY.incoming.failure.description": "Neúspěšná příchozí oznámení",
 
   // "admin-notify-logs.NOTIFY.outgoing.failure": "Currently displaying: Failed notifications",
-  // TODO New key - Add a translation
-  "admin-notify-logs.NOTIFY.outgoing.failure": "Currently displaying: Failed notifications",
+  "admin-notify-logs.NOTIFY.outgoing.failure": "Zobrazuje se: Neúspěšná oznámení",
 
   // "admin-notify-dashboard.NOTIFY.outgoing.failure": "Failure",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.outgoing.failure": "Failure",
+  "admin-notify-dashboard.NOTIFY.outgoing.failure": "Chyba",
 
   // "admin-notify-dashboard.NOTIFY.outgoing.failure.description": "Failed outbound notifications",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.outgoing.failure.description": "Failed outbound notifications",
+  "admin-notify-dashboard.NOTIFY.outgoing.failure.description": "Neúspěšná odchozí oznámení",
 
   // "admin-notify-logs.NOTIFY.incoming.untrusted": "Currently displaying: Untrusted notifications",
-  // TODO New key - Add a translation
-  "admin-notify-logs.NOTIFY.incoming.untrusted": "Currently displaying: Untrusted notifications",
+  "admin-notify-logs.NOTIFY.incoming.untrusted": "Zobrazuje se: Nedůvěryhodná oznámení",
 
   // "admin-notify-dashboard.NOTIFY.incoming.untrusted": "Untrusted",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.incoming.untrusted": "Untrusted",
+  "admin-notify-dashboard.NOTIFY.incoming.untrusted": "Nedůvěryhodná",
 
   // "admin-notify-dashboard.NOTIFY.incoming.untrusted.description": "Inbound notifications not trusted",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.incoming.untrusted.description": "Inbound notifications not trusted",
+  "admin-notify-dashboard.NOTIFY.incoming.untrusted.description": "Nedůvěryhodná příchozí oznámení",
 
   // "admin-notify-logs.NOTIFY.incoming.delivered": "Currently displaying: Delivered notifications",
-  // TODO New key - Add a translation
-  "admin-notify-logs.NOTIFY.incoming.delivered": "Currently displaying: Delivered notifications",
+  "admin-notify-logs.NOTIFY.incoming.delivered": "Zobrazuje se: Doručená oznámení",
 
   // "admin-notify-dashboard.NOTIFY.incoming.delivered.description": "Inbound notifications successfully delivered",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.incoming.delivered.description": "Inbound notifications successfully delivered",
+  "admin-notify-dashboard.NOTIFY.incoming.delivered.description": "Úspěšně doručená příchozí oznámení",
 
   // "admin-notify-dashboard.NOTIFY.outgoing.delivered": "Delivered",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.outgoing.delivered": "Delivered",
+  "admin-notify-dashboard.NOTIFY.outgoing.delivered": "Doručeno",
 
   // "admin-notify-logs.NOTIFY.outgoing.delivered": "Currently displaying: Delivered notifications",
-  // TODO New key - Add a translation
-  "admin-notify-logs.NOTIFY.outgoing.delivered": "Currently displaying: Delivered notifications",
+  "admin-notify-logs.NOTIFY.outgoing.delivered": "Zobrazuje se: Doručená oznámení",
 
   // "admin-notify-dashboard.NOTIFY.outgoing.delivered.description": "Outbound notifications successfully delivered",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.outgoing.delivered.description": "Outbound notifications successfully delivered",
+  "admin-notify-dashboard.NOTIFY.outgoing.delivered.description": "Úspěšně doručená odchozí oznámení",
 
   // "admin-notify-logs.NOTIFY.outgoing.queued": "Currently displaying: Queued notifications",
-  // TODO New key - Add a translation
-  "admin-notify-logs.NOTIFY.outgoing.queued": "Currently displaying: Queued notifications",
+  "admin-notify-logs.NOTIFY.outgoing.queued": "Zobrazuje se: Zařazená oznámení",
 
   // "admin-notify-dashboard.NOTIFY.outgoing.queued.description": "Notifications currently queued",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.outgoing.queued.description": "Notifications currently queued",
+  "admin-notify-dashboard.NOTIFY.outgoing.queued.description": "Oznámení aktuálně ve frontě",
 
   // "admin-notify-dashboard.NOTIFY.outgoing.queued": "Queued",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.outgoing.queued": "Queued",
+  "admin-notify-dashboard.NOTIFY.outgoing.queued": "Ve frontě",
 
   // "admin-notify-logs.NOTIFY.outgoing.queued_for_retry": "Currently displaying: Queued for retry notifications",
-  // TODO New key - Add a translation
-  "admin-notify-logs.NOTIFY.outgoing.queued_for_retry": "Currently displaying: Queued for retry notifications",
+  "admin-notify-logs.NOTIFY.outgoing.queued_for_retry": "Zobrazuje se: Oznámení ve frontě pro opakování",
 
   // "admin-notify-dashboard.NOTIFY.outgoing.queued_for_retry": "Queued for retry",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.outgoing.queued_for_retry": "Queued for retry",
+  "admin-notify-dashboard.NOTIFY.outgoing.queued_for_retry": "Ve frontě pro opakování",
 
   // "admin-notify-dashboard.NOTIFY.outgoing.queued_for_retry.description": "Notifications currently queued for retry",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.outgoing.queued_for_retry.description": "Notifications currently queued for retry",
+  "admin-notify-dashboard.NOTIFY.outgoing.queued_for_retry.description": "Oznámení aktuálně ve frontě pro opakování",
 
   // "admin-notify-dashboard.NOTIFY.incoming.involvedItems": "Items involved",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.incoming.involvedItems": "Items involved",
+  "admin-notify-dashboard.NOTIFY.incoming.involvedItems": "Zapojené záznamy",
 
   // "admin-notify-dashboard.NOTIFY.incoming.involvedItems.description": "Items related to inbound notifications",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.incoming.involvedItems.description": "Items related to inbound notifications",
+  "admin-notify-dashboard.NOTIFY.incoming.involvedItems.description": "Záznamy související s příchozími oznámeními",
 
   // "admin-notify-dashboard.NOTIFY.outgoing.involvedItems": "Items involved",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.outgoing.involvedItems": "Items involved",
+  "admin-notify-dashboard.NOTIFY.outgoing.involvedItems": "Zapojené záznamy",
 
   // "admin-notify-dashboard.NOTIFY.outgoing.involvedItems.description": "Items related to outbound notifications",
-  // TODO New key - Add a translation
-  "admin-notify-dashboard.NOTIFY.outgoing.involvedItems.description": "Items related to outbound notifications",
+  "admin-notify-dashboard.NOTIFY.outgoing.involvedItems.description": "Záznamy související s odchozími oznámeními",
 
   // "admin.notify.dashboard.breadcrumbs": "Dashboard",
-  // TODO New key - Add a translation
-  "admin.notify.dashboard.breadcrumbs": "Dashboard",
+  "admin.notify.dashboard.breadcrumbs": "Řídicí panel",
 
   // "admin.notify.dashboard.inbound": "Inbound messages",
-  // TODO New key - Add a translation
-  "admin.notify.dashboard.inbound": "Inbound messages",
+  "admin.notify.dashboard.inbound": "Příchozí zprávy",
 
   // "admin.notify.dashboard.inbound-logs": "Logs/Inbound",
-  // TODO New key - Add a translation
-  "admin.notify.dashboard.inbound-logs": "Logs/Inbound",
+  "admin.notify.dashboard.inbound-logs": "Protokoly/Příchozí",
 
   // "admin.notify.dashboard.filter": "Filter: ",
-  // TODO New key - Add a translation
-  "admin.notify.dashboard.filter": "Filter: ",
+  "admin.notify.dashboard.filter": "Filtr: ",
 
   // "search.filters.applied.f.relateditem": "Related items",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.relateditem": "Related items",
+  "search.filters.applied.f.relateditem": "Související záznamy",
 
   // "search.filters.applied.f.ldn_service": "LDN Service",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.ldn_service": "LDN Service",
+  "search.filters.applied.f.ldn_service": "LDN služba",
 
   // "search.filters.applied.f.notifyReview": "Notify Review",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.notifyReview": "Notify Review",
+  "search.filters.applied.f.notifyReview": "Notify recenze",
 
   // "search.filters.applied.f.notifyEndorsement": "Notify Endorsement",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.notifyEndorsement": "Notify Endorsement",
+  "search.filters.applied.f.notifyEndorsement": "Notify doporučení",
 
   // "search.filters.applied.f.notifyRelation": "Notify Relation",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.notifyRelation": "Notify Relation",
+  "search.filters.applied.f.notifyRelation": "Notify vztah",
 
   // "search.filters.applied.f.access_status": "Access type",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.access_status": "Access type",
+  "search.filters.applied.f.access_status": "Typ přístupu",
 
   // "search.filters.filter.queue_last_start_time.head": "Last processing time ",
-  // TODO New key - Add a translation
-  "search.filters.filter.queue_last_start_time.head": "Last processing time ",
+  "search.filters.filter.queue_last_start_time.head": "Čas posledního zpracování ",
 
   // "search.filters.filter.queue_last_start_time.min.label": "Min range",
-  // TODO New key - Add a translation
-  "search.filters.filter.queue_last_start_time.min.label": "Min range",
+  "search.filters.filter.queue_last_start_time.min.label": "Minimální rozsah",
 
   // "search.filters.filter.queue_last_start_time.max.label": "Max range",
-  // TODO New key - Add a translation
-  "search.filters.filter.queue_last_start_time.max.label": "Max range",
+  "search.filters.filter.queue_last_start_time.max.label": "Maximální rozsah",
 
   // "search.filters.applied.f.queue_last_start_time.min": "Min range",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.queue_last_start_time.min": "Min range",
+  "search.filters.applied.f.queue_last_start_time.min": "Minimální rozsah",
 
   // "search.filters.applied.f.queue_last_start_time.max": "Max range",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.queue_last_start_time.max": "Max range",
+  "search.filters.applied.f.queue_last_start_time.max": "Maximální rozsah",
 
   // "admin.notify.dashboard.outbound": "Outbound messages",
-  // TODO New key - Add a translation
-  "admin.notify.dashboard.outbound": "Outbound messages",
+  "admin.notify.dashboard.outbound": "Odchozí zprávy",
 
   // "admin.notify.dashboard.outbound-logs": "Logs/Outbound",
-  // TODO New key - Add a translation
-  "admin.notify.dashboard.outbound-logs": "Logs/Outbound",
+  "admin.notify.dashboard.outbound-logs": "Protokoly/Odchozí",
 
   // "NOTIFY.incoming.search.results.head": "Incoming",
-  // TODO New key - Add a translation
-  "NOTIFY.incoming.search.results.head": "Incoming",
+  "NOTIFY.incoming.search.results.head": "Příchozí",
 
   // "search.filters.filter.relateditem.head": "Related item",
-  // TODO New key - Add a translation
-  "search.filters.filter.relateditem.head": "Related item",
+  "search.filters.filter.relateditem.head": "Související záznam",
 
   // "search.filters.filter.origin.head": "Origin",
-  // TODO New key - Add a translation
-  "search.filters.filter.origin.head": "Origin",
+  "search.filters.filter.origin.head": "Původ",
 
   // "search.filters.filter.ldn_service.head": "LDN Service",
-  // TODO New key - Add a translation
-  "search.filters.filter.ldn_service.head": "LDN Service",
+  "search.filters.filter.ldn_service.head": "LDN služba",
 
   // "search.filters.filter.target.head": "Target",
-  // TODO New key - Add a translation
-  "search.filters.filter.target.head": "Target",
+  "search.filters.filter.target.head": "Cíl",
 
   // "search.filters.filter.queue_status.head": "Queue status",
-  // TODO New key - Add a translation
-  "search.filters.filter.queue_status.head": "Queue status",
+  "search.filters.filter.queue_status.head": "Stav fronty",
 
   // "search.filters.filter.activity_stream_type.head": "Activity stream type",
-  // TODO New key - Add a translation
-  "search.filters.filter.activity_stream_type.head": "Activity stream type",
+  "search.filters.filter.activity_stream_type.head": "Typ proudu aktivit",
 
   // "search.filters.filter.coar_notify_type.head": "COAR Notify type",
-  // TODO New key - Add a translation
-  "search.filters.filter.coar_notify_type.head": "COAR Notify type",
+  "search.filters.filter.coar_notify_type.head": "Typ COAR Notify",
 
   // "search.filters.filter.notification_type.head": "Notification type",
-  // TODO New key - Add a translation
-  "search.filters.filter.notification_type.head": "Notification type",
+  "search.filters.filter.notification_type.head": "Typ oznámení",
 
   // "search.filters.filter.relateditem.label": "Search related items",
-  // TODO New key - Add a translation
-  "search.filters.filter.relateditem.label": "Search related items",
+  "search.filters.filter.relateditem.label": "Hledat související záznamy",
 
   // "search.filters.filter.queue_status.label": "Search queue status",
-  // TODO New key - Add a translation
-  "search.filters.filter.queue_status.label": "Search queue status",
+  "search.filters.filter.queue_status.label": "Hledat stav fronty",
 
   // "search.filters.filter.target.label": "Search target",
-  // TODO New key - Add a translation
-  "search.filters.filter.target.label": "Search target",
+  "search.filters.filter.target.label": "Hledat cíl",
 
   // "search.filters.filter.activity_stream_type.label": "Search activity stream type",
-  // TODO New key - Add a translation
-  "search.filters.filter.activity_stream_type.label": "Search activity stream type",
+  "search.filters.filter.activity_stream_type.label": "Hledat typ proudu aktivit",
 
   // "search.filters.applied.f.queue_status": "Queue Status",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.queue_status": "Queue Status",
+  "search.filters.applied.f.queue_status": "Stav fronty",
 
   // "search.filters.queue_status.0,authority": "Untrusted Ip",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.0,authority": "Untrusted Ip",
+  "search.filters.queue_status.0,authority": "Nedůvěryhodná IP",
 
   // "search.filters.queue_status.1,authority": "Queued",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.1,authority": "Queued",
+  "search.filters.queue_status.1,authority": "Ve frontě",
 
   // "search.filters.queue_status.2,authority": "Processing",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.2,authority": "Processing",
+  "search.filters.queue_status.2,authority": "Zpracovává se",
 
   // "search.filters.queue_status.3,authority": "Processed",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.3,authority": "Processed",
+  "search.filters.queue_status.3,authority": "Zpracováno",
 
   // "search.filters.queue_status.4,authority": "Failed",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.4,authority": "Failed",
+  "search.filters.queue_status.4,authority": "Chyba",
 
   // "search.filters.queue_status.5,authority": "Untrusted",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.5,authority": "Untrusted",
+  "search.filters.queue_status.5,authority": "Nedůvěryhodné",
 
   // "search.filters.queue_status.6,authority": "Unmapped Action",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.6,authority": "Unmapped Action",
+  "search.filters.queue_status.6,authority": "Nemapovaná akce",
 
   // "search.filters.queue_status.7,authority": "Queued for retry",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.7,authority": "Queued for retry",
+  "search.filters.queue_status.7,authority": "Ve frontě pro opakování",
 
   // "search.filters.applied.f.activity_stream_type": "Activity stream type",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.activity_stream_type": "Activity stream type",
+  "search.filters.applied.f.activity_stream_type": "Typ proudu aktivit",
 
   // "search.filters.applied.f.coar_notify_type": "COAR Notify type",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.coar_notify_type": "COAR Notify type",
+  "search.filters.applied.f.coar_notify_type": "Typ COAR Notify",
 
   // "search.filters.applied.f.notification_type": "Notification type",
-  // TODO New key - Add a translation
-  "search.filters.applied.f.notification_type": "Notification type",
+  "search.filters.applied.f.notification_type": "Typ oznámení",
 
   // "search.filters.filter.coar_notify_type.label": "Search COAR Notify type",
-  // TODO New key - Add a translation
-  "search.filters.filter.coar_notify_type.label": "Search COAR Notify type",
+  "search.filters.filter.coar_notify_type.label": "Hledat typ COAR Notify",
 
   // "search.filters.filter.notification_type.label": "Search notification type",
-  // TODO New key - Add a translation
-  "search.filters.filter.notification_type.label": "Search notification type",
+  "search.filters.filter.notification_type.label": "Hledat typ oznámení",
 
   // "search.filters.filter.relateditem.placeholder": "Related items",
-  // TODO New key - Add a translation
-  "search.filters.filter.relateditem.placeholder": "Related items",
+  "search.filters.filter.relateditem.placeholder": "Související záznamy",
 
   // "search.filters.filter.target.placeholder": "Target",
-  // TODO New key - Add a translation
-  "search.filters.filter.target.placeholder": "Target",
+  "search.filters.filter.target.placeholder": "Cíl",
 
   // "search.filters.filter.origin.label": "Search source",
-  // TODO New key - Add a translation
-  "search.filters.filter.origin.label": "Search source",
+  "search.filters.filter.origin.label": "Hledat zdroj",
 
   // "search.filters.filter.origin.placeholder": "Source",
-  // TODO New key - Add a translation
-  "search.filters.filter.origin.placeholder": "Source",
+  "search.filters.filter.origin.placeholder": "Zdroj",
 
   // "search.filters.filter.ldn_service.label": "Search LDN Service",
-  // TODO New key - Add a translation
-  "search.filters.filter.ldn_service.label": "Search LDN Service",
+  "search.filters.filter.ldn_service.label": "Hledat LDN službu",
 
   // "search.filters.filter.ldn_service.placeholder": "LDN Service",
-  // TODO New key - Add a translation
-  "search.filters.filter.ldn_service.placeholder": "LDN Service",
+  "search.filters.filter.ldn_service.placeholder": "LDN služba",
 
   // "search.filters.filter.queue_status.placeholder": "Queue status",
-  // TODO New key - Add a translation
-  "search.filters.filter.queue_status.placeholder": "Queue status",
+  "search.filters.filter.queue_status.placeholder": "Stav fronty",
 
   // "search.filters.filter.activity_stream_type.placeholder": "Activity stream type",
-  // TODO New key - Add a translation
-  "search.filters.filter.activity_stream_type.placeholder": "Activity stream type",
+  "search.filters.filter.activity_stream_type.placeholder": "Typ proudu aktivit",
 
   // "search.filters.filter.coar_notify_type.placeholder": "COAR Notify type",
-  // TODO New key - Add a translation
-  "search.filters.filter.coar_notify_type.placeholder": "COAR Notify type",
+  "search.filters.filter.coar_notify_type.placeholder": "Typ COAR Notify",
 
   // "search.filters.filter.notification_type.placeholder": "Notification",
-  // TODO New key - Add a translation
-  "search.filters.filter.notification_type.placeholder": "Notification",
+  "search.filters.filter.notification_type.placeholder": "Oznámení",
 
   // "search.filters.filter.notifyRelation.head": "Notify Relation",
-  // TODO New key - Add a translation
-  "search.filters.filter.notifyRelation.head": "Notify Relation",
+  "search.filters.filter.notifyRelation.head": "Notify vztah",
 
   // "search.filters.filter.notifyRelation.label": "Search Notify Relation",
-  // TODO New key - Add a translation
-  "search.filters.filter.notifyRelation.label": "Search Notify Relation",
+  "search.filters.filter.notifyRelation.label": "Hledat Notify vztah",
 
   // "search.filters.filter.notifyRelation.placeholder": "Notify Relation",
-  // TODO New key - Add a translation
-  "search.filters.filter.notifyRelation.placeholder": "Notify Relation",
+  "search.filters.filter.notifyRelation.placeholder": "Notify vztah",
 
   // "search.filters.filter.notifyReview.head": "Notify Review",
-  // TODO New key - Add a translation
-  "search.filters.filter.notifyReview.head": "Notify Review",
+  "search.filters.filter.notifyReview.head": "Notify recenze",
 
   // "search.filters.filter.notifyReview.label": "Search Notify Review",
-  // TODO New key - Add a translation
-  "search.filters.filter.notifyReview.label": "Search Notify Review",
+  "search.filters.filter.notifyReview.label": "Hledat Notify recenze",
 
   // "search.filters.filter.notifyReview.placeholder": "Notify Review",
-  // TODO New key - Add a translation
-  "search.filters.filter.notifyReview.placeholder": "Notify Review",
+  "search.filters.filter.notifyReview.placeholder": "Notify recenze",
 
   // "search.filters.coar_notify_type.coar-notify:ReviewAction": "Review action",
-  // TODO New key - Add a translation
-  "search.filters.coar_notify_type.coar-notify:ReviewAction": "Review action",
+  "search.filters.coar_notify_type.coar-notify:ReviewAction": "Akce recenze",
 
   // "search.filters.coar_notify_type.coar-notify:ReviewAction,authority": "Review action",
-  // TODO New key - Add a translation
-  "search.filters.coar_notify_type.coar-notify:ReviewAction,authority": "Review action",
+  "search.filters.coar_notify_type.coar-notify:ReviewAction,authority": "Akce recenze",
 
   // "notify-detail-modal.coar-notify:ReviewAction": "Review action",
-  // TODO New key - Add a translation
-  "notify-detail-modal.coar-notify:ReviewAction": "Review action",
+  "notify-detail-modal.coar-notify:ReviewAction": "Akce recenze",
 
   // "search.filters.coar_notify_type.coar-notify:EndorsementAction": "Endorsement action",
-  // TODO New key - Add a translation
-  "search.filters.coar_notify_type.coar-notify:EndorsementAction": "Endorsement action",
+  "search.filters.coar_notify_type.coar-notify:EndorsementAction": "Akce doporučení",
 
   // "search.filters.coar_notify_type.coar-notify:EndorsementAction,authority": "Endorsement action",
-  // TODO New key - Add a translation
-  "search.filters.coar_notify_type.coar-notify:EndorsementAction,authority": "Endorsement action",
+  "search.filters.coar_notify_type.coar-notify:EndorsementAction,authority": "Akce doporučení",
 
   // "notify-detail-modal.coar-notify:EndorsementAction": "Endorsement action",
-  // TODO New key - Add a translation
-  "notify-detail-modal.coar-notify:EndorsementAction": "Endorsement action",
+  "notify-detail-modal.coar-notify:EndorsementAction": "Akce doporučení",
 
   // "search.filters.coar_notify_type.coar-notify:IngestAction": "Ingest action",
-  // TODO New key - Add a translation
-  "search.filters.coar_notify_type.coar-notify:IngestAction": "Ingest action",
+  "search.filters.coar_notify_type.coar-notify:IngestAction": "Akce převzetí",
 
   // "search.filters.coar_notify_type.coar-notify:IngestAction,authority": "Ingest action",
-  // TODO New key - Add a translation
-  "search.filters.coar_notify_type.coar-notify:IngestAction,authority": "Ingest action",
+  "search.filters.coar_notify_type.coar-notify:IngestAction,authority": "Akce převzetí",
 
   // "notify-detail-modal.coar-notify:IngestAction": "Ingest action",
-  // TODO New key - Add a translation
-  "notify-detail-modal.coar-notify:IngestAction": "Ingest action",
+  "notify-detail-modal.coar-notify:IngestAction": "Akce převzetí",
 
   // "search.filters.coar_notify_type.coar-notify:RelationshipAction": "Relationship action",
-  // TODO New key - Add a translation
-  "search.filters.coar_notify_type.coar-notify:RelationshipAction": "Relationship action",
+  "search.filters.coar_notify_type.coar-notify:RelationshipAction": "Akce vztahu",
 
   // "search.filters.coar_notify_type.coar-notify:RelationshipAction,authority": "Relationship action",
-  // TODO New key - Add a translation
-  "search.filters.coar_notify_type.coar-notify:RelationshipAction,authority": "Relationship action",
+  "search.filters.coar_notify_type.coar-notify:RelationshipAction,authority": "Akce vztahu",
 
   // "notify-detail-modal.coar-notify:RelationshipAction": "Relationship action",
-  // TODO New key - Add a translation
-  "notify-detail-modal.coar-notify:RelationshipAction": "Relationship action",
+  "notify-detail-modal.coar-notify:RelationshipAction": "Akce vztahu",
 
   // "search.filters.queue_status.QUEUE_STATUS_QUEUED": "Queued",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.QUEUE_STATUS_QUEUED": "Queued",
+  "search.filters.queue_status.QUEUE_STATUS_QUEUED": "Ve frontě",
 
   // "notify-detail-modal.QUEUE_STATUS_QUEUED": "Queued",
-  // TODO New key - Add a translation
-  "notify-detail-modal.QUEUE_STATUS_QUEUED": "Queued",
+  "notify-detail-modal.QUEUE_STATUS_QUEUED": "Ve frontě",
 
   // "search.filters.queue_status.QUEUE_STATUS_QUEUED_FOR_RETRY": "Queued for retry",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.QUEUE_STATUS_QUEUED_FOR_RETRY": "Queued for retry",
+  "search.filters.queue_status.QUEUE_STATUS_QUEUED_FOR_RETRY": "Ve frontě pro opakování",
 
   // "notify-detail-modal.QUEUE_STATUS_QUEUED_FOR_RETRY": "Queued for retry",
-  // TODO New key - Add a translation
-  "notify-detail-modal.QUEUE_STATUS_QUEUED_FOR_RETRY": "Queued for retry",
+  "notify-detail-modal.QUEUE_STATUS_QUEUED_FOR_RETRY": "Ve frontě pro opakování",
 
   // "search.filters.queue_status.QUEUE_STATUS_PROCESSING": "Processing",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.QUEUE_STATUS_PROCESSING": "Processing",
+  "search.filters.queue_status.QUEUE_STATUS_PROCESSING": "Zpracovává se",
 
   // "notify-detail-modal.QUEUE_STATUS_PROCESSING": "Processing",
-  // TODO New key - Add a translation
-  "notify-detail-modal.QUEUE_STATUS_PROCESSING": "Processing",
+  "notify-detail-modal.QUEUE_STATUS_PROCESSING": "Zpracovává se",
 
   // "search.filters.queue_status.QUEUE_STATUS_PROCESSED": "Processed",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.QUEUE_STATUS_PROCESSED": "Processed",
+  "search.filters.queue_status.QUEUE_STATUS_PROCESSED": "Zpracováno",
 
   // "notify-detail-modal.QUEUE_STATUS_PROCESSED": "Processed",
-  // TODO New key - Add a translation
-  "notify-detail-modal.QUEUE_STATUS_PROCESSED": "Processed",
+  "notify-detail-modal.QUEUE_STATUS_PROCESSED": "Zpracováno",
 
   // "search.filters.queue_status.QUEUE_STATUS_FAILED": "Failed",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.QUEUE_STATUS_FAILED": "Failed",
+  "search.filters.queue_status.QUEUE_STATUS_FAILED": "Selhalo",
 
   // "notify-detail-modal.QUEUE_STATUS_FAILED": "Failed",
-  // TODO New key - Add a translation
-  "notify-detail-modal.QUEUE_STATUS_FAILED": "Failed",
+  "notify-detail-modal.QUEUE_STATUS_FAILED": "Selhalo",
 
   // "search.filters.queue_status.QUEUE_STATUS_UNTRUSTED": "Untrusted",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.QUEUE_STATUS_UNTRUSTED": "Untrusted",
+  "search.filters.queue_status.QUEUE_STATUS_UNTRUSTED": "Nedůvěryhodné",
 
   // "search.filters.queue_status.QUEUE_STATUS_UNTRUSTED_IP": "Untrusted Ip",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.QUEUE_STATUS_UNTRUSTED_IP": "Untrusted Ip",
+  "search.filters.queue_status.QUEUE_STATUS_UNTRUSTED_IP": "Nedůvěryhodná IP",
 
   // "notify-detail-modal.QUEUE_STATUS_UNTRUSTED": "Untrusted",
-  // TODO New key - Add a translation
-  "notify-detail-modal.QUEUE_STATUS_UNTRUSTED": "Untrusted",
+  "notify-detail-modal.QUEUE_STATUS_UNTRUSTED": "Nedůvěryhodné",
 
   // "notify-detail-modal.QUEUE_STATUS_UNTRUSTED_IP": "Untrusted Ip",
-  // TODO New key - Add a translation
-  "notify-detail-modal.QUEUE_STATUS_UNTRUSTED_IP": "Untrusted Ip",
+  "notify-detail-modal.QUEUE_STATUS_UNTRUSTED_IP": "Nedůvěryhodná IP",
 
   // "search.filters.queue_status.QUEUE_STATUS_UNMAPPED_ACTION": "Unmapped Action",
-  // TODO New key - Add a translation
-  "search.filters.queue_status.QUEUE_STATUS_UNMAPPED_ACTION": "Unmapped Action",
+  "search.filters.queue_status.QUEUE_STATUS_UNMAPPED_ACTION": "Nemapovaná akce",
 
   // "notify-detail-modal.QUEUE_STATUS_UNMAPPED_ACTION": "Unmapped Action",
-  // TODO New key - Add a translation
-  "notify-detail-modal.QUEUE_STATUS_UNMAPPED_ACTION": "Unmapped Action",
+  "notify-detail-modal.QUEUE_STATUS_UNMAPPED_ACTION": "Nemapovaná akce",
 
   // "sorting.queue_last_start_time.DESC": "Last started queue Descending",
-  // TODO New key - Add a translation
-  "sorting.queue_last_start_time.DESC": "Last started queue Descending",
+  "sorting.queue_last_start_time.DESC": "Poslední start fronty sestupně",
 
   // "sorting.queue_last_start_time.ASC": "Last started queue Ascending",
-  // TODO New key - Add a translation
-  "sorting.queue_last_start_time.ASC": "Last started queue Ascending",
+  "sorting.queue_last_start_time.ASC": "Poslední start fronty vzestupně",
 
   // "sorting.queue_attempts.DESC": "Queue attempted Descending",
-  // TODO New key - Add a translation
-  "sorting.queue_attempts.DESC": "Queue attempted Descending",
+  "sorting.queue_attempts.DESC": "Pokusy fronty sestupně",
 
   // "sorting.queue_attempts.ASC": "Queue attempted Ascending",
-  // TODO New key - Add a translation
-  "sorting.queue_attempts.ASC": "Queue attempted Ascending",
+  "sorting.queue_attempts.ASC": "Pokusy fronty vzestupně",
 
   // "NOTIFY.incoming.involvedItems.search.results.head": "Items involved in incoming LDN",
-  // TODO New key - Add a translation
-  "NOTIFY.incoming.involvedItems.search.results.head": "Items involved in incoming LDN",
+  "NOTIFY.incoming.involvedItems.search.results.head": "Záznamy zapojené v příchozí LDN",
 
   // "NOTIFY.outgoing.involvedItems.search.results.head": "Items involved in outgoing LDN",
-  // TODO New key - Add a translation
-  "NOTIFY.outgoing.involvedItems.search.results.head": "Items involved in outgoing LDN",
+  "NOTIFY.outgoing.involvedItems.search.results.head": "Záznamy zapojené v odchozí LDN",
 
   // "type.notify-detail-modal": "Type",
-  // TODO New key - Add a translation
-  "type.notify-detail-modal": "Type",
+  "type.notify-detail-modal": "Typ",
 
   // "id.notify-detail-modal": "Id",
-  // TODO New key - Add a translation
-  "id.notify-detail-modal": "Id",
+  "id.notify-detail-modal": "ID",
 
   // "coarNotifyType.notify-detail-modal": "COAR Notify type",
-  // TODO New key - Add a translation
-  "coarNotifyType.notify-detail-modal": "COAR Notify type",
+  "coarNotifyType.notify-detail-modal": "Typ COAR Notify",
 
   // "activityStreamType.notify-detail-modal": "Activity stream type",
-  // TODO New key - Add a translation
-  "activityStreamType.notify-detail-modal": "Activity stream type",
+  "activityStreamType.notify-detail-modal": "Typ proudu aktivit",
 
   // "inReplyTo.notify-detail-modal": "In reply to",
-  // TODO New key - Add a translation
-  "inReplyTo.notify-detail-modal": "In reply to",
+  "inReplyTo.notify-detail-modal": "V odpovědi na",
 
   // "object.notify-detail-modal": "Repository Item",
-  // TODO New key - Add a translation
-  "object.notify-detail-modal": "Repository Item",
+  "object.notify-detail-modal": "Záznam v repozitáři",
 
   // "context.notify-detail-modal": "Repository Item",
-  // TODO New key - Add a translation
-  "context.notify-detail-modal": "Repository Item",
+  "context.notify-detail-modal": "Záznam v repozitáři",
 
   // "queueAttempts.notify-detail-modal": "Queue attempts",
-  // TODO New key - Add a translation
-  "queueAttempts.notify-detail-modal": "Queue attempts",
+  "queueAttempts.notify-detail-modal": "Pokusy fronty",
 
   // "queueLastStartTime.notify-detail-modal": "Queue last started",
-  // TODO New key - Add a translation
-  "queueLastStartTime.notify-detail-modal": "Queue last started",
+  "queueLastStartTime.notify-detail-modal": "Fronta naposledy spuštěna",
 
   // "origin.notify-detail-modal": "LDN Service",
-  // TODO New key - Add a translation
-  "origin.notify-detail-modal": "LDN Service",
+  "origin.notify-detail-modal": "LDN služba",
 
   // "target.notify-detail-modal": "LDN Service",
-  // TODO New key - Add a translation
-  "target.notify-detail-modal": "LDN Service",
+  "target.notify-detail-modal": "LDN služba",
 
   // "queueStatusLabel.notify-detail-modal": "Queue status",
-  // TODO New key - Add a translation
-  "queueStatusLabel.notify-detail-modal": "Queue status",
+  "queueStatusLabel.notify-detail-modal": "Stav fronty",
 
   // "queueTimeout.notify-detail-modal": "Queue timeout",
-  // TODO New key - Add a translation
-  "queueTimeout.notify-detail-modal": "Queue timeout",
+  "queueTimeout.notify-detail-modal": "Časový limit fronty",
 
   // "notify-message-modal.title": "Message Detail",
-  // TODO New key - Add a translation
-  "notify-message-modal.title": "Message Detail",
+  "notify-message-modal.title": "Detail zprávy",
 
   // "notify-message-modal.show-message": "Show message",
-  // TODO New key - Add a translation
-  "notify-message-modal.show-message": "Show message",
+  "notify-message-modal.show-message": "Zobrazit zprávu",
 
   // "notify-message-result.timestamp": "Timestamp",
-  // TODO New key - Add a translation
-  "notify-message-result.timestamp": "Timestamp",
+  "notify-message-result.timestamp": "Časové razítko",
 
   // "notify-message-result.repositoryItem": "Repository Item",
-  // TODO New key - Add a translation
-  "notify-message-result.repositoryItem": "Repository Item",
+  "notify-message-result.repositoryItem": "Záznam v repozitáři",
 
   // "notify-message-result.ldnService": "LDN Service",
-  // TODO New key - Add a translation
-  "notify-message-result.ldnService": "LDN Service",
+  "notify-message-result.ldnService": "LDN služba",
 
   // "notify-message-result.type": "Type",
-  // TODO New key - Add a translation
-  "notify-message-result.type": "Type",
+  "notify-message-result.type": "Typ",
 
   // "notify-message-result.status": "Status",
-  // TODO New key - Add a translation
-  "notify-message-result.status": "Status",
+  "notify-message-result.status": "Stav",
 
   // "notify-message-result.action": "Action",
-  // TODO New key - Add a translation
-  "notify-message-result.action": "Action",
+  "notify-message-result.action": "Akce",
 
   // "notify-message-result.detail": "Detail",
-  // TODO New key - Add a translation
   "notify-message-result.detail": "Detail",
 
   // "notify-message-result.reprocess": "Reprocess",
-  // TODO New key - Add a translation
-  "notify-message-result.reprocess": "Reprocess",
+  "notify-message-result.reprocess": "Znovu zpracovat",
 
   // "notify-queue-status.processed": "Processed",
-  // TODO New key - Add a translation
-  "notify-queue-status.processed": "Processed",
+  "notify-queue-status.processed": "Zpracováno",
 
   // "notify-queue-status.failed": "Failed",
-  // TODO New key - Add a translation
-  "notify-queue-status.failed": "Failed",
+  "notify-queue-status.failed": "Selhalo",
 
   // "notify-queue-status.queue_retry": "Queued for retry",
-  // TODO New key - Add a translation
-  "notify-queue-status.queue_retry": "Queued for retry",
+  "notify-queue-status.queue_retry": "Ve frontě pro opakování",
 
   // "notify-queue-status.unmapped_action": "Unmapped action",
-  // TODO New key - Add a translation
-  "notify-queue-status.unmapped_action": "Unmapped action",
+  "notify-queue-status.unmapped_action": "Nemapovaná akce",
 
   // "notify-queue-status.processing": "Processing",
-  // TODO New key - Add a translation
-  "notify-queue-status.processing": "Processing",
+  "notify-queue-status.processing": "Zpracovává se",
 
   // "notify-queue-status.queued": "Queued",
-  // TODO New key - Add a translation
-  "notify-queue-status.queued": "Queued",
+  "notify-queue-status.queued": "Ve frontě",
 
   // "notify-queue-status.untrusted": "Untrusted",
-  // TODO New key - Add a translation
-  "notify-queue-status.untrusted": "Untrusted",
+  "notify-queue-status.untrusted": "Nedůvěryhodné",
 
   // "ldnService.notify-detail-modal": "LDN Service",
-  // TODO New key - Add a translation
-  "ldnService.notify-detail-modal": "LDN Service",
+  "ldnService.notify-detail-modal": "LDN služba",
 
   // "relatedItem.notify-detail-modal": "Related Item",
-  // TODO New key - Add a translation
-  "relatedItem.notify-detail-modal": "Related Item",
+  "relatedItem.notify-detail-modal": "Související záznam",
 
   // "search.filters.filter.notifyEndorsement.head": "Notify Endorsement",
-  // TODO New key - Add a translation
-  "search.filters.filter.notifyEndorsement.head": "Notify Endorsement",
+  "search.filters.filter.notifyEndorsement.head": "Notify doporučení",
 
   // "search.filters.filter.notifyEndorsement.placeholder": "Notify Endorsement",
-  // TODO New key - Add a translation
-  "search.filters.filter.notifyEndorsement.placeholder": "Notify Endorsement",
+  "search.filters.filter.notifyEndorsement.placeholder": "Notify doporučení",
 
   // "search.filters.filter.notifyEndorsement.label": "Search Notify Endorsement",
-  // TODO New key - Add a translation
-  "search.filters.filter.notifyEndorsement.label": "Search Notify Endorsement",
+  "search.filters.filter.notifyEndorsement.label": "Hledat Notify doporučení",
 
   // "form.date-picker.placeholder.year": "Year",
-  // TODO New key - Add a translation
-  "form.date-picker.placeholder.year": "Year",
+  "form.date-picker.placeholder.year": "Rok",
 
   // "form.date-picker.placeholder.month": "Month",
-  // TODO New key - Add a translation
-  "form.date-picker.placeholder.month": "Month",
+  "form.date-picker.placeholder.month": "Měsíc",
 
   // "form.date-picker.placeholder.day": "Day",
-  // TODO New key - Add a translation
-  "form.date-picker.placeholder.day": "Day",
+  "form.date-picker.placeholder.day": "Den",
 
   // "item.page.cc.license.title": "Creative Commons license",
-  // TODO New key - Add a translation
-  "item.page.cc.license.title": "Creative Commons license",
+  "item.page.cc.license.title": "Licence Creative Commons",
 
   // "item.page.cc.license.disclaimer": "Except where otherwised noted, this item's license is described as",
-  // TODO New key - Add a translation
-  "item.page.cc.license.disclaimer": "Except where otherwised noted, this item's license is described as",
+  "item.page.cc.license.disclaimer": "Pokud není uvedeno jinak, licence tohoto záznamu je popsána jako",
 
   // "browse.search-form.placeholder": "Search the repository",
   "browse.search-form.placeholder": "Hledat v repozitáři",
@@ -11281,211 +10725,160 @@
   "dynamic-form-array.sortable-list.label": "Seznam, který lze třídit",
 
   // "external-login.component.or": "or",
-  // TODO New key - Add a translation
-  "external-login.component.or": "or",
+  "external-login.component.or": "nebo",
 
   // "external-login.confirmation.header": "Information needed to complete the login process",
-  // TODO New key - Add a translation
-  "external-login.confirmation.header": "Information needed to complete the login process",
+  "external-login.confirmation.header": "Informace potřebné k dokončení přihlášení",
 
   // "external-login.noEmail.informationText": "The information received from {{authMethod}} are not sufficient to complete the login process. Please provide the missing information below, or login via a different method to associate your {{authMethod}} to an existing account.",
-  // TODO New key - Add a translation
-  "external-login.noEmail.informationText": "The information received from {{authMethod}} are not sufficient to complete the login process. Please provide the missing information below, or login via a different method to associate your {{authMethod}} to an existing account.",
+  "external-login.noEmail.informationText": "Informace získané od {{authMethod}} nejsou dostačující pro dokončení přihlášení. Poskytněte prosím chybějící údaje níže, nebo se přihlaste jinou metodou a přiřaďte svůj {{authMethod}} k existujícímu účtu.",
 
   // "external-login.haveEmail.informationText": "It seems that you have not yet an account in this system. If this is the case, please confirm the data received from {{authMethod}} and a new account will be created for you. Otherwise, if you already have an account in the system, please update the email address to match the one already in use in the system or login via a different method to associate your {{authMethod}} to your existing account.",
-  // TODO New key - Add a translation
-  "external-login.haveEmail.informationText": "It seems that you have not yet an account in this system. If this is the case, please confirm the data received from {{authMethod}} and a new account will be created for you. Otherwise, if you already have an account in the system, please update the email address to match the one already in use in the system or login via a different method to associate your {{authMethod}} to your existing account.",
+  "external-login.haveEmail.informationText": "Zdá se, že ještě nemáte účet v tomto systému. Pokud je to pravda, potvrďte prosím údaje získané od {{authMethod}} a bude vám vytvořen nový účet. V opačném případě, pokud již účet máte, aktualizujte e‑mailovou adresu, aby odpovídala té, kterou již v systému používáte, nebo se přihlaste jinou metodou a přiřaďte svůj {{authMethod}} ke svému existujícímu účtu.",
 
   // "external-login.confirm-email.header": "Confirm or update email",
-  // TODO New key - Add a translation
-  "external-login.confirm-email.header": "Confirm or update email",
+  "external-login.confirm-email.header": "Potvrďte nebo aktualizujte e‑mail",
 
   // "external-login.confirmation.email-required": "Email is required.",
-  // TODO New key - Add a translation
-  "external-login.confirmation.email-required": "Email is required.",
+  "external-login.confirmation.email-required": "E‑mail je povinný.",
 
   // "external-login.confirmation.email-label": "User Email",
-  // TODO New key - Add a translation
-  "external-login.confirmation.email-label": "User Email",
+  "external-login.confirmation.email-label": "E‑mail uživatele",
 
   // "external-login.confirmation.email-invalid": "Invalid email format.",
-  // TODO New key - Add a translation
-  "external-login.confirmation.email-invalid": "Invalid email format.",
+  "external-login.confirmation.email-invalid": "Neplatný formát e‑mailu.",
 
   // "external-login.confirm.button.label": "Confirm this email",
-  // TODO New key - Add a translation
-  "external-login.confirm.button.label": "Confirm this email",
+  "external-login.confirm.button.label": "Potvrdit tento e‑mail",
 
   // "external-login.confirm-email-sent.header": "Confirmation email sent",
-  // TODO New key - Add a translation
-  "external-login.confirm-email-sent.header": "Confirmation email sent",
+  "external-login.confirm-email-sent.header": "Potvrzovací e‑mail odeslán",
 
   // "external-login.confirm-email-sent.info": " We have sent an email to the provided address to validate your input. <br> Please follow the instructions in the email to complete the login process.",
-  // TODO New key - Add a translation
-  "external-login.confirm-email-sent.info": " We have sent an email to the provided address to validate your input. <br> Please follow the instructions in the email to complete the login process.",
+  "external-login.confirm-email-sent.info": "Na zadanou adresu jsme poslali e‑mail pro ověření vašich údajů. <br> Postupujte podle pokynů v e‑mailu pro dokončení přihlášení.",
 
   // "external-login.provide-email.header": "Provide email",
-  // TODO New key - Add a translation
-  "external-login.provide-email.header": "Provide email",
+  "external-login.provide-email.header": "Zadejte e‑mail",
 
   // "external-login.provide-email.button.label": "Send Verification link",
-  // TODO New key - Add a translation
-  "external-login.provide-email.button.label": "Send Verification link",
+  "external-login.provide-email.button.label": "Odeslat ověřovací odkaz",
 
   // "external-login-validation.review-account-info.header": "Review your account information",
-  // TODO New key - Add a translation
-  "external-login-validation.review-account-info.header": "Review your account information",
+  "external-login-validation.review-account-info.header": "Zkontrolujte informace o svém účtu",
 
   // "external-login-validation.review-account-info.info": "The information received from ORCID differs from the one recorded in your profile. <br /> Please review them and decide if you want to update any of them.After saving you will be redirected to your profile page.",
-  // TODO New key - Add a translation
-  "external-login-validation.review-account-info.info": "The information received from ORCID differs from the one recorded in your profile. <br /> Please review them and decide if you want to update any of them.After saving you will be redirected to your profile page.",
+  "external-login-validation.review-account-info.info": "Informace získané z ORCID se liší od těch uložených ve vašem profilu. <br /> Zkontrolujte je a rozhodněte se, zda chcete některé aktualizovat. Po uložení budete přesměrováni na stránku profilu.",
 
   // "external-login-validation.review-account-info.table.header.information": "Information",
-  // TODO New key - Add a translation
-  "external-login-validation.review-account-info.table.header.information": "Information",
+  "external-login-validation.review-account-info.table.header.information": "Informace",
 
   // "external-login-validation.review-account-info.table.header.received-value": "Received value",
-  // TODO New key - Add a translation
-  "external-login-validation.review-account-info.table.header.received-value": "Received value",
+  "external-login-validation.review-account-info.table.header.received-value": "Získaná hodnota",
 
   // "external-login-validation.review-account-info.table.header.current-value": "Current value",
-  // TODO New key - Add a translation
-  "external-login-validation.review-account-info.table.header.current-value": "Current value",
+  "external-login-validation.review-account-info.table.header.current-value": "Aktuální hodnota",
 
   // "external-login-validation.review-account-info.table.header.action": "Override",
-  // TODO New key - Add a translation
-  "external-login-validation.review-account-info.table.header.action": "Override",
+  "external-login-validation.review-account-info.table.header.action": "Přepsat",
 
   // "external-login-validation.review-account-info.table.row.not-applicable": "N/A",
-  // TODO New key - Add a translation
   "external-login-validation.review-account-info.table.row.not-applicable": "N/A",
 
   // "on-label": "ON",
-  // TODO New key - Add a translation
-  "on-label": "ON",
+  "on-label": "ZAP",
 
   // "off-label": "OFF",
-  // TODO New key - Add a translation
-  "off-label": "OFF",
+  "off-label": "VYP",
 
   // "review-account-info.merge-data.notification.success": "Your account information has been updated successfully",
-  // TODO New key - Add a translation
-  "review-account-info.merge-data.notification.success": "Your account information has been updated successfully",
+  "review-account-info.merge-data.notification.success": "Informace o vašem účtu byly úspěšně aktualizovány",
 
   // "review-account-info.merge-data.notification.error": "Something went wrong while updating your account information",
-  // TODO New key - Add a translation
-  "review-account-info.merge-data.notification.error": "Something went wrong while updating your account information",
+  "review-account-info.merge-data.notification.error": "Při aktualizaci informací o vašem účtu se něco pokazilo",
 
   // "review-account-info.alert.error.content": "Something went wrong. Please try again later.",
-  // TODO New key - Add a translation
-  "review-account-info.alert.error.content": "Something went wrong. Please try again later.",
+  "review-account-info.alert.error.content": "Došlo k chybě. Zkuste to prosím později.",
 
   // "external-login-page.provide-email.notifications.error": "Something went wrong.Email address was omitted or the operation is not valid.",
-  // TODO New key - Add a translation
-  "external-login-page.provide-email.notifications.error": "Something went wrong.Email address was omitted or the operation is not valid.",
+  "external-login-page.provide-email.notifications.error": "Něco se pokazilo. E‑mailová adresa chybí nebo operace není platná.",
 
   // "external-login.error.notification": "There was an error while processing your request. Please try again later.",
-  // TODO New key - Add a translation
-  "external-login.error.notification": "There was an error while processing your request. Please try again later.",
+  "external-login.error.notification": "Při zpracování vašeho požadavku došlo k chybě. Zkuste to prosím později.",
 
   // "external-login.connect-to-existing-account.label": "Connect to an existing user",
-  // TODO New key - Add a translation
-  "external-login.connect-to-existing-account.label": "Connect to an existing user",
+  "external-login.connect-to-existing-account.label": "Připojit k existujícímu uživateli",
 
   // "external-login.modal.label.close": "Close",
-  // TODO New key - Add a translation
-  "external-login.modal.label.close": "Close",
+  "external-login.modal.label.close": "Zavřít",
 
   // "external-login-page.provide-email.create-account.notifications.error.header": "Something went wrong",
-  // TODO New key - Add a translation
-  "external-login-page.provide-email.create-account.notifications.error.header": "Something went wrong",
+  "external-login-page.provide-email.create-account.notifications.error.header": "Něco se pokazilo",
 
   // "external-login-page.provide-email.create-account.notifications.error.content": "Please check again your email address and try again.",
-  // TODO New key - Add a translation
-  "external-login-page.provide-email.create-account.notifications.error.content": "Please check again your email address and try again.",
+  "external-login-page.provide-email.create-account.notifications.error.content": "Zkontrolujte prosím znovu svou e‑mailovou adresu a zkuste to znovu.",
 
   // "external-login-page.confirm-email.create-account.notifications.error.no-netId": "Something went wrong with this email account. Try again or use a different method to login.",
-  // TODO New key - Add a translation
-  "external-login-page.confirm-email.create-account.notifications.error.no-netId": "Something went wrong with this email account. Try again or use a different method to login.",
+  "external-login-page.confirm-email.create-account.notifications.error.no-netId": "S tímto e‑mailovým účtem se něco pokazilo. Zkuste to znovu nebo použijte k přihlášení jinou metodu.",
 
   // "external-login-page.orcid-confirmation.firstname": "First name",
-  // TODO New key - Add a translation
-  "external-login-page.orcid-confirmation.firstname": "First name",
+  "external-login-page.orcid-confirmation.firstname": "Jméno",
 
   // "external-login-page.orcid-confirmation.firstname.label": "First name",
-  // TODO New key - Add a translation
-  "external-login-page.orcid-confirmation.firstname.label": "First name",
+  "external-login-page.orcid-confirmation.firstname.label": "Jméno",
 
   // "external-login-page.orcid-confirmation.lastname": "Last name",
-  // TODO New key - Add a translation
-  "external-login-page.orcid-confirmation.lastname": "Last name",
+  "external-login-page.orcid-confirmation.lastname": "Příjmení",
 
   // "external-login-page.orcid-confirmation.lastname.label": "Last name",
-  // TODO New key - Add a translation
-  "external-login-page.orcid-confirmation.lastname.label": "Last name",
+  "external-login-page.orcid-confirmation.lastname.label": "Příjmení",
 
   // "external-login-page.orcid-confirmation.netid": "Account Identifier",
-  // TODO New key - Add a translation
-  "external-login-page.orcid-confirmation.netid": "Account Identifier",
+  "external-login-page.orcid-confirmation.netid": "Identifikátor účtu",
 
   // "external-login-page.orcid-confirmation.netid.placeholder": "xxxx-xxxx-xxxx-xxxx",
-  // TODO New key - Add a translation
   "external-login-page.orcid-confirmation.netid.placeholder": "xxxx-xxxx-xxxx-xxxx",
 
   // "external-login-page.orcid-confirmation.email": "Email",
-  // TODO New key - Add a translation
-  "external-login-page.orcid-confirmation.email": "Email",
+  "external-login-page.orcid-confirmation.email": "E‑mail",
 
   // "external-login-page.orcid-confirmation.email.label": "Email",
-  // TODO New key - Add a translation
-  "external-login-page.orcid-confirmation.email.label": "Email",
+  "external-login-page.orcid-confirmation.email.label": "E‑mail",
 
   // "search.filters.access_status.open.access": "Open access",
-  // TODO New key - Add a translation
-  "search.filters.access_status.open.access": "Open access",
+  "search.filters.access_status.open.access": "Otevřený přístup",
 
   // "search.filters.access_status.restricted": "Restricted access",
-  // TODO New key - Add a translation
-  "search.filters.access_status.restricted": "Restricted access",
+  "search.filters.access_status.restricted": "Omezený přístup",
 
   // "search.filters.access_status.embargo": "Embargoed access",
-  // TODO New key - Add a translation
-  "search.filters.access_status.embargo": "Embargoed access",
+  "search.filters.access_status.embargo": "Embargovaný přístup",
 
   // "search.filters.access_status.metadata.only": "Metadata only",
-  // TODO New key - Add a translation
-  "search.filters.access_status.metadata.only": "Metadata only",
+  "search.filters.access_status.metadata.only": "Pouze metadata",
 
   // "search.filters.access_status.unknown": "Unknown",
-  // TODO New key - Add a translation
-  "search.filters.access_status.unknown": "Unknown",
+  "search.filters.access_status.unknown": "Neznámé",
 
   // "metadata-export-filtered-items.tooltip": "Export report output as CSV",
-  // TODO New key - Add a translation
-  "metadata-export-filtered-items.tooltip": "Export report output as CSV",
+  "metadata-export-filtered-items.tooltip": "Exportovat výstup sestavy jako CSV",
 
   // "metadata-export-filtered-items.submit.success": "CSV export succeeded.",
-  // TODO New key - Add a translation
-  "metadata-export-filtered-items.submit.success": "CSV export succeeded.",
+  "metadata-export-filtered-items.submit.success": "Export CSV byl úspěšný.",
 
   // "metadata-export-filtered-items.submit.error": "CSV export failed.",
-  // TODO New key - Add a translation
-  "metadata-export-filtered-items.submit.error": "CSV export failed.",
+  "metadata-export-filtered-items.submit.error": "Export CSV selhal.",
 
   // "metadata-export-filtered-items.columns.warning": "CSV export automatically includes all relevant fields, so selections in this list are not taken into account.",
-  // TODO New key - Add a translation
-  "metadata-export-filtered-items.columns.warning": "CSV export automatically includes all relevant fields, so selections in this list are not taken into account.",
+  "metadata-export-filtered-items.columns.warning": "Export CSV automaticky zahrne všechna relevantní pole, proto se výběry v tomto seznamu neberou v potaz.",
 
   // "embargo.listelement.badge": "Embargo until {{ date }}",
-  // TODO New key - Add a translation
-  "embargo.listelement.badge": "Embargo until {{ date }}",
+  "embargo.listelement.badge": "Embargo do {{ date }}",
 
   // "metadata-export-search.submit.error.limit-exceeded": "Only the first {{limit}} items will be exported",
   "metadata-export-search.submit.error.limit-exceeded": "Budou exportovány pouze první {{limit}} položky",
 
   // "file-download-link.request-copy": "Request a copy of ",
-  // TODO New key - Add a translation
-  "file-download-link.request-copy": "Request a copy of ",
+  "file-download-link.request-copy": "Požádat o kopii ",
 
 
 }

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -1218,7 +1218,7 @@
   "admin.batch-import.page.dropMsg": "Přetáhněte soubor ZIP k importu",
 
   // "admin.metadata-import.page.dropMsgReplace": "Drop to replace the metadata CSV to import",
-  "admin.metadata-import.page.dropMsgReplace": "Přetažením nahraďte importovaný CSV metadat",
+  "admin.metadata-import.page.dropMsgReplace": "CSV k importu",
 
   // "admin.batch-import.page.dropMsgReplace": "Drop to replace the batch ZIP to import",
   "admin.batch-import.page.dropMsgReplace": "Nahraďte přetažením soubor ZIP k importu",
@@ -2577,7 +2577,7 @@
   "curation-task.task.vscan.label": "Antivirová kontrola",
 
   // "curation-task.task.registerdoi.label": "Register DOI",
-  "curation-task.task.registerdoi.label": "Zaregistrovat DOI",
+  "curation-task.task.registerdoi.label": "Zaregistrujte DOI",
 
   // "curation.form.task-select.label": "Task:",
   "curation.form.task-select.label": "Úloha:",
@@ -3234,7 +3234,7 @@
   "grant-request-copy.intro.attachment": "Žadateli bude odeslána zpráva. Požadované dokumenty budou přiloženy.",
 
   // "grant-request-copy.intro.link": "A message will be sent to the applicant of the request. A secure link providing access to the requested document(s) will be attached. The link will provide access for the duration of time selected in the \"Access Period\" menu below.",
-  "grant-request-copy.intro.link": „Žadateli bude odeslána zpráva. Bude přiložen zabezpečený odkaz poskytující přístup k požadovaným dokumentům. Odkaz bude platný po dobu zvolenou v nabídce ‚Doba přístupu‘ níže.“,
+  "grant-request-copy.intro.link": "Žadateli bude odeslána zpráva. Bude přiložen zabezpečený odkaz poskytující přístup k požadovaným dokumentům. Odkaz bude platný po dobu zvolenou v nabídce ‚Doba přístupu‘ níže.",
 
   // "grant-request-copy.intro.link.preview": "Below is a preview of the link that will be sent to the applicant:",
   "grant-request-copy.intro.link.preview": "Níže je náhled odkazu, který bude odeslán žadateli:",
@@ -4401,7 +4401,7 @@
   "item.page.link.full": "Zobrazit celý záznam",
 
   // "item.page.link.simple": "Simple item page",
-  "item.page.link.simple": "Zobrazit jednoduchý záznam",
+  "item.page.link.simple": "Zobrazit minimální záznam",
 
   // "item.page.options": "Options",
   "item.page.options": "Možnosti",
@@ -5202,7 +5202,7 @@
   "menu.section.browse_community_by_title": "Podle názvu",
 
   // "menu.section.browse_global": "All of DSpace",
-  "menu.section.browse_global": "Celý DSpace“",
+  "menu.section.browse_global": "Procházet podle",
 
   // "menu.section.browse_global_by_author": "By Author",
   "menu.section.browse_global_by_author": "Podle autora",
@@ -5223,7 +5223,7 @@
   "menu.section.browse_global_by_title": "Podle názvu",
 
   // "menu.section.browse_global_by_horizon": "By Horizon",
-  "menu.section.browse_global_by_horizon": "Podle Horizon",
+  "menu.section.browse_global_by_horizon": "Podle horizon",
 
   // "menu.section.browse_global_by_affiliation": "By Faculty",
   "menu.section.browse_global_by_affiliation": "Podle fakulty",

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -27,7 +27,7 @@
   "500.link.home-page": "Návrat na domovskou stránku",
 
   // "404.help": "We can't find the page you're looking for. The page may have been moved or deleted. You can use the button below to get back to the home page. ",
-  "404.help": "Nemůžeme najít stránku, kterou hledáte. Stránka mohla být přesunuta nebo smazána. Pomocí níže uvedeného tlačítka se můžete vrátit na domovskou stránku. ",
+  "404.help": "Nemůžeme najít stránku, kterou hledáte. Stránka mohla být přesunuta nebo smazána. Pomocí níže uvedeného tlačítka se můžete vrátit na domovskou stránku.",
 
   // "404.link.home-page": "Take me to the home page",
   "404.link.home-page": "Návrat na domovskou stránku",
@@ -87,7 +87,7 @@
   "admin.registries.bitstream-formats.create.failure.content": "Při vytváření nového formátu souboru došlo k chybě.",
 
   // "admin.registries.bitstream-formats.create.failure.head": "Failure",
-  "admin.registries.bitstream-formats.create.failure.head": "Vytváření nového formátu souboru selhalo",
+  "admin.registries.bitstream-formats.create.failure.head": "Vytvoření nového formátu souboru selhalo",
 
   // "admin.registries.bitstream-formats.create.head": "Create bitstream format",
   "admin.registries.bitstream-formats.create.head": "Vytvořit formát souboru",
@@ -108,7 +108,7 @@
   "admin.registries.bitstream-formats.delete.failure.head": "Odstranění formátu souboru selhalo",
 
   // "admin.registries.bitstream-formats.delete.success.amount": "Successfully removed {{ amount }} format(s)",
-  "admin.registries.bitstream-formats.delete.success.amount": "Úspěšně odstraněno {{ amount }} formatů",
+  "admin.registries.bitstream-formats.delete.success.amount": "Úspěšně odstraněno {{ amount }} formátů",
 
   // "admin.registries.bitstream-formats.delete.success.head": "Success",
   "admin.registries.bitstream-formats.delete.success.head": "Úspěšně odstraněno",
@@ -324,10 +324,10 @@
   "admin.registries.schema.head": "Metadatové schéma",
 
   // "admin.registries.schema.notification.created": "Successfully created metadata schema \"{{prefix}}\"",
-  "admin.registries.schema.notification.created": "Metadatové schéma bylo Úspěšně vytvořeno \"{{prefix}}\"",
+  "admin.registries.schema.notification.created": "Metadatové schéma bylo úspěšně vytvořeno \"{{prefix}}\"",
 
   // "admin.registries.schema.notification.deleted.failure": "Failed to delete {{amount}} metadata schemas",
-  "admin.registries.schema.notification.deleted.failure": "Nepodařilo se odstranit metadatové schéma {{amount}}",
+  "admin.registries.schema.notification.deleted.failure": "Nepodařilo se odstranit {{amount}} metadatových schémat",
 
   // "admin.registries.schema.notification.deleted.success": "Successfully deleted {{amount}} metadata schemas",
   "admin.registries.schema.notification.deleted.success": "Úspěšně odstraněno {{amount}} metadatových schémat",
@@ -663,7 +663,7 @@
   "admin.access-control.groups.form.delete-group.modal.header": "Odstranit skupinu \"{{ dsoName }}\"",
 
   // "admin.access-control.groups.form.delete-group.modal.info": "Are you sure you want to delete Group \"{{ dsoName }}\" and all its associated policies?",
-  "admin.access-control.groups.form.delete-group.modal.info": "Určitě chcete odstranit skupinu \"{{ dsoName }}\"  a všechny s ní spojené zásady?",
+  "admin.access-control.groups.form.delete-group.modal.info": "Opravdu chcete odstranit skupinu \"{{ dsoName }}\" a všechny s ní spojené zásady?",
 
   // "admin.access-control.groups.form.delete-group.modal.cancel": "Cancel",
   "admin.access-control.groups.form.delete-group.modal.cancel": "Zrušit",
@@ -795,7 +795,7 @@
   "admin.access-control.groups.form.subgroups-list.notification.failure.subgroupToAddIsActiveGroup": "Toto je aktuální skupina, nelze přidat.",
 
   // "admin.access-control.groups.form.subgroups-list.no-items": "No groups found with this in their name or this as UUID",
-  "admin.access-control.groups.form.subgroups-list.no-items": "Nebyla nalezena žádná skupina s tímto v návzvu nebo UUID",
+  "admin.access-control.groups.form.subgroups-list.no-items": "Nebyla nalezena žádná skupina s tímto názvem nebo UUID",
 
   // "admin.access-control.groups.form.subgroups-list.no-subgroups-yet": "No subgroups in group yet.",
   "admin.access-control.groups.form.subgroups-list.no-subgroups-yet": "Ve skupině zatím nejsou žádné podskupiny.",
@@ -819,13 +819,13 @@
   "admin.notifications.source.breadcrumbs": "Zajištění kvality",
 
   // "admin.access-control.groups.form.tooltip.editGroupPage": "On this page, you can modify the properties and members of a group. In the top section, you can edit the group name and description, unless this is an admin group for a collection or community, in which case the group name and description are auto-generated and cannot be edited. In the following sections, you can edit group membership. See [the wiki](https://wiki.lyrasis.org/display/DSDOC7x/Create+or+manage+a+user+group) for more details.",
-  "admin.access-control.groups.form.tooltip.editGroupPage": "Na této stránce můžete upravit vlastnosti a členy skupiny. V horní části můžete upravit název a popis skupiny, pokud se nejedá o skupinu admin pro kolekci nebo komunitu. V takovém případě jsou název a popis skupiny vygenerovány automaticky a nelze je upravovat. V následujících částech můžete upravovat členství ve skupině. Další podrobnosti naleznete v části [wiki](https://wiki.lyrasis.org/display/DSDOC7x/Create+or+manage+a+user+group).",
+  "admin.access-control.groups.form.tooltip.editGroupPage": "Na této stránce můžete upravit vlastnosti a členy skupiny. V horní části můžete upravit název a popis skupiny, pokud se nejedná o skupinu admin pro kolekci nebo komunitu. V takovém případě jsou název a popis skupiny vygenerovány automaticky a nelze je upravovat. V následujících částech můžete upravovat členství ve skupině. Další podrobnosti naleznete v části [wiki](https://wiki.lyrasis.org/display/DSDOC7x/Create+or+manage+a+user+group).",
 
   // "admin.access-control.groups.form.tooltip.editGroup.addEpeople": "To add or remove an EPerson to/from this group, either click the 'Browse All' button or use the search bar below to search for users (use the dropdown to the left of the search bar to choose whether to search by metadata or by email). Then click the plus icon for each user you wish to add in the list below, or the trash can icon for each user you wish to remove. The list below may have several pages: use the page controls below the list to navigate to the next pages.",
   "admin.access-control.groups.form.tooltip.editGroup.addEpeople": "Pro přidání nebo odebrání uživatele z této skupiny, buď klikněte na „Prohledávat všechny“ nebo použijte vyhledávací okno pro vyhledání uživatele (použijte roletku na levé straně vyhledávacího okna a vyberte, zda chcete prohledávat pomocí metadat nebo e-mailu). Potom klikněte na tlačítko plus u každého uživatele, kterého chcete přidat, nebo na ikonu odpadkového koše u každého uživatele, kterého chcete odebrat. Seznam níže může obsahovat několik stránek: k přechodu na další stránku použijte ovládací prvky pod seznamem. Až budete hotovi, uložte změny pomocí tlačítka „Uložit“ v horní části.",
 
   // "admin.access-control.groups.form.tooltip.editGroup.addSubgroups": "To add or remove a Subgroup to/from this group, either click the 'Browse All' button or use the search bar below to search for groups. Then click the plus icon for each group you wish to add in the list below, or the trash can icon for each group you wish to remove. The list below may have several pages: use the page controls below the list to navigate to the next pages.",
-  "admin.access-control.groups.form.tooltip.editGroup.addSubgroups": "Pro přidání nebo odebrání podskupiny z této skupiny, buď klikněte na „Prohledávat všechny“ nebo použijte vyhledávací okno níže pro vyhledání uživatele. Potom klikněte na tlačítko plus u každého uživatele, kterého chcete přidat, nebo na ikonu odpadkového koše u každého uživatele, kterého chcete odebrat. Seznam níže může obsahovat několik stránek: k přechodu na další stránku použijte ovládací prvky pod seznamem. Až budete hotovi, uložte změny pomocí tlačítka „Uložit“ v horní části.",
+  "admin.access-control.groups.form.tooltip.editGroup.addSubgroups": "Pro přidání nebo odebrání podskupiny z této skupiny, buď klikněte na „Prohledávat všechny“ nebo použijte vyhledávací okno níže pro vyhledání skupiny. Potom klikněte na tlačítko plus u každé skupiny, kterou chcete přidat, nebo na ikonu odpadkového koše u každé skupiny, kterou chcete odebrat. Seznam níže může obsahovat několik stránek: k přechodu na další stránku použijte ovládací prvky pod seznamem. Až budete hotovi, uložte změny pomocí tlačítka „Uložit“ v horní části.",
 
   // "admin.reports.collections.title": "Collection Filter Report",
   "admin.reports.collections.title": "Zpráva o filtru kolekcí",
@@ -1218,7 +1218,7 @@
   "admin.batch-import.page.dropMsg": "Přetáhněte soubor ZIP k importu",
 
   // "admin.metadata-import.page.dropMsgReplace": "Drop to replace the metadata CSV to import",
-  "admin.metadata-import.page.dropMsgReplace": "CSV k importu",
+  "admin.metadata-import.page.dropMsgReplace": "Přetažením nahraďte importovaný CSV metadat",
 
   // "admin.batch-import.page.dropMsgReplace": "Drop to replace the batch ZIP to import",
   "admin.batch-import.page.dropMsgReplace": "Nahraďte přetažením soubor ZIP k importu",
@@ -1248,7 +1248,7 @@
   "admin.metadata-import.page.toggle.url": "URL",
 
   // "admin.metadata-import.page.urlMsg": "Insert the batch ZIP url to import",
-  "admin.metadata-import.page.urlMsg": "Vložte url ZIP souboru pro import",
+  "admin.metadata-import.page.urlMsg": "Vložte URL ZIP souboru pro import",
 
   // "admin.metadata-import.page.validateOnly": "Validate Only",
   "admin.metadata-import.page.validateOnly": "Pouze ověřit",
@@ -1356,7 +1356,7 @@
   "auth.messages.expired": "Vaše relace vypršela. Přihlaste se prosím znovu.",
 
   // "auth.messages.token-refresh-failed": "Refreshing your session token failed. Please log in again.",
-  "auth.messages.token-refresh-failed": "Nepodařilo se obnovit váš přístupový token. Prosím, přihlašte se znovu.",
+  "auth.messages.token-refresh-failed": "Nepodařilo se obnovit váš přístupový token. Prosím, přihlaste se znovu.",
 
   // "bitstream.download.page": "Now downloading {{bitstream}}...",
   "bitstream.download.page": "Nyní se stahuje {{bitstream}}...",
@@ -1710,13 +1710,13 @@
   "browse.title": "Procházet podle {{ field }}{{ startsWith }} {{ value }}",
 
   // "browse.title.page": "Browsing by {{ field }} {{ value }}",
-  "browse.title.page": "Procházet podle {{ field }}. {{ value }}",
+  "browse.title.page": "Procházet podle {{ field }} {{ value }}",
 
   // "search.browse.item-back": "Back to Results",
   "search.browse.item-back": "Zpět na seznam výsledků",
 
   // "chips.remove": "Remove chip",
-  "chips.remove": "Odstranit chip",
+  "chips.remove": "Odstranit čip",
 
   // "claimed-approved-search-result-list-element.title": "Approved",
   "claimed-approved-search-result-list-element.title": "Schváleno",
@@ -1878,7 +1878,7 @@
   "collection.edit.tabs.curate.head": "Spravovat",
 
   // "collection.edit.tabs.curate.title": "Collection Edit - Curate",
-  "collection.edit.tabs.curate.title": "Upravit kolekci - správa",
+  "collection.edit.tabs.curate.title": "Upravit kolekci - Spravovat",
 
   // "collection.edit.tabs.authorizations.head": "Authorizations",
   "collection.edit.tabs.authorizations.head": "Oprávnění",
@@ -2037,7 +2037,7 @@
   "collection.page.edit": "Upravit tuto kolekci",
 
   // "collection.page.handle": "Permanent URI for this collection",
-  "collection.page.handle": "Permanentní URI této kolekce",
+  "collection.page.handle": "Permanentní URI pro tuto kolekci",
 
   // "collection.page.license": "License",
   "collection.page.license": "Licence",
@@ -2115,7 +2115,7 @@
   "collection.source.controls.reset.submit.error": "Něco se pokazilo při zahájení resetu a opětovného importu",
 
   // "collection.source.controls.reset.failed": "An error occurred during the reset and reimport",
-  "collection.source.controls.reset.failed": "Během resetování a opětovnému importu došlo k chybě",
+  "collection.source.controls.reset.failed": "Během resetování a opětovného importu došlo k chybě",
 
   // "collection.source.controls.reset.completed": "The reset and reimport completed",
   "collection.source.controls.reset.completed": "Reset a opětovný import byl dokončen",
@@ -2385,7 +2385,7 @@
   "comcol-role.edit.scorereviewers.name": "Recenzenti výsledků",
 
   // "comcol-role.edit.scorereviewers.description": "Reviewers are able to give a score to incoming submissions, this will define whether the submission will be rejected or not.",
-  "comcol-role.edit.scorereviewers.description": "Recenzenti mohou hodnotit příchozí příspěvky což určí, zda příspěvek bude zamítnut či nikoliv.",
+  "comcol-role.edit.scorereviewers.description": "Recenzenti mohou hodnotit příchozí příspěvky, což určí, zda příspěvek bude zamítnut či nikoliv.",
 
   // "community.form.abstract": "Short Description",
   "community.form.abstract": "Krátký popis",
@@ -2409,7 +2409,7 @@
   "community.page.edit": "Upravit tuto komunitu",
 
   // "community.page.handle": "Permanent URI for this community",
-  "community.page.handle": "Trvalé URI",
+  "community.page.handle": "Trvalé URI pro tuto komunitu",
 
   // "community.page.license": "License",
   "community.page.license": "Licence",
@@ -2490,7 +2490,7 @@
   "cookies.consent.content-modal.privacy-policy.text": "Chcete-li se dozvědět více, přečtěte si prosím naše {privacyPolicy}.",
 
   // "cookies.consent.content-modal.no-privacy-policy.text": "",
-  "cookies.consent.content-modal.no-privacy-policy.text": "",upnosti",
+  "cookies.consent.content-modal.no-privacy-policy.text": "",
 
   // "cookies.consent.content-modal.title": "Information that we collect",
   "cookies.consent.content-modal.title": "Informace, které shromažďujeme",
@@ -2577,7 +2577,7 @@
   "curation-task.task.vscan.label": "Antivirová kontrola",
 
   // "curation-task.task.registerdoi.label": "Register DOI",
-  "curation-task.task.registerdoi.label": "Zaregistrujte DOI",
+  "curation-task.task.registerdoi.label": "Zaregistrovat DOI",
 
   // "curation.form.task-select.label": "Task:",
   "curation.form.task-select.label": "Úloha:",
@@ -2700,7 +2700,7 @@
   "dso-selector.placeholder.type.collection": "kolekce",
 
   // "dso-selector.placeholder.type.item": "item",
-  "dso-selector.placeholder.type.community": "komunita",
+  "dso-selector.placeholder.type.community": "záznam",
 
   // "dso-selector.select.collection.head": "Select a collection",
   "dso-selector.results-could-not-be-retrieved": "Něco se nepovedlo, zkuste, prosím, načíst znovu ↻",
@@ -2769,7 +2769,7 @@
   "supervision-group-selector.notification.create.failure.title": "Chyba",
 
   // "supervision-group-selector.notification.create.already-existing": "A supervision order already exists on this item for selected group",
-  "supervision-group-selector.notification.create.already-existing": "Příkaz k supervizi již existuje na tomto záznamu pro vybranou skupinu",
+  "supervision-group-selector.notification.create.already-existing": "Příkaz supervize již existuje na tomto záznamu pro vybranou skupinu",
 
   // "confirmation-modal.export-metadata.header": "Export metadata for {{ dsoName }}",
   "confirmation-modal.export-metadata.header": "Exportovat metadata pro {{ dsoName }}",
@@ -2949,7 +2949,7 @@
   "error.validation.metadata.qualifier.max-length": "Toto pole nesmí obsahovat více než 64 znaků",
 
   // "feed.description": "Syndication feed",
-  "feed.description": "Synchronizační kanál",
+  "feed.description": "Syndikační kanál",
 
   // "file-download-link.restricted": "Restricted bitstream",
   "file-download-link.restricted": "Soubor s omezeným přístupem",
@@ -3045,7 +3045,7 @@
   "forgot-password.form.label.passwordrepeat": "Zadejte znovu pro ověření",
 
   // "forgot-password.form.error.empty-password": "Please enter a password in the boxes above.",
-  "forgot-password.form.error.empty-password": "Zadejte prosím heslo do níže uvedeného pole.",
+  "forgot-password.form.error.empty-password": "Zadejte prosím heslo do výše uvedeného pole.",
 
   // "forgot-password.form.error.matching-passwords": "The passwords do not match.",
   "forgot-password.form.error.matching-passwords": "Hesla se neshodují.",
@@ -3066,7 +3066,7 @@
   "form.add": "Přidat další",
 
   // "form.add-help": "Click here to add the current entry and to add another one",
-  "form.add-help": "Klikněte zde pro přidání aktuálního záznamu a pro přidání dalšího",
+  "form.add-help": "Klikněte zde pro přidání aktuálního záznamu a přidání dalšího",
 
   // "form.cancel": "Cancel",
   "form.cancel": "Zrušit",
@@ -3234,7 +3234,7 @@
   "grant-request-copy.intro.attachment": "Žadateli bude odeslána zpráva. Požadované dokumenty budou přiloženy.",
 
   // "grant-request-copy.intro.link": "A message will be sent to the applicant of the request. A secure link providing access to the requested document(s) will be attached. The link will provide access for the duration of time selected in the \"Access Period\" menu below.",
-  "grant-request-copy.intro.link": "A message will be sent to the applicant of the request. A secure link providing access to the requested document(s) will be attached. The link will provide access for the duration of time selected in the \"Access Period\" menu below.",
+  "grant-request-copy.intro.link": „Žadateli bude odeslána zpráva. Bude přiložen zabezpečený odkaz poskytující přístup k požadovaným dokumentům. Odkaz bude platný po dobu zvolenou v nabídce ‚Doba přístupu‘ níže.“,
 
   // "grant-request-copy.intro.link.preview": "Below is a preview of the link that will be sent to the applicant:",
   "grant-request-copy.intro.link.preview": "Níže je náhled odkazu, který bude odeslán žadateli:",
@@ -3540,7 +3540,7 @@
   "item.edit.bitstreams.bundle.edit.buttons.upload": "Nahrát",
 
   // "item.edit.bitstreams.bundle.displaying": "Currently displaying {{ amount }} bitstreams of {{ total }}.",
-  "item.edit.bitstreams.bundle.displaying": "Aktuálně zobrazuje {{ amount }} souborů z {{ total }}.",
+  "item.edit.bitstreams.bundle.displaying": "Aktuálně se zobrazuje {{ amount }} souborů z {{ total }}.",
 
   // "item.edit.bitstreams.bundle.load.all": "Load all ({{ total }})",
   "item.edit.bitstreams.bundle.load.all": "Načíst všechny ({{ total }})",
@@ -3759,7 +3759,7 @@
   "item.edit.item-mapper.cancel": "Zrušit",
 
   // "item.edit.item-mapper.description": "This is the item mapper tool that allows administrators to map this item to other collections. You can search for collections and map them, or browse the list of collections the item is currently mapped to.",
-  "item.edit.item-mapper.description": "Toto je nástroj pro mapování záznamů, který umožňuje správcům mapovat tento záznam do jiné kolekce. Můžete vyhledávat kolekce a mapovat je nebo procházet seznam kolekcí, ke kterým je záznam aktuálně mapována.",
+  "item.edit.item-mapper.description": "Toto je nástroj pro mapování záznamů, který umožňuje správcům mapovat tento záznam do jiné kolekce. Můžete vyhledávat kolekce a mapovat je nebo procházet seznam kolekcí, ke kterým je záznam aktuálně mapován.",
 
   // "item.edit.item-mapper.head": "Item Mapper - Map Item to Collections",
   "item.edit.item-mapper.head": "Mapování do jiných kolekcí - mapovat záznam do kolekcí",
@@ -3777,19 +3777,19 @@
   "item.edit.item-mapper.notifications.add.error.head": "Chyby při mapování",
 
   // "item.edit.item-mapper.notifications.add.success.content": "Successfully mapped item to {{amount}} collections.",
-  "item.edit.item-mapper.notifications.add.success.content": "Úspěšné mapování záznamu do {{amount}} kolekcí .",
+  "item.edit.item-mapper.notifications.add.success.content": "Úspěšné mapování záznamu do {{amount}} kolekcí.",
 
   // "item.edit.item-mapper.notifications.add.success.head": "Mapping completed",
   "item.edit.item-mapper.notifications.add.success.head": "Mapování dokončeno",
 
   // "item.edit.item-mapper.notifications.remove.error.content": "Errors occurred for the removal of the mapping to {{amount}} collections.",
-  "item.edit.item-mapper.notifications.remove.error.content": "Při odstraňování mapování do {{amount}} kolekcí  došlo k chybám.",
+  "item.edit.item-mapper.notifications.remove.error.content": "Při odstraňování mapování do {{amount}} kolekcí došlo k chybám.",
 
   // "item.edit.item-mapper.notifications.remove.error.head": "Removal of mapping errors",
   "item.edit.item-mapper.notifications.remove.error.head": "Odstranění chyb při mapování",
 
   // "item.edit.item-mapper.notifications.remove.success.content": "Successfully removed mapping of item to {{amount}} collections.",
-  "item.edit.item-mapper.notifications.remove.success.content": "Úspěšně odstraněno mapování záznamu do {{amount}} kolekcí .",
+  "item.edit.item-mapper.notifications.remove.success.content": "Úspěšně odstraněno mapování záznamu do {{amount}} kolekcí.",
 
   // "item.edit.item-mapper.notifications.remove.success.head": "Removal of mapping completed",
   "item.edit.item-mapper.notifications.remove.success.head": "Odstranění mapování dokončeno",
@@ -3972,7 +3972,7 @@
   "item.edit.private.confirm": "Učinit nedohledatelným",
 
   // "item.edit.private.description": "Are you sure this item should be made non-discoverable in the archive?",
-  "item.edit.private.description": "Jste si jisti, že by tento záznam neměl být v archivu objeven?",
+  "item.edit.private.description": "Jste si jisti, že by tento záznam neměl být v archivu dohledatelný?",
 
   // "item.edit.private.error": "An error occurred while making the item non-discoverable",
   "item.edit.private.error": "Při změně stavu záznamu na nedohledatelný došlo k chybě",
@@ -4071,7 +4071,7 @@
   "item.edit.tabs.bitstreams.head": "Soubory",
 
   // "item.edit.tabs.bitstreams.title": "Item Edit - Bitstreams",
-  "item.edit.tabs.bitstreams.title": "Úprava záznamu - soubor",
+  "item.edit.tabs.bitstreams.title": "Úprava záznamu - soubory",
 
   // "item.edit.tabs.curate.head": "Curate",
   "item.edit.tabs.curate.head": "Spravovat",
@@ -4161,7 +4161,7 @@
   "item.edit.tabs.status.labels.handle": "Handle",
 
   // "item.edit.tabs.status.labels.id": "Item Internal ID",
-  "item.edit.tabs.status.labels.id": "Položka Internal ID",
+  "item.edit.tabs.status.labels.id": "Interní ID položky",
 
   // "item.edit.tabs.status.labels.itemPage": "Item Page",
   "item.edit.tabs.status.labels.itemPage": "Stránka záznamu",
@@ -4191,7 +4191,7 @@
   "item.edit.withdraw.cancel": "Zrušit",
 
   // "item.edit.withdraw.confirm": "Withdraw",
-  "item.edit.withdraw.confirm": "Potvrdit",
+  "item.edit.withdraw.confirm": "Odebrat",
 
   // "item.edit.withdraw.description": "Are you sure this item should be withdrawn from the archive?",
   "item.edit.withdraw.description": "Jste si jisti, že by tento záznam měl být odebrán z archivu?",
@@ -4401,7 +4401,7 @@
   "item.page.link.full": "Zobrazit celý záznam",
 
   // "item.page.link.simple": "Simple item page",
-  "item.page.link.simple": "Zobrazit minimální záznam",
+  "item.page.link.simple": "Zobrazit jednoduchý záznam",
 
   // "item.page.options": "Options",
   "item.page.options": "Možnosti",
@@ -4437,7 +4437,7 @@
   "item.page.subject": "Klíčová slova",
 
   // "item.page.uri": "URI",
-  "item.page.uri": "Permanentní identifikátor",
+  "item.page.uri": "Trvalý identifikátor",
 
   // "item.page.bitstreams.view-more": "Show more",
   "item.page.bitstreams.view-more": "Zobrazit více",
@@ -4674,7 +4674,7 @@
   "item.version.history.table.item": "Záznam",
 
   // "item.version.history.table.editor": "Editor",
-  "item.version.history.table.editor": "Upravit",
+  "item.version.history.table.editor": "Editor",
 
   // "item.version.history.table.date": "Date",
   "item.version.history.table.date": "Datum",
@@ -5202,7 +5202,7 @@
   "menu.section.browse_community_by_title": "Podle názvu",
 
   // "menu.section.browse_global": "All of DSpace",
-  "menu.section.browse_global": "Procházet podle",
+  "menu.section.browse_global": "Celý DSpace“",
 
   // "menu.section.browse_global_by_author": "By Author",
   "menu.section.browse_global_by_author": "Podle autora",
@@ -5223,7 +5223,7 @@
   "menu.section.browse_global_by_title": "Podle názvu",
 
   // "menu.section.browse_global_by_horizon": "By Horizon",
-  "menu.section.browse_global_by_horizon": "Podle horizon",
+  "menu.section.browse_global_by_horizon": "Podle Horizon",
 
   // "menu.section.browse_global_by_affiliation": "By Faculty",
   "menu.section.browse_global_by_affiliation": "Podle fakulty",
@@ -5283,7 +5283,7 @@
   "menu.section.icon.control_panel": "Sekce menu Ovládací panel",
 
   // "menu.section.icon.curation_tasks": "Curation Task menu section",
-  "menu.section.icon.curation_tasks": "Sekce menu úloha správy",
+  "menu.section.icon.curation_tasks": "Sekce menu Úloha správy",
 
   // "menu.section.icon.edit": "Edit menu section",
   "menu.section.icon.edit": "Sekce menu Upravit",
@@ -5385,7 +5385,7 @@
   "menu.section.toggle.control_panel": "Přepnout sekci ovládacího panelu",
 
   // "menu.section.toggle.curation_task": "Toggle Curation Task section",
-  "menu.section.toggle.curation_task": "Přepnout sekci úloha správy",
+  "menu.section.toggle.curation_task": "Přepnout sekci Úloha správy",
 
   // "menu.section.toggle.edit": "Toggle Edit section",
   "menu.section.toggle.edit": "Přepnout sekci Úpravy",
@@ -5502,7 +5502,7 @@
   "mydspace.results.no-uri": "Žádné URI",
 
   // "mydspace.search-form.placeholder": "Search in MyDSpace...",
-  "mydspace.search-form.placeholder": "Hledat v mém dspace...",
+  "mydspace.search-form.placeholder": "Hledat v mém DSpace...",
 
   // "mydspace.show.workflow": "Workflow tasks",
   "mydspace.show.workflow": "Úlohy workflow",
@@ -5538,7 +5538,7 @@
   "mydspace.upload.upload-failed": "Chyba při vytváření nového pracovního prostoru. Před dalším pokusem ověřte nahraný obsah.",
 
   // "mydspace.upload.upload-failed-manyentries": "Unprocessable file. Detected too many entries but allowed only one for file.",
-  "mydspace.upload.upload-failed-manyentries": "Nezpracovatelný soubor. Zjištěno příliš mnoho záznamů, ale povolen pouze jeden pro soubor",
+  "mydspace.upload.upload-failed-manyentries": "Nezpracovatelný soubor. Zjištěno příliš mnoho záznamů, ale povolen pouze jeden pro soubor.",
 
   // "mydspace.upload.upload-failed-moreonefile": "Unprocessable request. Only one file is allowed.",
   "mydspace.upload.upload-failed-moreonefile": "Nezpracovatelný požadavek. Je povolen pouze jeden soubor.",
@@ -5610,7 +5610,7 @@
   "nav.toggle": "Přepnout navigaci",
 
   // "nav.user.description": "User profile bar",
-  "nav.user.description": "Panel uživatelského profilu ",
+  "nav.user.description": "Panel uživatelského profilu",
 
   // "listelement.badge.dso-type": "Item type:",
   "listelement.badge.dso-type": "Typ položky:",
@@ -6153,7 +6153,7 @@
   "process.overview.delete.processing": "Maže se {{count}} procesů. Počkejte prosím na úplné dokončení mazání. To může chvíli trvat.",
 
   // "process.overview.delete.body": "Are you sure you want to delete {{count}} process(es)?",
-  "process.overview.delete.body": "Určitě chcete smazat {{count}} procesů",
+  "process.overview.delete.body": "Určitě chcete smazat {{count}} procesů?",
 
   // "process.overview.delete.header": "Delete processes",
   "process.overview.delete.header": "Smazat procesy",
@@ -6522,7 +6522,7 @@
   "register-page.registration.header": "Registrace nového uživatele",
 
   // "register-page.registration.info": "Register an account to subscribe to collections for email updates, and submit new items to DSpace.",
-  "register-page.registration.info": "Zaregistrujte si účet a přihlaste se k odběru kolekcí pro e-mailové aktualizace a odesílejte nové záznamy do systému DSpace",
+  "register-page.registration.info": "Zaregistrujte si účet a přihlaste se k odběru kolekcí pro e-mailové aktualizace a odesílejte nové záznamy do systému DSpace.",
 
   // "register-page.registration.email": "Email Address *",
   "register-page.registration.email": "E-mailová adresa *",
@@ -6531,7 +6531,7 @@
   "register-page.registration.email.error.required": "Vyplňte prosím e-mailovou adresu",
 
   // "register-page.registration.email.error.not-email-form": "Please fill in a valid email address.",
-  "register-page.registration.email.error.not-email-form": "Prosím vyplňte platnou emailovou adresu.",
+  "register-page.registration.email.error.not-email-form": "Prosím, vyplňte platnou emailovou adresu.",
 
   // "register-page.registration.email.error.not-valid-domain": "Use email with allowed domains: {{ domains }}",
   "register-page.registration.email.error.not-valid-domain": "Použijte email s povolenými doménami: {{ domains }}",
@@ -6795,7 +6795,7 @@
   "resource-policies.form.name.hint": "Maximálně 30 znaků",
 
   // "resource-policies.form.policy-type.label": "Select the policy type",
-  "resource-policies.form.policy-type.label": "vyberte typ politiky",
+  "resource-policies.form.policy-type.label": "Vyberte typ politiky",
 
   // "resource-policies.form.policy-type.required": "You must select the resource policy type.",
   "resource-policies.form.policy-type.required": "Je třeba vybrat typ politiky zdrojů.",
@@ -7025,7 +7025,7 @@
   "search.filters.filter.creativeWorkKeywords.placeholder": "Předmět",
 
   // "search.filters.filter.creativeWorkKeywords.label": "Search subject",
-  "search.filters.filter.creativeWorkKeywords.label": "Předmět hledání",
+  "search.filters.filter.creativeWorkKeywords.label": "Hledat předmět",
 
   // "search.filters.filter.creativeWorkPublisher.head": "Publisher",
   "search.filters.filter.creativeWorkPublisher.head": "Nakladatel",
@@ -7223,10 +7223,10 @@
   "search.filters.filter.funding.placeholder": "Financování",
 
   // "search.filters.filter.supervisedBy.head": "Supervised By",
-  "search.filters.filter.supervisedBy.head": "Dohlížející autorita:",
+  "search.filters.filter.supervisedBy.head": "Dohlížející autorita",
 
   // "search.filters.filter.supervisedBy.placeholder": "Supervised By",
-  "search.filters.filter.supervisedBy.placeholder": "Dohlížející autorita:",
+  "search.filters.filter.supervisedBy.placeholder": "Dohlížející autorita",
 
   // "search.filters.filter.supervisedBy.label": "Search Supervised By",
   "search.filters.filter.supervisedBy.label": "Hledat dohlížející autoritu",
@@ -7769,7 +7769,7 @@
   "submission.sections.describe.relationship-lookup.external-source.import-button-title.OrgUnit": "Importovat externě uloženou organizační jednotku",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-button-title.Funding": "Import remote fund",
-  "submission.sections.describe.relationship-lookup.external-source.import-button-title.Funding": "Importovat fond",
+  "submission.sections.describe.relationship-lookup.external-source.import-button-title.Funding": "Importovat externě uložený fond",
 
   // "submission.sections.describe.relationship-lookup.external-source.import-button-title.Person": "Import remote person",
   "submission.sections.describe.relationship-lookup.external-source.import-button-title.Person": "Importovat externě uloženou osobu",
@@ -7919,7 +7919,7 @@
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.isAuthorOfPublication": "Lokálně uložení autoři ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalOfPublication": "Local Journals ({{ count }})",
-  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalOfPublication": "Lokálně uložené časopisy({{ count }})",
+  "submission.sections.describe.relationship-lookup.search-tab.tab-title.isJournalOfPublication": "Lokálně uložené časopisy ({{ count }})",
 
   // "submission.sections.describe.relationship-lookup.search-tab.tab-title.Project": "Local Projects ({{ count }})",
   "submission.sections.describe.relationship-lookup.search-tab.tab-title.Project": "Lokálně uložené projekty ({{ count }})",
@@ -8141,7 +8141,7 @@
   "submission.sections.describe.relationship-lookup.selection-tab.title.Publication": "Vybrané publikace",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.Person": "Selected Authors",
-  "submission.sections.describe.relationship-lookup.selection-tab.title.Person": "Vybraní Autoři",
+  "submission.sections.describe.relationship-lookup.selection-tab.title.Person": "Vybraní autoři",
 
   // "submission.sections.describe.relationship-lookup.selection-tab.title.OrgUnit": "Selected Organizational Units",
   "submission.sections.describe.relationship-lookup.selection-tab.title.OrgUnit": "Vybrané organizační jednotky",
@@ -8336,7 +8336,7 @@
   "submission.sections.identifiers.otherIdentifiers_label": "Jiné identifikátory: ",
 
   // "submission.sections.submit.progressbar.accessCondition": "Item access conditions",
-  "submission.sections.submit.progressbar.accessCondition": "Podmínky přístupu k záznamům",
+  "submission.sections.submit.progressbar.accessCondition": "Podmínky přístupu k záznamu",
 
   // "submission.sections.submit.progressbar.CClicense": "Creative commons license",
   "submission.sections.submit.progressbar.CClicense": "Licence Creative Commons",
@@ -9575,10 +9575,10 @@
   "item-access-control-title": "Tento formulář umožňuje provést změny typu přístupu k metadatovému záznamu nebo souborům.",
 
   // "collection-access-control-title": "This form allows you to perform changes to the access conditions of all the items owned by this collection. Changes may be performed to either all Item metadata or all content (bitstreams).",
-  "collection-access-control-title": "Tento formulář umožňuje provést změny typu přístupu u všech záznamů v této kolekci. Změny mohou být uplatněny bud na všechny metadatové záznamy nebo veškerý obsah (soubory).",
+  "collection-access-control-title": "Tento formulář umožňuje provést změny typu přístupu u všech záznamů v této kolekci. Změny mohou být uplatněny buď na všechny metadatové záznamy nebo veškerý obsah (soubory).",
 
   // "community-access-control-title": "This form allows you to perform changes to the access conditions of all the items owned by any collection under this community. Changes may be performed to either all Item metadata or all content (bitstreams).",
-  "community-access-control-title": "Tento formulář umožňuje provést změny typu přístupu u všech záznamů v kolekcích této komunity. Změny mohou být uplatněny bud na všechny metadatové záznamy nebo veškerý obsah (soubory).",
+  "community-access-control-title": "Tento formulář umožňuje provést změny typu přístupu u všech záznamů v kolekcích této komunity. Změny mohou být uplatněny buď na všechny metadatové záznamy nebo veškerý obsah (soubory).",
 
   // "access-control-item-header-toggle": "Item's Metadata",
   "access-control-item-header-toggle": "Metadata záznamu",
@@ -9620,7 +9620,7 @@
   "access-control-process-all-bitstreams": "Aktualizovat všechny soubory u daného záznamu",
 
   // "access-control-bitstreams-selected": "bitstreams selected",
-  "access-control-bitstreams-selected": "vybrány soubory",
+  "access-control-bitstreams-selected": "vybrané soubory",
 
   // "access-control-bitstreams-select": "Select bitstreams",
   "access-control-bitstreams-select": "Vybrat soubory",
@@ -10069,10 +10069,10 @@
   "submission.sections.submit.progressbar.coarnotify": "COAR Notify",
 
   // "submission.section.section-coar-notify.control.request-review.label": "You can request a review to one of the following services",
-  "submission.section.section-coar-notify.control.request-review.label": "Můžete požádat o recenzi jednu z následujících služeb",
+  "submission.section.section-coar-notify.control.request-review.label": "Můžete požádat o recenzi u jedné z následujících služeb",
 
   // "submission.section.section-coar-notify.control.request-endorsement.label": "You can request an Endorsement to one of the following overlay journals",
-  "submission.section.section-coar-notify.control.request-endorsement.label": "Můžete požádat o doporučení jeden z následujících overlay časopisů",
+  "submission.section.section-coar-notify.control.request-endorsement.label": "Můžete požádat o doporučení u jednoho z následujících overlay časopisů",
 
   // "submission.section.section-coar-notify.control.request-ingest.label": "You can request to ingest a copy of your submission to one of the following services",
   "submission.section.section-coar-notify.control.request-ingest.label": "Můžete požádat o převzetí kopie vašeho příspěvku do jedné z následujících služeb",
@@ -10201,7 +10201,7 @@
   "menu.section.coar_notify": "COAR Notify",
 
   // "admin-notify-dashboard.title": "Notify Dashboard",
-  "admin-notify-dashboard.title": "Notify řídicí panel",
+  "admin-notify-dashboard.title": "Řídicí panel Notify",
 
   // "admin-notify-dashboard.description": "The Notify dashboard monitor the general usage of the COAR Notify protocol across the repository. In the “Metrics” tab are statistics about usage of the COAR Notify protocol. In the “Logs/Inbound” and “Logs/Outbound” tabs it’s possible to search and check the individual status of each LDN message, either received or sent.",
   "admin-notify-dashboard.description": "Řídicí panel Notify sleduje celkové používání protokolu COAR Notify v repozitáři. Na kartě \"Metriky\" jsou statistiky o použití protokolu COAR Notify. Na kartách \"Protokoly/Příchozí\" a \"Protokoly/Odchozí\" je možné vyhledávat a kontrolovat individuální stav každé LDN zprávy, přijaté nebo odeslané.",
@@ -10633,7 +10633,7 @@
   "notify-message-modal.show-message": "Zobrazit zprávu",
 
   // "notify-message-result.timestamp": "Timestamp",
-  "notify-message-result.timestamp": "Časové razítko",
+  "notify-message-result.timestamp": "Časová značka",
 
   // "notify-message-result.repositoryItem": "Repository Item",
   "notify-message-result.repositoryItem": "Záznam v repozitáři",
@@ -10726,7 +10726,7 @@
   "live-region.ordering.instructions": "Stiskněte mezerník pro přeskupení {{ itemName }}.",
 
   // "live-region.ordering.status": "{{ itemName }}, grabbed. Current position in list: {{ index }} of  {{ length }}. Press up and down arrow keys to change position, SpaceBar to drop, Escape to cancel.",
-  "live-region.ordering.status": "{{ itemName }}, uchopeno. Aktuální pozice v seznamu: {{ index }} z {{ length }}. Použijte šipky nahoru/dolů pro změnu pozice, mezerník pro uvolnění, Escape pro zrušení.",
+  "live-region.ordering.status": "{{ itemName }}, uchopeno. Aktuální pozice v seznamu: {{ index }} z {{ length }}. Použijte šipky nahoru a dolů pro změnu pozice, mezerník pro uvolnění, Escape pro zrušení.",
 
   // "live-region.ordering.moved": "{{ itemName }}, moved to position {{ index }} of {{ length }}. Press up and down arrow keys to change position, SpaceBar to drop, Escape to cancel.",
   "live-region.ordering.moved": "{{ itemName }}, přesunuto na pozici {{ index }} z {{ length }}. Použijte šipky nahoru/dolů pro změnu pozice, mezerník pro uvolnění, Escape pro zrušení.",
@@ -10882,7 +10882,7 @@
   "metadata-export-filtered-items.submit.error": "Export CSV selhal.",
 
   // "metadata-export-filtered-items.columns.warning": "CSV export automatically includes all relevant fields, so selections in this list are not taken into account.",
-  "metadata-export-filtered-items.columns.warning": "Export CSV automaticky zahrne všechna relevantní pole, proto se výběry v tomto seznamu neberou v potaz.",
+  "metadata-export-filtered-items.columns.warning": "Export CSV automaticky zahrnuje všechna relevantní pole, proto se výběry v tomto seznamu neberou v potaz.",
 
   // "embargo.listelement.badge": "Embargo until {{ date }}",
   "embargo.listelement.badge": "Embargo do {{ date }}",


### PR DESCRIPTION
## Problem description
There are missing translations in v9
Steps:
- [x] 1. Cherry-pick from upstream to sync some of the translations.
- [x] 2. Complete all czech translations
- [x] 3. Check all translations

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [x] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot