### PR TITLE
MENDELU/Fix security error unsafe resource url (NG0904)

### DIFF
--- a/src/app/item-page/simple/field-components/specific-field/citation/item-page-citation.component.html
+++ b/src/app/item-page/simple/field-components/specific-field/citation/item-page-citation.component.html
@@ -1,8 +1,8 @@
-@if (citaceProStatus) {
+@if (citaceProStatus && citaceProURL) {
   <iframe
     height="200px"
     width="100%"
     style="border: none;"
-    [src]="iframeSrc"
+    [src]="citaceProURL"
   ></iframe>
 }

--- a/src/app/item-page/simple/field-components/specific-field/citation/item-page-citation.component.ts
+++ b/src/app/item-page/simple/field-components/specific-field/citation/item-page-citation.component.ts
@@ -30,7 +30,7 @@ export class ItemPageCitationFieldComponent implements OnInit {
   @Input() handle: string;
 
   citaceProStatus = true;
-  private citaceProURL: SafeResourceUrl | null;
+  citaceProURL: SafeResourceUrl | null = null;
 
   constructor(
     private sanitizer: DomSanitizer,
@@ -66,11 +66,10 @@ export class ItemPageCitationFieldComponent implements OnInit {
     citaceProBaseUrl: string,
     universityUsingDspace: string,
   ): SafeResourceUrl | null {
+    if (!citaceProBaseUrl || !universityUsingDspace || !this.handle) {
+      return null;
+    }
     const url = `${citaceProBaseUrl}:${universityUsingDspace}:${this.handle}`;
     return this.sanitizer.bypassSecurityTrustResourceUrl(url);
-  }
-
-  get iframeSrc(): SafeResourceUrl | null {
-    return this.citaceProURL;
   }
 }


### PR DESCRIPTION
## Problem description
Fix NG0904 unsafe resource URL error in citation iframe by initializing citaceProURL, adding null validation, and ensuring URL is sanitized before binding. Instead of using iframeSrc method, use citaceProURL instead.
<img width="1881" height="757" alt="image" src="https://github.com/user-attachments/assets/b31b3925-74eb-49f0-a968-1b1a47ec0121" />
... on localhost, run on dev mode, the message was:
`ERROR RuntimeError: NG0904: unsafe value used in a resource URL context (see https://g.co/ng/security#xss)
    at ɵɵsanitizeResourceUrl (core.mjs:10232:11)
    at elementPropertyInternal (core.mjs:12606:37)
    at Module.ɵɵproperty (core.mjs:22504:9)
    at ItemPageCitationFieldComponent_Conditional_0_Template (item-page-citation.component.html:6:5)`

### Copilot review
- [x] Requested review from Copilot