### PR TITLE
TUL/Breadcrumbs cypress fix

### DIFF
--- a/config/config.tul.ui.tests.json
+++ b/config/config.tul.ui.tests.json
@@ -6,7 +6,8 @@
       "has_resource_select": false,
       "has_contact_person": false,
       "has_license_select": false,
-      "has_size_dropdown": false
+      "has_size_dropdown": false,
+      "has_static_page": false
     },
     "locators": {
       "title": "DSpace :: Home",

--- a/cypress/integration/breadcrumbs.spec.ts
+++ b/cypress/integration/breadcrumbs.spec.ts
@@ -7,7 +7,7 @@ describe('Breadcrumbs', () => {
             runMode: 8,
             openMode: 8,
         },
-        defaultCommandTimeout: 10000
+        defaultCommandTimeout: 30000
     }, () => {
         // Visit an Item, as those have more breadcrumbs
         cy.visit('/entities/publication/' + TEST_ENTITY_PUBLICATION);

--- a/cypress/integration/breadcrumbs.spec.ts
+++ b/cypress/integration/breadcrumbs.spec.ts
@@ -2,7 +2,13 @@ import { TEST_ENTITY_PUBLICATION } from 'cypress/support';
 import { testA11y } from 'cypress/support/utils';
 
 describe('Breadcrumbs', () => {
-    it('should pass accessibility tests', () => {
+    it('should pass accessibility tests', {
+        retries: {
+            runMode: 8,
+            openMode: 8,
+        },
+        defaultCommandTimeout: 10000
+    }, () => {
         // Visit an Item, as those have more breadcrumbs
         cy.visit('/entities/publication/' + TEST_ENTITY_PUBLICATION);
 

--- a/cypress/integration/breadcrumbs.spec.ts
+++ b/cypress/integration/breadcrumbs.spec.ts
@@ -7,7 +7,7 @@ describe('Breadcrumbs', () => {
             runMode: 8,
             openMode: 8,
         },
-        defaultCommandTimeout: 30000
+        defaultCommandTimeout: 10000
     }, () => {
         // Visit an Item, as those have more breadcrumbs
         cy.visit('/entities/publication/' + TEST_ENTITY_PUBLICATION);


### PR DESCRIPTION
## Problem description
Failing breadcrumbs e2e test

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [x] Requested review from Copilot