### PR TITLE
VSB-TUO/Fix of translation messages

### DIFF
--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -1226,6 +1226,9 @@
   // "browse.metadata.title": "Title",
   "browse.metadata.title": "Název",
 
+  // "browse.metadata.type": "Type",
+  "browse.metadata.type": "Typ",
+
   // "browse.metadata.author.breadcrumbs": "Browse by Author",
   "browse.metadata.author.breadcrumbs": "Procházet podle autora",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -817,6 +817,8 @@
 
   "browse.metadata.title": "Title",
 
+  "browse.metadata.type": "Type",
+
   "browse.metadata.author.breadcrumbs": "Browse by Author",
 
   "browse.metadata.dateissued.breadcrumbs": "Browse by Date",


### PR DESCRIPTION
## Problem description
- Missing "browse.metadata.type" key caused i18n key to be visible on https://dspace.vsb.cz/browse/type page

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [x] Requested review from Copilot