### PR TITLE
Lindat/Fix incorrect translation of "withdraw"

### DIFF
--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -3663,10 +3663,10 @@
   "item.edit.tabs.status.buttons.unauthorized": "Nejste oprávněni provést tuto akci",
 
   // "item.edit.tabs.status.buttons.withdraw.button": "Withdraw this item",
-  "item.edit.tabs.status.buttons.withdraw.button": "Odstranit...",
+  "item.edit.tabs.status.buttons.withdraw.button": "Stáhnout...",
 
   // "item.edit.tabs.status.buttons.withdraw.label": "Withdraw item from the repository",
-  "item.edit.tabs.status.buttons.withdraw.label": "Odstranit záznam z repozitáře",
+  "item.edit.tabs.status.buttons.withdraw.label": "Stáhnout záznam z repozitáře",
 
   // "item.edit.tabs.status.description": "Welcome to the item management page. From here you can withdraw, reinstate, move or delete the item. You may also update or add new metadata / bitstreams on the other tabs.",
   "item.edit.tabs.status.description": "Vítejte na stránce pro správu záznamů. Odtud můžete záznam stáhnout, obnovit, přesunout nebo odstranit. Na ostatních záložkách můžete také aktualizovat nebo přidávat nová metadata / bitové toky.",
@@ -3711,16 +3711,16 @@
   "item.edit.withdraw.confirm": "Potvrdit",
 
   // "item.edit.withdraw.description": "Are you sure this item should be withdrawn from the archive?",
-  "item.edit.withdraw.description": "Jste si jisti, že by tento záznam měl být odebrán z archivu?",
+  "item.edit.withdraw.description": "Jste si jisti, že by tento záznam měl být stažen z archivu?",
 
   // "item.edit.withdraw.error": "An error occurred while withdrawing the item",
-  "item.edit.withdraw.error": "Při odebírání záznamu došlo k chybě",
+  "item.edit.withdraw.error": "Při stahování záznamu došlo k chybě",
 
   // "item.edit.withdraw.header": "Withdraw item: {{ id }}",
-  "item.edit.withdraw.header": "Odebrat záznam: {{ id }}",
+  "item.edit.withdraw.header": "Stáhnout záznam: {{ id }}",
 
   // "item.edit.withdraw.success": "The item was withdrawn successfully",
-  "item.edit.withdraw.success": "Záznam byl úspěšně odebrán",
+  "item.edit.withdraw.success": "Záznam byl úspěšně stažen",
 
   // "item.orcid.return": "Back",
   "item.orcid.return": "Zpět",


### PR DESCRIPTION
## Problem description
https://github.com/dataquest-dev/dspace-angular/pull/1191

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot