### PR TITLE
UFAL/Display all versions in version history

### DIFF
--- a/src/app/item-page/simple/field-components/clarin-item-versions-field/clarin-item-versions-field.component.ts
+++ b/src/app/item-page/simple/field-components/clarin-item-versions-field/clarin-item-versions-field.component.ts
@@ -41,6 +41,11 @@ interface EnhancedVersionDTO extends VersionDTO {
 export class ClarinItemVersionsFieldComponent extends ItemVersionsComponent implements OnInit {
 
   /**
+   * Maximum number of versions to fetch at once for the dropdown display.
+   */
+  private readonly MAX_VERSIONS_TO_DISPLAY = 9999;
+
+  /**
    * Icon name for the clarin field
    */
   @Input() iconName?: string;
@@ -63,7 +68,7 @@ export class ClarinItemVersionsFieldComponent extends ItemVersionsComponent impl
 
   ngOnInit(): void {
     // Override the parent's pageSize to fetch all versions at once for the dropdown display
-    this.pageSize = 9999;
+    this.pageSize = this.MAX_VERSIONS_TO_DISPLAY;
     this.options = Object.assign(this.options, {
       pageSize: this.pageSize
     });

--- a/src/app/item-page/simple/field-components/clarin-item-versions-field/clarin-item-versions-field.component.ts
+++ b/src/app/item-page/simple/field-components/clarin-item-versions-field/clarin-item-versions-field.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Observable, of, combineLatest } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
+import { map, switchMap, shareReplay } from 'rxjs/operators';
 import { ItemVersionsComponent } from '../../../versions/item-versions.component';
 import { Item } from '../../../../core/shared/item.model';
 import { Version } from '../../../../core/shared/version.model';
@@ -62,7 +62,12 @@ export class ClarinItemVersionsFieldComponent extends ItemVersionsComponent impl
   enhancedVersions$: Observable<EnhancedVersionDTO[]>;
 
   ngOnInit(): void {
-    // Call parent's ngOnInit first to set up all the observables
+    // Override the parent's pageSize to fetch all versions at once for the dropdown display
+    this.pageSize = 9999;
+    this.options = Object.assign(this.options, {
+      pageSize: this.pageSize
+    });
+
     super.ngOnInit();
 
     // Set up clarin-specific showMetadataValue logic
@@ -98,7 +103,8 @@ export class ClarinItemVersionsFieldComponent extends ItemVersionsComponent impl
               isCurrentVersion: versionDTO.version.id === currentVersionId
             } as EnhancedVersionDTO;
           });
-        })
+        }),
+        shareReplay(1) // Cache the result to prevent duplicate requests
       );
     } else {
       // Fallback: check if isAdmin$ is available, otherwise hide the component


### PR DESCRIPTION
## Problem description
https://github.com/dataquest-dev/dspace-customers/issues/408
In version history are displayed only 10 versions of item.

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [x] Requested review from Copilot