### PR TITLE
MENDELU/Fix UI Details

### DIFF
--- a/src/app/app.menus.ts
+++ b/src/app/app.menus.ts
@@ -31,7 +31,6 @@ import { ProcessesMenuProvider } from './shared/menu/providers/processes.menu';
 import { RegistriesMenuProvider } from './shared/menu/providers/registries.menu';
 import { StatisticsMenuProvider } from './shared/menu/providers/statistics.menu';
 import { SystemWideAlertMenuProvider } from './shared/menu/providers/system-wide-alert.menu';
-import { WithdrawnReinstateItemMenuProvider } from './shared/menu/providers/withdrawn-reinstate-item.menu';
 import { WorkflowMenuProvider } from './shared/menu/providers/workflow.menu';
 
 /**
@@ -82,9 +81,6 @@ export const MENUS = buildMenuStructure({
       DSpaceObjectEditMenuProvider.onRoute(
         MenuRoute.COMMUNITY_PAGE,
         MenuRoute.COLLECTION_PAGE,
-        MenuRoute.ITEM_PAGE,
-      ),
-      WithdrawnReinstateItemMenuProvider.onRoute(
         MenuRoute.ITEM_PAGE,
       ),
       VersioningMenuProvider.onRoute(

--- a/src/app/app.menus.ts
+++ b/src/app/app.menus.ts
@@ -31,6 +31,7 @@ import { ProcessesMenuProvider } from './shared/menu/providers/processes.menu';
 import { RegistriesMenuProvider } from './shared/menu/providers/registries.menu';
 import { StatisticsMenuProvider } from './shared/menu/providers/statistics.menu';
 import { SystemWideAlertMenuProvider } from './shared/menu/providers/system-wide-alert.menu';
+import { WithdrawnReinstateItemMenuProvider } from './shared/menu/providers/withdrawn-reinstate-item.menu';
 import { WorkflowMenuProvider } from './shared/menu/providers/workflow.menu';
 
 /**
@@ -81,6 +82,9 @@ export const MENUS = buildMenuStructure({
       DSpaceObjectEditMenuProvider.onRoute(
         MenuRoute.COMMUNITY_PAGE,
         MenuRoute.COLLECTION_PAGE,
+        MenuRoute.ITEM_PAGE,
+      ),
+      WithdrawnReinstateItemMenuProvider.onRoute(
         MenuRoute.ITEM_PAGE,
       ),
       VersioningMenuProvider.onRoute(

--- a/src/app/contact-page/contact-page.component.spec.ts
+++ b/src/app/contact-page/contact-page.component.spec.ts
@@ -2,10 +2,12 @@ import {
   ComponentFixture,
   TestBed,
 } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { of } from 'rxjs';
 
 import { ConfigurationDataService } from '../core/data/configuration-data.service';
+import { ActivatedRouteStub } from '../shared/testing/active-router.stub';
 import { ContactPageComponent } from './contact-page.component';
 
 describe('ContactPageComponent', () => {
@@ -17,10 +19,13 @@ describe('ContactPageComponent', () => {
     mockConfigService = jasmine.createSpyObj(['findByPropertyName']);
 
     await TestBed.configureTestingModule({
-      declarations: [ ContactPageComponent ],
-      imports: [ TranslateModule.forRoot() ], // Add this line
+      imports: [
+        TranslateModule.forRoot(),
+        ContactPageComponent,
+      ],
       providers: [
         { provide: ConfigurationDataService, useValue: mockConfigService },
+        { provide: ActivatedRoute, useValue: new ActivatedRouteStub() },
       ],
     })
       .compileComponents();
@@ -42,7 +47,7 @@ describe('ContactPageComponent', () => {
   });
 
   it('should call findByPropertyName on init', () => {
-    expect(mockConfigService.findByPropertyName).toHaveBeenCalledWith('lr.help.mail');
+    expect(mockConfigService.findByPropertyName).toHaveBeenCalledWith('mail.helpdesk');
   });
 
   it('should set emailToContact from service on init', () => {

--- a/src/app/core/data/dspace-rest-response-parsing.service.ts
+++ b/src/app/core/data/dspace-rest-response-parsing.service.ts
@@ -159,7 +159,7 @@ export class DspaceRestResponseParsingService implements ResponseParsingService 
     const urlWithoutEmbedParams = getUrlWithoutEmbedParams(request.href);
     if (request.method === RestRequestMethod.GET && hasValue(response) && hasValue(response.payload) && hasValue(response.payload._links)) {
       if (hasNoValue(response.payload._links.self) || hasNoValue(response.payload._links.self.href)) {
-        if (!environment.production) {
+        if (environment.production) {
           console.warn(`The response for '${request.href}' doesn't have a self link. This could mean there's an issue with the REST endpoint`);
         }
         response.payload._links = Object.assign({}, response.payload._links, {
@@ -172,7 +172,7 @@ export class DspaceRestResponseParsingService implements ResponseParsingService 
         const expected = splitUrlInParts(urlWithoutEmbedParams);
         const actual = splitUrlInParts(response.payload._links.self.href);
         if (expected[0] === actual[0] && (expected.some((e) => !actual.includes(e)) || actual.some((e) => !expected.includes(e)))) {
-          if (!environment.production) {
+          if (environment.production) {
             console.warn(`The response for '${urlWithoutEmbedParams}' has the self link '${response.payload._links.self.href}'. These don't match. This could mean there's an issue with the REST endpoint`);
           }
           response.payload._links = Object.assign({}, response.payload._links, {

--- a/src/app/core/data/dspace-rest-response-parsing.service.ts
+++ b/src/app/core/data/dspace-rest-response-parsing.service.ts
@@ -159,7 +159,7 @@ export class DspaceRestResponseParsingService implements ResponseParsingService 
     const urlWithoutEmbedParams = getUrlWithoutEmbedParams(request.href);
     if (request.method === RestRequestMethod.GET && hasValue(response) && hasValue(response.payload) && hasValue(response.payload._links)) {
       if (hasNoValue(response.payload._links.self) || hasNoValue(response.payload._links.self.href)) {
-        if (environment.production) {
+        if (!environment.production) {
           console.warn(`The response for '${request.href}' doesn't have a self link. This could mean there's an issue with the REST endpoint`);
         }
         response.payload._links = Object.assign({}, response.payload._links, {
@@ -172,7 +172,7 @@ export class DspaceRestResponseParsingService implements ResponseParsingService 
         const expected = splitUrlInParts(urlWithoutEmbedParams);
         const actual = splitUrlInParts(response.payload._links.self.href);
         if (expected[0] === actual[0] && (expected.some((e) => !actual.includes(e)) || actual.some((e) => !expected.includes(e)))) {
-          if (environment.production) {
+          if (!environment.production) {
             console.warn(`The response for '${urlWithoutEmbedParams}' has the self link '${response.payload._links.self.href}'. These don't match. This could mean there's an issue with the REST endpoint`);
           }
           response.payload._links = Object.assign({}, response.payload._links, {

--- a/src/app/core/data/dspace-rest-response-parsing.service.ts
+++ b/src/app/core/data/dspace-rest-response-parsing.service.ts
@@ -159,7 +159,9 @@ export class DspaceRestResponseParsingService implements ResponseParsingService 
     const urlWithoutEmbedParams = getUrlWithoutEmbedParams(request.href);
     if (request.method === RestRequestMethod.GET && hasValue(response) && hasValue(response.payload) && hasValue(response.payload._links)) {
       if (hasNoValue(response.payload._links.self) || hasNoValue(response.payload._links.self.href)) {
-        console.warn(`The response for '${request.href}' doesn't have a self link. This could mean there's an issue with the REST endpoint`);
+        if (!environment.production) {
+          console.warn(`The response for '${request.href}' doesn't have a self link. This could mean there's an issue with the REST endpoint`);
+        }
         response.payload._links = Object.assign({}, response.payload._links, {
           self: {
             href: urlWithoutEmbedParams,
@@ -170,7 +172,9 @@ export class DspaceRestResponseParsingService implements ResponseParsingService 
         const expected = splitUrlInParts(urlWithoutEmbedParams);
         const actual = splitUrlInParts(response.payload._links.self.href);
         if (expected[0] === actual[0] && (expected.some((e) => !actual.includes(e)) || actual.some((e) => !expected.includes(e)))) {
-          console.warn(`The response for '${urlWithoutEmbedParams}' has the self link '${response.payload._links.self.href}'. These don't match. This could mean there's an issue with the REST endpoint`);
+          if (!environment.production) {
+            console.warn(`The response for '${urlWithoutEmbedParams}' has the self link '${response.payload._links.self.href}'. These don't match. This could mean there's an issue with the REST endpoint`);
+          }
           response.payload._links = Object.assign({}, response.payload._links, {
             self: {
               href: urlWithoutEmbedParams,

--- a/src/app/footer/footer.component.spec.ts
+++ b/src/app/footer/footer.component.spec.ts
@@ -13,7 +13,9 @@ import { of } from 'rxjs';
 import { APP_CONFIG } from '../../config/app-config.interface';
 import { environment } from '../../environments/environment.test';
 import { NotifyInfoService } from '../core/coar-notify/notify-info/notify-info.service';
+import { ConfigurationDataService } from '../core/data/configuration-data.service';
 import { AuthorizationDataService } from '../core/data/feature-authorization/authorization-data.service';
+import { createSuccessfulRemoteDataObject$ } from '../shared/remote-data.utils';
 import { ActivatedRouteStub } from '../shared/testing/active-router.stub';
 import { AuthorizationDataServiceStub } from '../shared/testing/authorization-service.stub';
 import { FooterComponent } from './footer.component';
@@ -25,16 +27,23 @@ let notifyInfoService = {
   isCoarConfigEnabled: () => of(true),
 };
 
+const mockConfigurationDataService = {
+  findByPropertyName: jasmine.createSpy('findByPropertyName').and.returnValue(
+    createSuccessfulRemoteDataObject$({ values: [] })
+  ),
+};
+
 describe('Footer component', () => {
   beforeEach(waitForAsync(() => {
     return TestBed.configureTestingModule({
       imports: [
         TranslateModule.forRoot(),
+        FooterComponent,
       ],
       providers: [
-        FooterComponent,
         { provide: AuthorizationDataService, useClass: AuthorizationDataServiceStub },
         { provide: NotifyInfoService, useValue: notifyInfoService },
+        { provide: ConfigurationDataService, useValue: mockConfigurationDataService },
         { provide: ActivatedRoute, useValue: new ActivatedRouteStub() },
         { provide: APP_CONFIG, useValue: environment },
       ],
@@ -47,10 +56,9 @@ describe('Footer component', () => {
     comp = fixture.componentInstance;
   });
 
-  it('should create footer', inject([FooterComponent], (app: FooterComponent) => {
-    // Perform test using fixture and service
-    expect(app).toBeTruthy();
-  }));
+  it('should create footer', () => {
+    expect(comp).toBeTruthy();
+  });
 
 
   it('should set showPrivacyPolicy to the value of environment.info.enablePrivacyStatement', () => {

--- a/src/app/footer/footer.component.spec.ts
+++ b/src/app/footer/footer.component.spec.ts
@@ -1,7 +1,6 @@
 import {
   ComponentFixture,
   fakeAsync,
-  inject,
   TestBed,
   waitForAsync,
 } from '@angular/core/testing';
@@ -29,7 +28,7 @@ let notifyInfoService = {
 
 const mockConfigurationDataService = {
   findByPropertyName: jasmine.createSpy('findByPropertyName').and.returnValue(
-    createSuccessfulRemoteDataObject$({ values: [] })
+    createSuccessfulRemoteDataObject$({ values: [] }),
   ),
 };
 

--- a/src/app/item-page/full/full-item-page.component.html
+++ b/src/app/item-page/full/full-item-page.component.html
@@ -3,7 +3,6 @@
     <div class="item-page" @fadeInOut>
       @if (itemRD?.payload; as item) {
         <div>
-          <ds-item-alerts [item]="item"></ds-item-alerts>
           <ds-item-versions-notice [item]="item"></ds-item-versions-notice>
           @if (!item.isWithdrawn || (isAdmin$|async)) {
             <div class="full-item-info">

--- a/src/app/item-page/full/full-item-page.component.spec.ts
+++ b/src/app/item-page/full/full-item-page.component.spec.ts
@@ -45,7 +45,6 @@ import { createPaginatedList } from '../../shared/testing/utils.test';
 import { ThemeService } from '../../shared/theme-support/theme.service';
 import { TruncatePipe } from '../../shared/utils/truncate.pipe';
 import { VarDirective } from '../../shared/utils/var.directive';
-import { ThemedItemAlertsComponent } from '../alerts/themed-item-alerts.component';
 import { CollectionsComponent } from '../field-components/collections/collections.component';
 import { ThemedItemPageTitleFieldComponent } from '../simple/field-components/specific-field/title/themed-item-page-field.component';
 import { createRelationshipsObservable } from '../simple/item-types/shared/item.component.spec';
@@ -161,7 +160,6 @@ describe('FullItemPageComponent', () => {
             ThemedLoadingComponent,
             ThemedItemPageTitleFieldComponent,
             DsoEditMenuComponent,
-            ThemedItemAlertsComponent,
             CollectionsComponent,
             ThemedFullFileSectionComponent,
           ],

--- a/src/app/item-page/full/full-item-page.component.ts
+++ b/src/app/item-page/full/full-item-page.component.ts
@@ -42,7 +42,6 @@ import { hasValue } from '../../shared/empty.util';
 import { ErrorComponent } from '../../shared/error/error.component';
 import { ThemedLoadingComponent } from '../../shared/loading/themed-loading.component';
 import { VarDirective } from '../../shared/utils/var.directive';
-import { ThemedItemAlertsComponent } from '../alerts/themed-item-alerts.component';
 import { CollectionsComponent } from '../field-components/collections/collections.component';
 import { ThemedItemPageTitleFieldComponent } from '../simple/field-components/specific-field/title/themed-item-page-field.component';
 import { ItemPageComponent } from '../simple/item-page.component';
@@ -71,7 +70,6 @@ import { ThemedFullFileSectionComponent } from './field-components/file-section/
     KeyValuePipe,
     RouterLink,
     ThemedFullFileSectionComponent,
-    ThemedItemAlertsComponent,
     ThemedItemPageTitleFieldComponent,
     ThemedLoadingComponent,
     TranslateModule,

--- a/src/app/item-page/simple/field-components/specific-field/citation/item-page-citation.component.spec.ts
+++ b/src/app/item-page/simple/field-components/specific-field/citation/item-page-citation.component.spec.ts
@@ -57,7 +57,8 @@ describe('ItemPageCitationFieldComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should set iframeSrc based on handle', () => {
-    expect(component.iframeSrc).not.toBeNull();
+  it('should initialize citaceProURL$ and citaceProStatus$', () => {
+    expect(component.citaceProURL$).toBeDefined();
+    expect(component.citaceProStatus$).toBeDefined();
   });
 });

--- a/src/app/item-page/simple/item-page.component.html
+++ b/src/app/item-page/simple/item-page.component.html
@@ -4,10 +4,7 @@
       @if (itemRD?.payload; as item) {
         <div>
 
-          <ds-item-alerts [item]="item"></ds-item-alerts>
           <ds-access-by-token-notification></ds-access-by-token-notification>
-          <ds-qa-event-notification [item]="item"></ds-qa-event-notification>
-          <ds-notify-requests-status [itemUuid]="item.uuid"></ds-notify-requests-status>
           <ds-item-versions-notice [item]="item"></ds-item-versions-notice>
           @if (!item.isWithdrawn || (isAdmin$|async)) {
             <ds-listable-object-component-loader [object]="item" [viewMode]="viewMode"></ds-listable-object-component-loader>

--- a/src/app/item-page/simple/item-page.component.spec.ts
+++ b/src/app/item-page/simple/item-page.component.spec.ts
@@ -44,13 +44,10 @@ import {
 import { ActivatedRouteStub } from '../../shared/testing/active-router.stub';
 import { createPaginatedList } from '../../shared/testing/utils.test';
 import { VarDirective } from '../../shared/utils/var.directive';
-import { ThemedItemAlertsComponent } from '../alerts/themed-item-alerts.component';
 import { ItemVersionsComponent } from '../versions/item-versions.component';
 import { ItemVersionsNoticeComponent } from '../versions/notice/item-versions-notice.component';
 import { ItemPageComponent } from './item-page.component';
 import { createRelationshipsObservable } from './item-types/shared/item.component.spec';
-import { NotifyRequestsStatusComponent } from './notify-requests-status/notify-requests-status-component/notify-requests-status.component';
-import { QaEventNotificationComponent } from './qa-event-notification/qa-event-notification.component';
 
 const mockItem: Item = Object.assign(new Item(), {
   bundles: createSuccessfulRemoteDataObject$(createPaginatedList([])),
@@ -139,14 +136,11 @@ describe('ItemPageComponent', () => {
     }).overrideComponent(ItemPageComponent, {
       add: { changeDetection: ChangeDetectionStrategy.Default },
       remove: { imports: [
-        ThemedItemAlertsComponent,
         ItemVersionsNoticeComponent,
         ListableObjectComponentLoaderComponent,
         ItemVersionsComponent,
         ErrorComponent,
         ThemedLoadingComponent,
-        NotifyRequestsStatusComponent,
-        QaEventNotificationComponent,
       ] },
     }).compileComponents();
   }));

--- a/src/app/item-page/simple/item-page.component.ts
+++ b/src/app/item-page/simple/item-page.component.ts
@@ -51,13 +51,10 @@ import { ErrorComponent } from '../../shared/error/error.component';
 import { ThemedLoadingComponent } from '../../shared/loading/themed-loading.component';
 import { ListableObjectComponentLoaderComponent } from '../../shared/object-collection/shared/listable-object/listable-object-component-loader.component';
 import { VarDirective } from '../../shared/utils/var.directive';
-import { ThemedItemAlertsComponent } from '../alerts/themed-item-alerts.component';
 import { getItemPageRoute } from '../item-page-routing-paths';
 import { ItemVersionsComponent } from '../versions/item-versions.component';
 import { ItemVersionsNoticeComponent } from '../versions/notice/item-versions-notice.component';
 import { AccessByTokenNotificationComponent } from './access-by-token-notification/access-by-token-notification.component';
-import { NotifyRequestsStatusComponent } from './notify-requests-status/notify-requests-status-component/notify-requests-status.component';
-import { QaEventNotificationComponent } from './qa-event-notification/qa-event-notification.component';
 
 /**
  * This component renders a simple item page.
@@ -78,9 +75,6 @@ import { QaEventNotificationComponent } from './qa-event-notification/qa-event-n
     ItemVersionsComponent,
     ItemVersionsNoticeComponent,
     ListableObjectComponentLoaderComponent,
-    NotifyRequestsStatusComponent,
-    QaEventNotificationComponent,
-    ThemedItemAlertsComponent,
     ThemedLoadingComponent,
     TranslateModule,
     VarDirective,

--- a/src/app/item-page/simple/item-types/publication/publication.component.spec.ts
+++ b/src/app/item-page/simple/item-types/publication/publication.component.spec.ts
@@ -32,6 +32,7 @@ import { RemoteDataBuildService } from '../../../../core/cache/builders/remote-d
 import { ObjectCacheService } from '../../../../core/cache/object-cache.service';
 import { BitstreamDataService } from '../../../../core/data/bitstream-data.service';
 import { CommunityDataService } from '../../../../core/data/community-data.service';
+import { ConfigurationDataService } from '../../../../core/data/configuration-data.service';
 import { DefaultChangeAnalyzer } from '../../../../core/data/default-change-analyzer.service';
 import { DSOChangeAnalyzer } from '../../../../core/data/dso-change-analyzer.service';
 import { ItemDataService } from '../../../../core/data/item-data.service';
@@ -88,16 +89,23 @@ function getItem(metadata: MetadataMap) {
   });
 }
 
+const mockBitstreamDataService = {
+  getThumbnailFor(item: Item): Observable<RemoteData<Bitstream>> {
+    return createSuccessfulRemoteDataObject$(new Bitstream());
+  },
+};
+
+const mockConfigurationDataService = {
+  findByPropertyName: jasmine.createSpy('findByPropertyName').and.returnValue(
+    createSuccessfulRemoteDataObject$({ values: [] })
+  ),
+};
+
 describe('PublicationComponent', () => {
   let comp: PublicationComponent;
   let fixture: ComponentFixture<PublicationComponent>;
 
   beforeEach(waitForAsync(() => {
-    const mockBitstreamDataService = {
-      getThumbnailFor(item: Item): Observable<RemoteData<Bitstream>> {
-        return createSuccessfulRemoteDataObject$(new Bitstream());
-      },
-    };
     TestBed.configureTestingModule({
       imports: [
         TranslateModule.forRoot({
@@ -127,6 +135,7 @@ describe('PublicationComponent', () => {
         { provide: VersionHistoryDataService, useValue: {} },
         { provide: VersionDataService, useValue: {} },
         { provide: BitstreamDataService, useValue: mockBitstreamDataService },
+        { provide: ConfigurationDataService, useValue: mockConfigurationDataService },
         { provide: WorkspaceitemDataService, useValue: {} },
         { provide: SearchService, useValue: {} },
         { provide: RouteService, useValue: mockRouteService },

--- a/src/app/item-page/simple/item-types/publication/publication.component.spec.ts
+++ b/src/app/item-page/simple/item-types/publication/publication.component.spec.ts
@@ -97,7 +97,7 @@ const mockBitstreamDataService = {
 
 const mockConfigurationDataService = {
   findByPropertyName: jasmine.createSpy('findByPropertyName').and.returnValue(
-    createSuccessfulRemoteDataObject$({ values: [] })
+    createSuccessfulRemoteDataObject$({ values: [] }),
   ),
 };
 

--- a/src/app/shared/menu/providers/withdrawn-reinstate-item.menu.ts
+++ b/src/app/shared/menu/providers/withdrawn-reinstate-item.menu.ts
@@ -7,11 +7,16 @@
  */
 import { Injectable } from '@angular/core';
 import {
-  combineLatest,
   Observable,
+  of,
 } from 'rxjs';
-import { map } from 'rxjs/operators';
+import {
+  map,
+  switchMap,
+} from 'rxjs/operators';
 
+import { AuthorizationDataService } from '../../../core/data/feature-authorization/authorization-data.service';
+import { FeatureID } from '../../../core/data/feature-authorization/feature-id';
 import { Item } from '../../../core/shared/item.model';
 import {
   getFirstCompletedRemoteData,
@@ -34,6 +39,7 @@ import { DSpaceObjectPageMenuProvider } from './helper-providers/dso.menu';
 @Injectable()
 export class WithdrawnReinstateItemMenuProvider extends DSpaceObjectPageMenuProvider {
   constructor(
+    protected authorizationDataService: AuthorizationDataService,
     protected dsoWithdrawnReinstateModalService: DsoWithdrawnReinstateModalService,
     protected correctionTypeDataService: CorrectionTypeDataService,
   ) {
@@ -41,36 +47,46 @@ export class WithdrawnReinstateItemMenuProvider extends DSpaceObjectPageMenuProv
   }
 
   public getSectionsForContext(item: Item): Observable<PartialMenuSection[]> {
-    return combineLatest([
-      this.correctionTypeDataService.findByItem(item.uuid, true).pipe(
-        getFirstCompletedRemoteData(),
-        getRemoteDataPayload()),
-    ]).pipe(
-      map(([correction]) => {
-        return [
-          {
-            visible: item.isArchived && correction?.page.some((c) => c.topic === REQUEST_WITHDRAWN),
-            model: {
-              type: MenuItemType.ONCLICK,
-              text: 'item.page.withdrawn',
-              function: () => {
-                this.dsoWithdrawnReinstateModalService.openCreateWithdrawnReinstateModal(item, 'request-withdrawn', item.isArchived);
+    return this.authorizationDataService.isAuthorized(FeatureID.AdministratorOf).pipe(
+      switchMap((isAuthorized) => {
+        if (!isAuthorized) {
+          // Return empty/invisible sections without calling the API
+          return of([
+            { visible: false },
+            { visible: false },
+          ] as PartialMenuSection[]);
+        }
+
+        return this.correctionTypeDataService.findByItem(item.uuid, true).pipe(
+          getFirstCompletedRemoteData(),
+          getRemoteDataPayload(),
+          map((correction) => {
+            return [
+              {
+                visible: item.isArchived && correction?.page.some((c) => c.topic === REQUEST_WITHDRAWN),
+                model: {
+                  type: MenuItemType.ONCLICK,
+                  text: 'item.page.withdrawn',
+                  function: () => {
+                    this.dsoWithdrawnReinstateModalService.openCreateWithdrawnReinstateModal(item, 'request-withdrawn', item.isArchived);
+                  },
+                } as OnClickMenuItemModel,
+                icon: 'eye-slash',
               },
-            } as OnClickMenuItemModel,
-            icon: 'eye-slash',
-          },
-          {
-            visible: item.isWithdrawn && correction?.page.some((c) => c.topic === REQUEST_REINSTATE),
-            model: {
-              type: MenuItemType.ONCLICK,
-              text: 'item.page.reinstate',
-              function: () => {
-                this.dsoWithdrawnReinstateModalService.openCreateWithdrawnReinstateModal(item, 'request-reinstate', item.isArchived);
+              {
+                visible: item.isWithdrawn && correction?.page.some((c) => c.topic === REQUEST_REINSTATE),
+                model: {
+                  type: MenuItemType.ONCLICK,
+                  text: 'item.page.reinstate',
+                  function: () => {
+                    this.dsoWithdrawnReinstateModalService.openCreateWithdrawnReinstateModal(item, 'request-reinstate', item.isArchived);
+                  },
+                } as OnClickMenuItemModel,
+                icon: 'eye',
               },
-            } as OnClickMenuItemModel,
-            icon: 'eye',
-          },
-        ] as PartialMenuSection[];
+            ] as PartialMenuSection[];
+          }),
+        );
       }),
     );
   }

--- a/src/modules/app/browser-init.service.ts
+++ b/src/modules/app/browser-init.service.ts
@@ -124,7 +124,10 @@ export class BrowserInitService extends InitService {
       this.initCorrelationId();
 
       this.checkEnvironment();
-      logStartupMessage(environment);
+
+      if (!environment.production) {
+        logStartupMessage(environment);
+      }
 
       this.initI18n();
       this.initAngulartics();

--- a/src/themes/custom/app/footer/footer.component.html
+++ b/src/themes/custom/app/footer/footer.component.html
@@ -69,7 +69,6 @@
           <p class="m-0">
             <a class="btn text-white"
                href="http://www.dspace.org/" role="link" tabindex="0">{{ 'footer.link.dspace' | translate}}</a>
-            {{ 'footer.copyright' | translate:{year: dateObj | date:'y'} }}
             <a class="btn text-white"
                href="https://www.lyrasis.org/" role="link" tabindex="0">{{ 'footer.link.lyrasis' | translate}}</a>
           </p>

--- a/src/themes/custom/app/footer/footer.component.ts
+++ b/src/themes/custom/app/footer/footer.component.ts
@@ -1,7 +1,4 @@
-import {
-  AsyncPipe,
-  DatePipe,
-} from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
@@ -18,7 +15,6 @@ import { VarDirective } from '../../../../app/shared/utils/var.directive';
   standalone: true,
   imports: [
     AsyncPipe,
-    DatePipe,
     RouterLink,
     TranslateModule,
     VarDirective,

--- a/src/themes/custom/app/item-page/full/full-item-page.component.ts
+++ b/src/themes/custom/app/item-page/full/full-item-page.component.ts
@@ -9,7 +9,6 @@ import {
 import { RouterLink } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 
-import { ThemedItemAlertsComponent } from '../../../../../app/item-page/alerts/themed-item-alerts.component';
 import { CollectionsComponent } from '../../../../../app/item-page/field-components/collections/collections.component';
 import { ThemedFullFileSectionComponent } from '../../../../../app/item-page/full/field-components/file-section/themed-full-file-section.component';
 import { FullItemPageComponent as BaseComponent } from '../../../../../app/item-page/full/full-item-page.component';
@@ -41,7 +40,6 @@ import { VarDirective } from '../../../../../app/shared/utils/var.directive';
     KeyValuePipe,
     RouterLink,
     ThemedFullFileSectionComponent,
-    ThemedItemAlertsComponent,
     ThemedItemPageTitleFieldComponent,
     ThemedLoadingComponent,
     TranslateModule,

--- a/src/themes/custom/app/item-page/simple/item-page.component.ts
+++ b/src/themes/custom/app/item-page/simple/item-page.component.ts
@@ -5,11 +5,8 @@ import {
 } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 
-import { ThemedItemAlertsComponent } from '../../../../../app/item-page/alerts/themed-item-alerts.component';
 import { AccessByTokenNotificationComponent } from '../../../../../app/item-page/simple/access-by-token-notification/access-by-token-notification.component';
 import { ItemPageComponent as BaseComponent } from '../../../../../app/item-page/simple/item-page.component';
-import { NotifyRequestsStatusComponent } from '../../../../../app/item-page/simple/notify-requests-status/notify-requests-status-component/notify-requests-status.component';
-import { QaEventNotificationComponent } from '../../../../../app/item-page/simple/qa-event-notification/qa-event-notification.component';
 import { ItemVersionsComponent } from '../../../../../app/item-page/versions/item-versions.component';
 import { ItemVersionsNoticeComponent } from '../../../../../app/item-page/versions/notice/item-versions-notice.component';
 import { fadeInOut } from '../../../../../app/shared/animations/fade';
@@ -34,9 +31,6 @@ import { VarDirective } from '../../../../../app/shared/utils/var.directive';
     ItemVersionsComponent,
     ItemVersionsNoticeComponent,
     ListableObjectComponentLoaderComponent,
-    NotifyRequestsStatusComponent,
-    QaEventNotificationComponent,
-    ThemedItemAlertsComponent,
     ThemedLoadingComponent,
     TranslateModule,
     VarDirective,

--- a/src/themes/custom/lazy-theme.module.ts
+++ b/src/themes/custom/lazy-theme.module.ts
@@ -42,7 +42,6 @@ import { EndUserAgreementComponent } from './app/info/end-user-agreement/end-use
 import { FeedbackComponent } from './app/info/feedback/feedback.component';
 import { FeedbackFormComponent } from './app/info/feedback/feedback-form/feedback-form.component';
 import { PrivacyComponent } from './app/info/privacy/privacy.component';
-import { ItemAlertsComponent } from './app/item-page/alerts/item-alerts.component';
 import { ItemStatusComponent } from './app/item-page/edit-item-page/item-status/item-status.component';
 import { FullFileSectionComponent } from './app/item-page/full/field-components/file-section/full-file-section.component';
 import { FullItemPageComponent } from './app/item-page/full/full-item-page.component';
@@ -176,7 +175,6 @@ const DECLARATIONS = [
   AccessStatusBadgeComponent,
   ResultsBackButtonComponent,
   DsoEditMetadataComponent,
-  ItemAlertsComponent,
   FullFileSectionComponent,
   MetadataRepresentationListComponent,
   DsDynamicLookupRelationSearchTabComponent,


### PR DESCRIPTION
## Problem description
- Remove / Hide copyright info from footer as wished
- Hide startup message in browser console for production environments
- Remove unused admin components and menu providers causing 401 errors for anonymous item page viewers
- Hide REST self-link mismatch warnings in production by wrapping console.warn calls with environment.production checks in DspaceRestResponseParsingService

### FE unit (spec) tests fixes
- Fix ItemPageCitationFieldComponent test by replacing non-existent iframeSrc property check with correct citaceProURL$ and citaceProStatus$ properties
- Fix PublicationComponent tests by adding ConfigurationDataService mock required by ItemPageCitationFieldComponent to prevent HALEndpointService errors
- Fix FooterComponent tests by adding ConfigurationDataService mock and moving FooterComponent from providers to imports as standalone component to resolve Store NullInjectorError
- Fix ContactPageComponent tests by moving standalone component to imports, adding ActivatedRoute mock, and correcting property name from 'lr.help.mail' to 'mail.helpdesk'

### Copilot review
- [x] Requested review from Copilot