### PR TITLE
Increased timeout for rest tests after deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -162,7 +162,7 @@ jobs:
   rest-tests-after-deploy8:
     runs-on: ubuntu-latest
     needs: playwright-after-deploy8
-    timeout-minutes: 45
+    timeout-minutes: 120
     steps:
       - name: run rest-tests
         run: |
@@ -202,7 +202,7 @@ jobs:
   rest-tests-after-import8:
     runs-on: ubuntu-latest
     needs: playwright-after-import8
-    timeout-minutes: 45
+    timeout-minutes: 120
     steps:
       - name: run rest-tests
         run: |


### PR DESCRIPTION
## Problem description
Canceled rest-tests after timeout

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot