### PR TITLE
Fixed starting handle server - docker compose - permissions problem

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,9 +101,6 @@ jobs:
           ## !!!!! please remove this section if you do not want handle server !!!!!!!
           echo "====="
           echo "installing handle server"
-          docker exec dspace${INSTANCE} apt update
-          docker exec dspace${INSTANCE} apt install host -y
-          echo "installed host from apt"
           docker exec dspace${INSTANCE} /dspace/bin/make-handle-config
           echo "made handle config:"
           docker exec dspace${INSTANCE} cat /dspace/handle-server/config.dct


### PR DESCRIPTION
## Problem description
`sudo` commands cannot be run because of permissions - the dspace user cannot run `apt update`...

## Analysis
(Write here, if there is needed describe some specific problem. Erase it, when it is not needed.)
## Problems
(Write here, if some unexpected problems occur during solving issues. Erase it, when it is not needed.) 

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot