### PR TITLE
Mendelu/Added variable to playwright config

### DIFF
--- a/config/config.mendelu.ui.tests.json
+++ b/config/config.mendelu.ui.tests.json
@@ -10,6 +10,7 @@
     "profile_link": "a[href=\"/profile\"]",
     "logout_link": "button[data-test=\"logout-button\"]",
     "signon_link": "button[data-test=\"login-menu\"]",
-    "result_card": "li[data-test=\"list-object\"]"
+    "result_card": "li[data-test=\"list-object\"]",
+    "new_section": "nav#admin-sidebar"
   }
 }


### PR DESCRIPTION
## Problem description
Dspace 9 has different locator in admin nav bar, has to add new

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot