### PR TITLE
MENDELU/Search filter date start since 2015

### DIFF
--- a/src/app/shared/search/search-filters/search-filter/search-range-filter/search-range-filter.component.ts
+++ b/src/app/shared/search/search-filters/search-filter/search-range-filter/search-range-filter.component.ts
@@ -68,7 +68,7 @@ export class SearchRangeFilterComponent extends SearchFacetFilterComponent imple
   /**
    * Fallback minimum for the range
    */
-  min = 1950;
+  min = 2015;
 
   /**
    * i18n Label to use for minimum field


### PR DESCRIPTION
## Problem description
8.	U filtrování výsledků podle let je nastaven začátek 1950. My ovšem víme, že budeme mít publikace jen od roku 2015. Šlo by zkrátit prosím tento interval? 

### Copilot review
- [x] Requested review from Copilot