### PR TITLE
MENDELU/Fix errors after details fix

### DIFF
--- a/src/app/shared/menu/providers/withdrawn-reinstate-item.menu.spec.ts
+++ b/src/app/shared/menu/providers/withdrawn-reinstate-item.menu.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { Item } from '../../../core/shared/item.model';
@@ -76,6 +77,7 @@ describe('WithdrawnReinstateItemMenuProvider', () => {
         WithdrawnReinstateItemMenuProvider,
         { provide: CorrectionTypeDataService, useValue: correctionTypeDataService },
         { provide: DsoWithdrawnReinstateModalService, useValue: dsoWithdrawnReinstateModalService },
+        provideMockStore(),
       ],
     });
     provider = TestBed.inject(WithdrawnReinstateItemMenuProvider);

--- a/src/app/shared/menu/providers/withdrawn-reinstate-item.menu.spec.ts
+++ b/src/app/shared/menu/providers/withdrawn-reinstate-item.menu.spec.ts
@@ -1,7 +1,8 @@
 import { TestBed } from '@angular/core/testing';
-import { provideMockStore } from '@ngrx/store/testing';
 import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
 
+import { AuthorizationDataService } from '../../../core/data/feature-authorization/authorization-data.service';
 import { Item } from '../../../core/shared/item.model';
 import { ITEM } from '../../../core/shared/item.resource-type';
 import { CorrectionTypeDataService } from '../../../core/submission/correctiontype-data.service';
@@ -57,6 +58,7 @@ describe('WithdrawnReinstateItemMenuProvider', () => {
 
   let correctionTypeDataService;
   let dsoWithdrawnReinstateModalService;
+  let authorizationService;
 
   beforeEach(() => {
     const correctionType = Object.assign(new CorrectionType(), {
@@ -70,6 +72,9 @@ describe('WithdrawnReinstateItemMenuProvider', () => {
 
     dsoWithdrawnReinstateModalService = jasmine.createSpyObj('dsoWithdrawnReinstateModalService', ['openCreateWithdrawnReinstateModal']);
 
+    authorizationService = jasmine.createSpyObj('authorizationService', {
+      'isAuthorized': of(true),
+    });
 
     TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot()],
@@ -77,7 +82,7 @@ describe('WithdrawnReinstateItemMenuProvider', () => {
         WithdrawnReinstateItemMenuProvider,
         { provide: CorrectionTypeDataService, useValue: correctionTypeDataService },
         { provide: DsoWithdrawnReinstateModalService, useValue: dsoWithdrawnReinstateModalService },
-        provideMockStore(),
+        { provide: AuthorizationDataService, useValue: authorizationService },
       ],
     });
     provider = TestBed.inject(WithdrawnReinstateItemMenuProvider);

--- a/src/app/shared/menu/providers/withdrawn-reinstate-item.menu.spec.ts
+++ b/src/app/shared/menu/providers/withdrawn-reinstate-item.menu.spec.ts
@@ -12,6 +12,7 @@ import {
   REQUEST_WITHDRAWN,
 } from '../../dso-page/dso-withdrawn-reinstate-service/dso-withdrawn-reinstate-modal.service';
 import { createSuccessfulRemoteDataObject$ } from '../../remote-data.utils';
+import { AuthorizationDataServiceStub } from '../../testing/authorization-service.stub';
 import { createPaginatedList } from '../../testing/utils.test';
 import { OnClickMenuItemModel } from '../menu-item/models/onclick.model';
 import { MenuItemType } from '../menu-item-type.model';
@@ -58,7 +59,7 @@ describe('WithdrawnReinstateItemMenuProvider', () => {
 
   let correctionTypeDataService;
   let dsoWithdrawnReinstateModalService;
-  let authorizationService;
+  let authorizationServiceStub: AuthorizationDataServiceStub;
 
   beforeEach(() => {
     const correctionType = Object.assign(new CorrectionType(), {
@@ -72,9 +73,8 @@ describe('WithdrawnReinstateItemMenuProvider', () => {
 
     dsoWithdrawnReinstateModalService = jasmine.createSpyObj('dsoWithdrawnReinstateModalService', ['openCreateWithdrawnReinstateModal']);
 
-    authorizationService = jasmine.createSpyObj('authorizationService', {
-      'isAuthorized': of(true),
-    });
+    authorizationServiceStub = new AuthorizationDataServiceStub();
+    spyOn(authorizationServiceStub, 'isAuthorized').and.returnValue(of(true));
 
     TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot()],
@@ -82,7 +82,7 @@ describe('WithdrawnReinstateItemMenuProvider', () => {
         WithdrawnReinstateItemMenuProvider,
         { provide: CorrectionTypeDataService, useValue: correctionTypeDataService },
         { provide: DsoWithdrawnReinstateModalService, useValue: dsoWithdrawnReinstateModalService },
-        { provide: AuthorizationDataService, useValue: authorizationService },
+        { provide: AuthorizationDataService, useValue: authorizationServiceStub },
       ],
     });
     provider = TestBed.inject(WithdrawnReinstateItemMenuProvider);


### PR DESCRIPTION
## Problem description
Unit test fixes withdrawn reinstate menu item.
- fix: resolve NullInjectorError in WithdrawnReinstateItemMenuProvider test by adding provideMockStore
- fix: use AuthorizationDataServiceStub in WithdrawnReinstateItemMenuProvider test to resolve dependency injection errors

### Copilot review
- [x] Requested review from Copilot