### PR TITLE
MENDELU/Fix of translation messages vol.2

### DIFF
--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -1707,13 +1707,13 @@
   "browse.metadata.title": "Název",
 
   // "browse.metadata.srsc": "Subject Category",
-  "browse.metadata.srsc": "Subject Category",
+  "browse.metadata.srsc": "Předmětová kategorie",
 
   // "browse.metadata.horizon": "project Horizon",
   "browse.metadata.horizon": "projekt Horizon",
 
-  // "browse.metadata.affiliation": "Affiliation",
-  "browse.metadata.affiliation": "Afiliace",
+  // "browse.metadata.affiliation": "Faculty",
+  "browse.metadata.affiliation": "Fakulta",
 
   // "browse.metadata.author.breadcrumbs": "Browse by Author",
   "browse.metadata.author.breadcrumbs": "Procházet podle autora",
@@ -1726,6 +1726,12 @@
 
   // "browse.metadata.srsc.breadcrumbs": "Browse by Subject Category",
   "browse.metadata.srsc.breadcrumbs": "Procházet podle předmětu",
+
+  // "browse.metadata.horizon.breadcrumbs": "Browse by Horizon",
+  "browse.metadata.horizon.breadcrumbs": "Procházet podle horizon",
+
+  // "browse.metadata.affiliation.breadcrumbs": "Browse by Faculty",
+  "browse.metadata.affiliation.breadcrumbs": "Procházet podle fakulty",
 
   // "browse.metadata.srsc.tree.description": "Select a subject to add as search filter",
   // TODO New key - Add a translation
@@ -5595,10 +5601,10 @@
   "menu.section.browse_global_by_title": "Podle názvu",
 
   // "menu.section.browse_global_by_horizon": "By Horizon",
-  "menu.section.browse_global_by_horizon": "Podle Horizon",
+  "menu.section.browse_global_by_horizon": "Podle horizon",
 
-  // "menu.section.browse_global_by_affiliation": "By Affiliation",
-  "menu.section.browse_global_by_affiliation": "Podle afiliace",
+  // "menu.section.browse_global_by_affiliation": "By Faculty",
+  "menu.section.browse_global_by_affiliation": "Podle fakulty",
 
   // "menu.section.browse_global_communities_and_collections": "Communities & Collections",
   "menu.section.browse_global_communities_and_collections": "Komunity & kolekce",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1047,7 +1047,7 @@
 
   "browse.metadata.horizon": "project Horizon",
 
-  "browse.metadata.affiliation": "Affiliation",
+  "browse.metadata.affiliation": "Faculty",
 
   "browse.metadata.author.breadcrumbs": "Browse by Author",
 
@@ -1056,6 +1056,10 @@
   "browse.metadata.subject.breadcrumbs": "Browse by Subject",
 
   "browse.metadata.srsc.breadcrumbs": "Browse by Subject Category",
+
+  "browse.metadata.horizon.breadcrumbs": "Browse by Horizon",
+
+  "browse.metadata.affiliation.breadcrumbs": "Browse by Faculty",
 
   "browse.metadata.srsc.tree.description": "Select a subject to add as search filter",
 
@@ -3475,7 +3479,7 @@
 
   "menu.section.browse_global_by_horizon": "By Horizon",
 
-  "menu.section.browse_global_by_affiliation": "By Affiliation",
+  "menu.section.browse_global_by_affiliation": "By Faculty",
 
   "menu.section.browse_global_communities_and_collections": "Communities & Collections",
 


### PR DESCRIPTION
## Problem description
- Affiliation means Faculty
- Uppercase Horiozn in `Browse by` section was weird
- Missing breadcrumbs i18n keys for Horizon and Affiliation

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot