### PR TITLE
SAV/Allow bitstream format names to wrap in edit view

### DIFF
--- a/src/app/item-page/edit-item-page/item-bitstreams/item-edit-bitstream/item-edit-bitstream.component.html
+++ b/src/app/item-page/edit-item-page/item-bitstreams/item-edit-bitstream/item-edit-bitstream.component.html
@@ -17,7 +17,7 @@
   </div>
   <div class="{{columnSizes.columns[2].buildClasses()}} row-element d-flex align-items-center">
     <div class="text-center w-100">
-        <span class="text-truncate">
+        <span class="d-inline-block">
             {{ (format$ | async)?.shortDescription }}
         </span>
     </div>

--- a/src/app/item-page/edit-item-page/item-bitstreams/item-edit-bitstream/item-edit-bitstream.component.html
+++ b/src/app/item-page/edit-item-page/item-bitstreams/item-edit-bitstream/item-edit-bitstream.component.html
@@ -17,7 +17,7 @@
   </div>
   <div class="{{columnSizes.columns[2].buildClasses()}} row-element d-flex align-items-center">
     <div class="text-center w-100">
-        <span class="d-inline-block">
+        <span class="d-inline-block text-break">
             {{ (format$ | async)?.shortDescription }}
         </span>
     </div>


### PR DESCRIPTION
## Problem description
Long bitstream format names like "Microsoft Word XML" were being truncated with ellipsis, fixed by replacing text-truncate class with d-inline-block to allow text wrapping.

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [x] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [x] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [x] Requested review from Copilot