### PR TITLE
Skipping branches in triggering ui tests

### DIFF
--- a/.github/workflows/trigger-ui-tests.yml
+++ b/.github/workflows/trigger-ui-tests.yml
@@ -24,7 +24,7 @@ jobs:
 
           git fetch --prune origin
           BRANCHES=$(git ls-remote --heads origin | awk -F'/' '{print $3"/"$4}' | grep '^customer/')
-          SKIP_BRANCHES=("customer/sav" "customer/uk")
+          SKIP_BRANCHES=("customer/sav" "customer/uk" "customer/mendelu-v7" "customer/palo-docker" "customer/palo-docker-rebase" "customer/palo-docker-typo-fix")
           
           for branch in $(echo "$BRANCHES" | sed -e 's/[\[\]"]//g' -e 's/,/\n/g'); do
             if [[ " ${SKIP_BRANCHES[@]} " =~ " ${branch} " ]]; then


### PR DESCRIPTION
## Problem description
In some branches is not possible to run ui tests

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot