### PR TITLE
SAV/Incorrect CI image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       # Direct that step to utilize a DSpace REST service that has been started in docker.
       # Spin up UI on 127.0.0.1 to avoid host resolution issues in e2e tests with Node 18+
       INSTANCE: '2'
-      DSPACE_CI_IMAGE: 'dataquest/dspace:dspace-7_x-test'
+      DSPACE_CI_IMAGE: 'dataquest/dspace:customer-sav-test'
       DSPACE_SOLR_IMAGE: dataquest/dspace-solr:dspace-7_x
       DSPACE_REST_HOST: 127.0.0.1
       DSPACE_REST_PORT: 8080

--- a/cypress/e2e/submission-ui.cy.ts
+++ b/cypress/e2e/submission-ui.cy.ts
@@ -116,33 +116,6 @@ describe('Create a new submission', () => {
     createItemProcess.clickOnTypeSelection('Corpus');
   });
 
-  // Test CMDI input field
-  it('should be visible Has CMDI file input field because user is admin', {
-    retries: {
-      runMode: 6,
-      openMode: 6,
-    },
-    defaultCommandTimeout: 10000
-  },() => {
-    createItemProcess.checkLocalHasCMDIVisibility();
-  });
-
-  it('The local.hasCMDI value should be sent in the response after type change', {
-    retries: {
-      runMode: 6,
-      openMode: 6,
-    },
-    defaultCommandTimeout: 10000
-  },() => {
-    createItemProcess.clickOnSelectionInput('dc.type');
-    createItemProcess.clickOnTypeSelection('Corpus');
-    createItemProcess.checkCheckbox('local_hasCMDI');
-    createItemProcess.controlCheckedCheckbox('local_hasCMDI',true);
-    createItemProcess.clickOnSave();
-    cy.reload();
-    createItemProcess.controlCheckedCheckbox('local_hasCMDI',true);
-  });
-
   it('should change the step status after accepting/declining the distribution license', {
     retries: {
       runMode: 6,


### PR DESCRIPTION
## Problem description
The CI image in build is not customers but dtq-dev.

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot