### PR TITLE
TUL/Increased timeout for rest tests after deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,7 @@ jobs:
   rest-tests-after-deploy6:
     runs-on: ubuntu-latest
     needs: playwright-after-deploy6
-    timeout-minutes: 45
+    timeout-minutes: 120
     steps:
       - name: run rest-tests
         run: |
@@ -106,7 +106,7 @@ jobs:
   rest-tests-after-import6:
     runs-on: ubuntu-latest
     needs: playwright-after-import6
-    timeout-minutes: 45
+    timeout-minutes: 120
     steps:
       - name: run rest-tests
         run: |

--- a/config/config.tul.ui.tests.json
+++ b/config/config.tul.ui.tests.json
@@ -6,7 +6,8 @@
       "has_resource_select": false,
       "has_contact_person": false,
       "has_license_select": false,
-      "has_size_dropdown": false
+      "has_size_dropdown": false,
+      "has_static_page": false
     },
     "locators": {
       "title": "DSpace :: Home",


### PR DESCRIPTION
## Problem description
Canceled rest-tests after timeout

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot