### PR TITLE
UFAL/Fix: generate correct curl download URLs using backend handle endpoint

### DIFF
--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.html
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.html
@@ -12,7 +12,7 @@
 
     <ng-template #commandModal let-modal>
       <div class="modal-header">
-        <h5 class="modal-title">{{'item.page.download.button.command.line' | translate}}</h5>
+        <h5 class="modal-title" id="commandModalTitle">{{'item.page.download.button.command.line' | translate}}</h5>
         <button type="button" class="close" aria-label="Close" (click)="modal.dismiss()">
           <span aria-hidden="true">&times;</span>
         </button>

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.html
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.html
@@ -3,15 +3,33 @@
   <h6><i class="fa fa-paperclip">&nbsp;</i>{{'item.page.files.head' | translate}}</h6>
   <div class="pb-3">
     <span class="pr-1">
-      <a class="btn btn-download" (click)="setCommandline()" style="text-decoration: none"
+      <a class="btn btn-download" (click)="openCommandModal(commandModal)" style="text-decoration: none"
          *ngIf="canShowCurlDownload">
         <i class="fa fa-download fa-3x" style="display: block">&nbsp;</i>
         {{'item.page.download.button.command.line' | translate}}
       </a>
     </span>
-    <div id="command-div" *ngIf="isCommandLineVisible">
-        <pre class="command-pre">{{ command }}</pre>
-    </div>
+
+    <ng-template #commandModal let-modal>
+      <div class="modal-header">
+        <h5 class="modal-title">{{'item.page.download.button.command.line' | translate}}</h5>
+        <button type="button" class="close" aria-label="Close" (click)="modal.dismiss()">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <pre class="command-pre mb-0">{{ command }}</pre>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-outline-secondary" (click)="copyCommand()">
+          <i class="fa" [ngClass]="commandCopied ? 'fa-check' : 'fa-clipboard'"></i>
+          {{ commandCopied ? ('item.page.download.command.copied' | translate) : ('item.page.download.command.copy' | translate) }}
+        </button>
+        <button class="btn btn-secondary" (click)="modal.close()">
+          {{'item.page.download.command.close' | translate}}
+        </button>
+      </div>
+    </ng-template>
     <span>
       <a *ngIf="
       (totalFileSizes | async) > (downloadZipMinFileSize | async) &&

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.scss
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.scss
@@ -17,44 +17,17 @@ The styling file for the `clarin-files-section.component`
 
 .command-pre {
   display: block;
-  padding: 9.5px;
-  margin: 0 0 10px;
+  padding: 12px 16px;
+  margin: 0;
   font-size: 13px;
-  line-height: 1.428571429;
+  line-height: 1.5;
+  white-space: pre-wrap;
   word-break: break-all;
   word-wrap: break-word;
   background-color: #d9edf7;
   color: #3a87ad;
   border: 1px solid #ccc;
   border-radius: 4px;
-}
-
-#command-div .repo-copy-btn {
-  opacity: 0;
-  -webkit-transition: opacity 0.3s ease-in-out;
-  -o-transition: opacity 0.3s ease-in-out;
-  transition: opacity 0.3s ease-in-out;
-}
-
-#command-div:hover .repo-copy-btn, #command-div .repo-copy-btn:focus {
-  opacity: 1;
-}
-
-.repo-copy-btn {
-  width: 20px;
-  height: 20px;
-  position: relative;
-  display: inline-block;
-  padding: 0 !important;
-}
-
-.repo-copy-btn:before {
-  content: " ";
-  background-size: 13px 15px;
-  background-repeat: no-repeat;
-  background-color: red;
-  display: inline-block;
-  width: 13px;
-  height: 15px;
-  padding: 0 !important;
+  max-height: 60vh;
+  overflow-y: auto;
 }

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.spec.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.spec.ts
@@ -101,16 +101,16 @@ describe('ClarinFilesSectionComponent', () => {
   describe('generateCurlCommand', () => {
     const BASE = `${ROOT_HREF}/core/bitstreams/handle`;
 
-    it('should generate a curl command for a single file with brace expansion', () => {
+    it('should generate a curl command for a single file', () => {
       component.itemHandle = '123456789/1';
       component.listOfFiles.next([createMetadataBitstream('simple.txt')]);
       component.generateCurlCommand();
       expect(component.command).toBe(
-        `curl -o "simple.txt" "${BASE}/123456789/1{/simple.txt}"`
+        `curl -o "simple.txt" "${BASE}/123456789/1/simple.txt"`
       );
     });
 
-    it('should generate a curl command for multiple files with brace expansion', () => {
+    it('should generate a curl command for multiple files', () => {
       component.itemHandle = '123456789/2';
       component.listOfFiles.next([
         createMetadataBitstream('file1.txt'),
@@ -118,7 +118,8 @@ describe('ClarinFilesSectionComponent', () => {
       ]);
       component.generateCurlCommand();
       expect(component.command).toBe(
-        `curl -o "file1.txt" -o "file2.txt" "${BASE}/123456789/2{/file1.txt,/file2.txt}"`
+        `curl -o "file1.txt" "${BASE}/123456789/2/file1.txt" ` +
+        `-o "file2.txt" "${BASE}/123456789/2/file2.txt"`
       );
     });
 
@@ -127,7 +128,7 @@ describe('ClarinFilesSectionComponent', () => {
       component.listOfFiles.next([createMetadataBitstream('my file.txt')]);
       component.generateCurlCommand();
       expect(component.command).toBe(
-        `curl -o "my file.txt" "${BASE}/123456789/3{/my%20file.txt}"`
+        `curl -o "my file.txt" "${BASE}/123456789/3/my%20file.txt"`
       );
     });
 
@@ -136,7 +137,7 @@ describe('ClarinFilesSectionComponent', () => {
       component.listOfFiles.next([createMetadataBitstream('logo (2).png')]);
       component.generateCurlCommand();
       expect(component.command).toBe(
-        `curl -o "logo (2).png" "${BASE}/123456789/4{/logo%20%282%29.png}"`
+        `curl -o "logo (2).png" "${BASE}/123456789/4/logo%20%282%29.png"`
       );
     });
 
@@ -145,7 +146,7 @@ describe('ClarinFilesSectionComponent', () => {
       component.listOfFiles.next([createMetadataBitstream('dtq+logo.png')]);
       component.generateCurlCommand();
       expect(component.command).toBe(
-        `curl -o "dtq+logo.png" "${BASE}/123456789/5{/dtq%2Blogo.png}"`
+        `curl -o "dtq+logo.png" "${BASE}/123456789/5/dtq%2Blogo.png"`
       );
     });
 
@@ -157,8 +158,8 @@ describe('ClarinFilesSectionComponent', () => {
       ]);
       component.generateCurlCommand();
       expect(component.command).toBe(
-        `curl -o "dtq+logo (2).png" -o "Screenshot 1.png" ` +
-        `"${BASE}/123456789/6{/dtq%2Blogo%20%282%29.png,/Screenshot%201.png}"`
+        `curl -o "dtq+logo (2).png" "${BASE}/123456789/6/dtq%2Blogo%20%282%29.png" ` +
+        `-o "Screenshot 1.png" "${BASE}/123456789/6/Screenshot%201.png"`
       );
     });
 
@@ -167,7 +168,7 @@ describe('ClarinFilesSectionComponent', () => {
       component.listOfFiles.next([createMetadataBitstream('M\u00e9di\u00e1 (3).jfif')]);
       component.generateCurlCommand();
       expect(component.command).toBe(
-        `curl -o "M\u00e9di\u00e1 (3).jfif" "${BASE}/123456789/9{/M%C3%A9di%C3%A1%20%283%29.jfif}"`
+        `curl -o "M\u00e9di\u00e1 (3).jfif" "${BASE}/123456789/9/M%C3%A9di%C3%A1%20%283%29.jfif"`
       );
     });
 
@@ -176,7 +177,7 @@ describe('ClarinFilesSectionComponent', () => {
       component.listOfFiles.next([createMetadataBitstream('file "quoted".txt')]);
       component.generateCurlCommand();
       expect(component.command).toBe(
-        `curl -o "file \\"quoted\\".txt" "${BASE}/123456789/10{/file%20%22quoted%22.txt}"`
+        `curl -o "file \\"quoted\\".txt" "${BASE}/123456789/10/file%20%22quoted%22.txt"`
       );
     });
 
@@ -201,7 +202,7 @@ describe('ClarinFilesSectionComponent', () => {
       component.listOfFiles.next([createMetadataBitstream('100% done.txt')]);
       component.generateCurlCommand();
       expect(component.command).toBe(
-        `curl -o "100% done.txt" "${BASE}/123456789/11{/100%25%20done.txt}"`
+        `curl -o "100% done.txt" "${BASE}/123456789/11/100%25%20done.txt"`
       );
     });
 
@@ -210,7 +211,7 @@ describe('ClarinFilesSectionComponent', () => {
       component.listOfFiles.next([createMetadataBitstream('M\u00e9di\u00e1 (+)#9) ano')]);
       component.generateCurlCommand();
       expect(component.command).toBe(
-        `curl -o "M\u00e9di\u00e1 (+)#9) ano" "${BASE}/123456789/12{/M%C3%A9di%C3%A1%20%28%2B%29%239%29%20ano}"`
+        `curl -o "M\u00e9di\u00e1 (+)#9) ano" "${BASE}/123456789/12/M%C3%A9di%C3%A1%20%28%2B%29%239%29%20ano"`
       );
     });
   });

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.spec.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.spec.ts
@@ -63,7 +63,7 @@ describe('ClarinFilesSectionComponent', () => {
   });
 
   const configurationServiceSpy = jasmine.createSpyObj('configurationService', {
-    findByPropertyName: of('123456'),
+    findByPropertyName: createSuccessfulRemoteDataObject$({ values: ['123456'] }),
   });
 
   beforeEach(async () => {
@@ -214,6 +214,26 @@ describe('ClarinFilesSectionComponent', () => {
       component.generateCurlCommand();
       expect(component.command).toBe(
         `curl -o "M\u00e9di\u00e1 (+)#9) ano" "${BASE}/123456789/12/M%C3%A9di%C3%A1%20%28%2B%29%239%29%20ano"`
+      );
+    });
+
+    it('should reset canShowCurlDownload when called again with non-previewable files', () => {
+      component.itemHandle = '123456789/13';
+      component.listOfFiles.next([createMetadataBitstream('file.txt', true)]);
+      component.generateCurlCommand();
+      expect(component.canShowCurlDownload).toBeTrue();
+      // Now call again with non-previewable files
+      component.listOfFiles.next([createMetadataBitstream('file.txt', false)]);
+      component.generateCurlCommand();
+      expect(component.canShowCurlDownload).toBeFalse();
+    });
+
+    it('should escape dollar signs and backticks in filenames for shell safety', () => {
+      component.itemHandle = '123456789/14';
+      component.listOfFiles.next([createMetadataBitstream('price$100.txt')]);
+      component.generateCurlCommand();
+      expect(component.command).toBe(
+        `curl -o "price\\$100.txt" "${BASE}/123456789/14/price%24100.txt"`
       );
     });
   });

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.spec.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.spec.ts
@@ -204,5 +204,14 @@ describe('ClarinFilesSectionComponent', () => {
         `curl -o "100% done.txt" "${BASE}/123456789/11{/100%25%20done.txt}"`
       );
     });
+
+    it('should handle complex filename with diacritics, plus, hash, and unmatched paren', () => {
+      component.itemHandle = '123456789/12';
+      component.listOfFiles.next([createMetadataBitstream('M\u00e9di\u00e1 (+)#9) ano')]);
+      component.generateCurlCommand();
+      expect(component.command).toBe(
+        `curl -o "M\u00e9di\u00e1 (+)#9) ano" "${BASE}/123456789/12{/M%C3%A9di%C3%A1%20%28%2B%29%239%29%20ano}"`
+      );
+    });
   });
 });

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.spec.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.spec.ts
@@ -14,6 +14,7 @@ import { ConfigurationDataService } from '../../core/data/configuration-data.ser
 import { Item } from '../../core/shared/item.model';
 import { createSuccessfulRemoteDataObject$ } from '../../shared/remote-data.utils';
 import { createPaginatedList } from '../../shared/testing/utils.test';
+import { NgbModalModule } from '@ng-bootstrap/ng-bootstrap';
 
 describe('ClarinFilesSectionComponent', () => {
   let component: ClarinFilesSectionComponent;
@@ -77,7 +78,8 @@ describe('ClarinFilesSectionComponent', () => {
     await TestBed.configureTestingModule({
       declarations: [ ClarinFilesSectionComponent ],
       imports: [
-        TranslateModule.forRoot()
+        TranslateModule.forRoot(),
+        NgbModalModule,
       ],
       providers: [
         { provide: RegistryService, useValue: mockRegistryService },

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.spec.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.spec.ts
@@ -101,16 +101,16 @@ describe('ClarinFilesSectionComponent', () => {
   describe('generateCurlCommand', () => {
     const BASE = `${ROOT_HREF}/core/bitstreams/handle`;
 
-    it('should generate a curl command for a single file', () => {
+    it('should generate a curl command for a single file with brace expansion', () => {
       component.itemHandle = '123456789/1';
       component.listOfFiles.next([createMetadataBitstream('simple.txt')]);
       component.generateCurlCommand();
       expect(component.command).toBe(
-        `curl -o "simple.txt" "${BASE}/123456789/1/simple.txt"`
+        `curl -o "simple.txt" "${BASE}/123456789/1{/simple.txt}"`
       );
     });
 
-    it('should generate a curl command for multiple files', () => {
+    it('should generate a curl command for multiple files with brace expansion', () => {
       component.itemHandle = '123456789/2';
       component.listOfFiles.next([
         createMetadataBitstream('file1.txt'),
@@ -118,7 +118,7 @@ describe('ClarinFilesSectionComponent', () => {
       ]);
       component.generateCurlCommand();
       expect(component.command).toBe(
-        `curl -o "file1.txt" "${BASE}/123456789/2/file1.txt" -o "file2.txt" "${BASE}/123456789/2/file2.txt"`
+        `curl -o "file1.txt" -o "file2.txt" "${BASE}/123456789/2{/file1.txt,/file2.txt}"`
       );
     });
 
@@ -127,7 +127,7 @@ describe('ClarinFilesSectionComponent', () => {
       component.listOfFiles.next([createMetadataBitstream('my file.txt')]);
       component.generateCurlCommand();
       expect(component.command).toBe(
-        `curl -o "my file.txt" "${BASE}/123456789/3/my%20file.txt"`
+        `curl -o "my file.txt" "${BASE}/123456789/3{/my%20file.txt}"`
       );
     });
 
@@ -136,16 +136,16 @@ describe('ClarinFilesSectionComponent', () => {
       component.listOfFiles.next([createMetadataBitstream('logo (2).png')]);
       component.generateCurlCommand();
       expect(component.command).toBe(
-        `curl -o "logo (2).png" "${BASE}/123456789/4/logo%20%282%29.png"`
+        `curl -o "logo (2).png" "${BASE}/123456789/4{/logo%20%282%29.png}"`
       );
     });
 
-    it('should percent-encode plus signs in URL but keep real name in -o', () => {
+    it('should percent-encode plus signs in URL', () => {
       component.itemHandle = '123456789/5';
       component.listOfFiles.next([createMetadataBitstream('dtq+logo.png')]);
       component.generateCurlCommand();
       expect(component.command).toBe(
-        `curl -o "dtq+logo.png" "${BASE}/123456789/5/dtq%2Blogo.png"`
+        `curl -o "dtq+logo.png" "${BASE}/123456789/5{/dtq%2Blogo.png}"`
       );
     });
 
@@ -157,17 +157,17 @@ describe('ClarinFilesSectionComponent', () => {
       ]);
       component.generateCurlCommand();
       expect(component.command).toBe(
-        `curl -o "dtq+logo (2).png" "${BASE}/123456789/6/dtq%2Blogo%20%282%29.png" ` +
-        `-o "Screenshot 1.png" "${BASE}/123456789/6/Screenshot%201.png"`
+        `curl -o "dtq+logo (2).png" -o "Screenshot 1.png" ` +
+        `"${BASE}/123456789/6{/dtq%2Blogo%20%282%29.png,/Screenshot%201.png}"`
       );
     });
 
-    it('should preserve UTF-8 characters in -o filename', () => {
+    it('should preserve UTF-8 characters in -o filename and encode in URL', () => {
       component.itemHandle = '123456789/9';
       component.listOfFiles.next([createMetadataBitstream('M\u00e9di\u00e1 (3).jfif')]);
       component.generateCurlCommand();
       expect(component.command).toBe(
-        `curl -o "M\u00e9di\u00e1 (3).jfif" "${BASE}/123456789/9/M%C3%A9di%C3%A1%20%283%29.jfif"`
+        `curl -o "M\u00e9di\u00e1 (3).jfif" "${BASE}/123456789/9{/M%C3%A9di%C3%A1%20%283%29.jfif}"`
       );
     });
 
@@ -176,7 +176,7 @@ describe('ClarinFilesSectionComponent', () => {
       component.listOfFiles.next([createMetadataBitstream('file "quoted".txt')]);
       component.generateCurlCommand();
       expect(component.command).toBe(
-        `curl -o "file \\"quoted\\".txt" "${BASE}/123456789/10/file%20%22quoted%22.txt"`
+        `curl -o "file \\"quoted\\".txt" "${BASE}/123456789/10{/file%20%22quoted%22.txt}"`
       );
     });
 
@@ -201,7 +201,7 @@ describe('ClarinFilesSectionComponent', () => {
       component.listOfFiles.next([createMetadataBitstream('100% done.txt')]);
       component.generateCurlCommand();
       expect(component.command).toBe(
-        `curl -o "100% done.txt" "${BASE}/123456789/11/100%25%20done.txt"`
+        `curl -o "100% done.txt" "${BASE}/123456789/11{/100%25%20done.txt}"`
       );
     });
   });

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.spec.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.spec.ts
@@ -20,25 +20,32 @@ describe('ClarinFilesSectionComponent', () => {
   let fixture: ComponentFixture<ClarinFilesSectionComponent>;
 
   let mockRegistryService: any;
-  let halService: HALEndpointService;
-  // Set up the mock service's getMetadataBitstream method to return a simple stream
-  const metadatabitstream = new MetadataBitstream();
-  metadatabitstream.id = '70ccc608-f6a5-4c96-ab2d-53bc56ae8ebe';
-  metadatabitstream.name = 'test';
-  metadatabitstream.description = 'test';
-  metadatabitstream.fileSize = 1024;
-  metadatabitstream.checksum = 'abc';
-  metadatabitstream.type = new ResourceType('item');
-  metadatabitstream.fileInfo = [];
-  metadatabitstream.format = 'text';
-  metadatabitstream.canPreview = false;
-  metadatabitstream._links = {
-    self: new HALLink(),
-    schema: new HALLink(),
-  };
+  let halService: any;
 
-  metadatabitstream._links.self.href = '';
-  metadatabitstream._links.schema.href = '';
+  const ROOT_HREF = 'http://localhost:8080/server/api';
+
+  function createMetadataBitstream(name: string, canPreview: boolean = true): MetadataBitstream {
+    const bs = new MetadataBitstream();
+    bs.id = '70ccc608-f6a5-4c96-ab2d-53bc56ae8ebe';
+    bs.name = name;
+    bs.description = 'test';
+    bs.fileSize = 1024;
+    bs.checksum = 'abc';
+    bs.type = new ResourceType('item');
+    bs.fileInfo = [];
+    bs.format = 'text';
+    bs.canPreview = canPreview;
+    bs._links = {
+      self: new HALLink(),
+      schema: new HALLink(),
+    };
+    bs._links.self.href = '';
+    bs._links.schema.href = '';
+    return bs;
+  }
+
+  // Set up the mock service's getMetadataBitstream method to return a simple stream
+  const metadatabitstream = createMetadataBitstream('test', false);
   const metadataBitstreams: MetadataBitstream[] = [metadatabitstream];
   const bitstreamStream = new BehaviorSubject(metadataBitstreams);
 
@@ -63,7 +70,9 @@ describe('ClarinFilesSectionComponent', () => {
       'getMetadataBitstream': of(bitstreamStream)
     }
     );
-    halService = Object.assign(new HALEndpointServiceStub('some url'));
+    halService = Object.assign(new HALEndpointServiceStub('some url'), {
+      getRootHref: () => ROOT_HREF
+    });
 
     await TestBed.configureTestingModule({
       declarations: [ ClarinFilesSectionComponent ],
@@ -87,5 +96,104 @@ describe('ClarinFilesSectionComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('generateCurlCommand', () => {
+    const BASE = `${ROOT_HREF}/core/bitstreams/handle`;
+
+    it('should generate a curl command for a single file', () => {
+      component.itemHandle = '123456789/1';
+      component.listOfFiles.next([createMetadataBitstream('simple.txt')]);
+      component.generateCurlCommand();
+      expect(component.command).toBe(
+        `curl -o "simple.txt" "${BASE}/123456789/1/simple.txt"`
+      );
+    });
+
+    it('should generate a curl command for multiple files', () => {
+      component.itemHandle = '123456789/2';
+      component.listOfFiles.next([
+        createMetadataBitstream('file1.txt'),
+        createMetadataBitstream('file2.txt'),
+      ]);
+      component.generateCurlCommand();
+      expect(component.command).toBe(
+        `curl -o "file1.txt" "${BASE}/123456789/2/file1.txt" -o "file2.txt" "${BASE}/123456789/2/file2.txt"`
+      );
+    });
+
+    it('should percent-encode spaces in URL but keep real name in -o', () => {
+      component.itemHandle = '123456789/3';
+      component.listOfFiles.next([createMetadataBitstream('my file.txt')]);
+      component.generateCurlCommand();
+      expect(component.command).toBe(
+        `curl -o "my file.txt" "${BASE}/123456789/3/my%20file.txt"`
+      );
+    });
+
+    it('should percent-encode parentheses in URL but keep real name in -o', () => {
+      component.itemHandle = '123456789/4';
+      component.listOfFiles.next([createMetadataBitstream('logo (2).png')]);
+      component.generateCurlCommand();
+      expect(component.command).toBe(
+        `curl -o "logo (2).png" "${BASE}/123456789/4/logo%20%282%29.png"`
+      );
+    });
+
+    it('should percent-encode plus signs in URL but keep real name in -o', () => {
+      component.itemHandle = '123456789/5';
+      component.listOfFiles.next([createMetadataBitstream('dtq+logo.png')]);
+      component.generateCurlCommand();
+      expect(component.command).toBe(
+        `curl -o "dtq+logo.png" "${BASE}/123456789/5/dtq%2Blogo.png"`
+      );
+    });
+
+    it('should handle mixed special characters in multiple files', () => {
+      component.itemHandle = '123456789/6';
+      component.listOfFiles.next([
+        createMetadataBitstream('dtq+logo (2).png'),
+        createMetadataBitstream('Screenshot 1.png'),
+      ]);
+      component.generateCurlCommand();
+      expect(component.command).toBe(
+        `curl -o "dtq+logo (2).png" "${BASE}/123456789/6/dtq%2Blogo%20%282%29.png" ` +
+        `-o "Screenshot 1.png" "${BASE}/123456789/6/Screenshot%201.png"`
+      );
+    });
+
+    it('should preserve UTF-8 characters in -o filename', () => {
+      component.itemHandle = '123456789/9';
+      component.listOfFiles.next([createMetadataBitstream('M\u00e9di\u00e1 (3).jfif')]);
+      component.generateCurlCommand();
+      expect(component.command).toBe(
+        `curl -o "M\u00e9di\u00e1 (3).jfif" "${BASE}/123456789/9/M%C3%A9di%C3%A1%20%283%29.jfif"`
+      );
+    });
+
+    it('should escape double quotes in filenames', () => {
+      component.itemHandle = '123456789/10';
+      component.listOfFiles.next([createMetadataBitstream('file "quoted".txt')]);
+      component.generateCurlCommand();
+      expect(component.command).toBe(
+        `curl -o "file \\"quoted\\".txt" "${BASE}/123456789/10/file%20%22quoted%22.txt"`
+      );
+    });
+
+    it('should set canShowCurlDownload to true when any file canPreview', () => {
+      component.canShowCurlDownload = false;
+      component.itemHandle = '123456789/7';
+      component.listOfFiles.next([createMetadataBitstream('file.txt', true)]);
+      component.generateCurlCommand();
+      expect(component.canShowCurlDownload).toBeTrue();
+    });
+
+    it('should not set canShowCurlDownload for non-previewable files', () => {
+      component.canShowCurlDownload = false;
+      component.itemHandle = '123456789/8';
+      component.listOfFiles.next([createMetadataBitstream('file.txt', false)]);
+      component.generateCurlCommand();
+      expect(component.canShowCurlDownload).toBeFalse();
+    });
   });
 });

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.spec.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.spec.ts
@@ -195,5 +195,14 @@ describe('ClarinFilesSectionComponent', () => {
       component.generateCurlCommand();
       expect(component.canShowCurlDownload).toBeFalse();
     });
+
+    it('should handle filenames containing a literal percent sign', () => {
+      component.itemHandle = '123456789/11';
+      component.listOfFiles.next([createMetadataBitstream('100% done.txt')]);
+      component.generateCurlCommand();
+      expect(component.command).toBe(
+        `curl -o "100% done.txt" "${BASE}/123456789/11/100%25%20done.txt"`
+      );
+    });
   });
 });

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
@@ -114,7 +114,6 @@ export class ClarinFilesSectionComponent implements OnInit {
     const baseUrl = `${this.halService.getRootHref()}/core/bitstreams/handle/${this.itemHandle}`;
     const fileNamesFormatted = fileNames.map(fileName => `/${this.encodeFilenameForUrl(fileName)}`).join(',');
     this.command = `curl -OJ "${baseUrl}{${fileNamesFormatted}}"`;
-  
   }
 
   /**

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
@@ -107,22 +107,21 @@ export class ClarinFilesSectionComponent implements OnInit {
       return file.name;
     });
 
-    // Generate curl command using -o "filename" "url" pairs.
-    // This avoids curl -J (Content-Disposition), which cannot create files
-    // with non-ASCII characters on Windows due to code-page limitations.
+    // Generate curl command with brace expansion in the URL and -o flags for correct filenames.
+    // Brace expansion: curl expands {/a,/b} into two requests to baseUrl/a and baseUrl/b.
+    // -o flags: one per file, giving curl the real filename to save as (handles UTF-8 correctly
+    // because the shell passes it directly, unlike -J which depends on Content-Disposition parsing).
     const baseUrl = `${this.halService.getRootHref()}/core/bitstreams/handle/${this.itemHandle}`;
-    const parts = fileNames.map(name => {
-      // Encode the raw filename for use in a URL path segment.
-      // Do NOT use encodeRFC3986URIComponent here — it calls decodeURIComponent first,
-      // which throws URIError on filenames containing literal '%' followed by non-hex chars.
-      const encodedName = encodeURIComponent(name)
+    const encodedPaths = fileNames.map(name => {
+      return '/' + encodeURIComponent(name)
         .replace(/[()]/g, c => '%' + c.charCodeAt(0).toString(16).toUpperCase());
-      const url = `${baseUrl}/${encodedName}`;
-      // Escape backslashes and double quotes for safe use inside double-quoted shell strings
-      const safeName = name.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-      return `-o "${safeName}" "${url}"`;
     });
-    this.command = `curl ${parts.join(' ')}`;
+    const outputFlags = fileNames.map(name => {
+      const safeName = name.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      return `-o "${safeName}"`;
+    }).join(' ');
+    const braceList = encodedPaths.join(',');
+    this.command = `curl ${outputFlags} "${baseUrl}{${braceList}}"`;
   }
 
   loadDownloadZipConfigProperties() {

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
@@ -109,14 +109,13 @@ export class ClarinFilesSectionComponent implements OnInit {
 
     // Generate curl command for individual bitstream downloads by handle + filename.
     // Uses the backend endpoint: /api/core/bitstreams/handle/{prefix}/{suffix}/{filename}
+    // Always uses -o with the real filename to avoid percent-encoded filenames from -O.
     const baseUrl = `${this.halService.getRootHref()}/core/bitstreams/handle/${this.itemHandle}`;
-    if (fileNames.length === 1) {
-      const encodedName = this.encodeFilenameForUrl(fileNames[0]);
-      this.command = `curl -o "${fileNames[0]}" "${baseUrl}/${encodedName}"`;
-    } else {
-      const fileNamesFormatted = fileNames.map(fileName => `/${this.encodeFilenameForUrl(fileName)}`).join(',');
-      this.command = `curl -O "${baseUrl}{${fileNamesFormatted}}"`;
-    }
+    const commands = fileNames.map(fileName => {
+      const encodedName = this.encodeFilenameForUrl(fileName);
+      return `curl -o "${fileName}" "${baseUrl}/${encodedName}"`;
+    });
+    this.command = commands.join(' && ');
   }
 
   /**

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
@@ -109,13 +109,12 @@ export class ClarinFilesSectionComponent implements OnInit {
 
     // Generate curl command for individual bitstream downloads by handle + filename.
     // Uses the backend endpoint: /api/core/bitstreams/handle/{prefix}/{suffix}/{filename}
-    // Always uses -o with the real filename to avoid percent-encoded filenames from -O.
+    // -J tells curl to use the filename from the Content-Disposition header (the real name)
+    // instead of the percent-encoded URL path.
     const baseUrl = `${this.halService.getRootHref()}/core/bitstreams/handle/${this.itemHandle}`;
-    const commands = fileNames.map(fileName => {
-      const encodedName = this.encodeFilenameForUrl(fileName);
-      return `curl -o "${fileName}" "${baseUrl}/${encodedName}"`;
-    });
-    this.command = commands.join(' && ');
+    const fileNamesFormatted = fileNames.map(fileName => `/${this.encodeFilenameForUrl(fileName)}`).join(',');
+    this.command = `curl -OJ "${baseUrl}{${fileNamesFormatted}}"`;
+  
   }
 
   /**

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
@@ -8,6 +8,7 @@ import { Router } from '@angular/router';
 import { HALEndpointService } from '../../core/shared/hal-endpoint.service';
 import { ConfigurationDataService } from '../../core/data/configuration-data.service';
 import { BehaviorSubject } from 'rxjs';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
   selector: 'ds-clarin-files-section',
@@ -29,9 +30,9 @@ export class ClarinFilesSectionComponent implements OnInit {
   canShowCurlDownload = false;
 
   /**
-   * If download by command button is click, the command line will be shown
+   * Whether the command was recently copied to clipboard
    */
-  isCommandLineVisible = false;
+  commandCopied = false;
 
   /**
    * command for the download command feature
@@ -75,7 +76,8 @@ export class ClarinFilesSectionComponent implements OnInit {
   constructor(protected registryService: RegistryService,
               protected router: Router,
               protected halService: HALEndpointService,
-              protected configurationService: ConfigurationDataService) {
+              protected configurationService: ConfigurationDataService,
+              protected modalService: NgbModal) {
   }
 
   ngOnInit(): void {
@@ -90,8 +92,16 @@ export class ClarinFilesSectionComponent implements OnInit {
     this.loadDownloadZipConfigProperties();
   }
 
-  setCommandline() {
-    this.isCommandLineVisible = !this.isCommandLineVisible;
+  openCommandModal(content: any) {
+    this.commandCopied = false;
+    this.modalService.open(content, { size: 'lg', centered: true });
+  }
+
+  copyCommand() {
+    navigator.clipboard.writeText(this.command).then(() => {
+      this.commandCopied = true;
+      setTimeout(() => this.commandCopied = false, 2000);
+    });
   }
 
   downloadFiles() {

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
+import { encodeRFC3986URIComponent } from '../../shared/clarin-shared-util';
 import { Item } from '../../core/shared/item.model';
 import { getAllSucceededRemoteListPayload, getFirstSucceededRemoteDataPayload } from '../../core/shared/operators';
 import { getItemPageRoute } from '../item-page-routing-paths';
@@ -117,11 +118,10 @@ export class ClarinFilesSectionComponent implements OnInit {
   }
 
   /**
-   * Encode a filename for use in a URL path segment.
-   * Encodes special characters (spaces, parentheses, +, etc.) using percent-encoding.
+   * Encode a filename for use in a URL path segment using the shared RFC3986 utility.
    */
   private encodeFilenameForUrl(filename: string): string {
-    return encodeURIComponent(filename).replace(/[()]/g, c => '%' + c.charCodeAt(0).toString(16).toUpperCase());
+    return encodeRFC3986URIComponent(filename);
   }
 
   loadDownloadZipConfigProperties() {

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
@@ -94,13 +94,16 @@ export class ClarinFilesSectionComponent implements OnInit {
 
   openCommandModal(content: any) {
     this.commandCopied = false;
-    this.modalService.open(content, { size: 'lg', centered: true });
+    this.modalService.open(content, { size: 'lg', centered: true, ariaLabelledBy: 'commandModalTitle' });
   }
 
   copyCommand() {
     navigator.clipboard.writeText(this.command).then(() => {
       this.commandCopied = true;
       setTimeout(() => this.commandCopied = false, 2000);
+    }).catch(() => {
+      // Fallback: clipboard API may be unavailable (non-HTTPS, denied permissions)
+      this.commandCopied = false;
     });
   }
 
@@ -109,6 +112,7 @@ export class ClarinFilesSectionComponent implements OnInit {
   }
 
   generateCurlCommand() {
+    this.canShowCurlDownload = false;
     const fileNames = this.listOfFiles.value.map((file: MetadataBitstream) => {
       if (file.canPreview) {
         this.canShowCurlDownload = true;
@@ -126,7 +130,7 @@ export class ClarinFilesSectionComponent implements OnInit {
     const parts = fileNames.map(name => {
       const encodedName = encodeURIComponent(name)
         .replace(/[()]/g, c => '%' + c.charCodeAt(0).toString(16).toUpperCase());
-      const safeName = name.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      const safeName = name.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\$/g, '\\$').replace(/`/g, '\\`');
       return `-o "${safeName}" "${baseUrl}/${encodedName}"`;
     });
     this.command = `curl ${parts.join(' ')}`;

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
@@ -111,11 +111,20 @@ export class ClarinFilesSectionComponent implements OnInit {
     // Uses the backend endpoint: /api/core/bitstreams/handle/{prefix}/{suffix}/{filename}
     const baseUrl = `${this.halService.getRootHref()}/core/bitstreams/handle/${this.itemHandle}`;
     if (fileNames.length === 1) {
-      this.command = `curl -o '${fileNames[0]}' '${baseUrl}/${fileNames[0]}'`;
+      const encodedName = this.encodeFilenameForUrl(fileNames[0]);
+      this.command = `curl -o "${fileNames[0]}" "${baseUrl}/${encodedName}"`;
     } else {
-      const fileNamesFormatted = fileNames.map(fileName => `/${fileName}`).join(',');
-      this.command = `curl -O '${baseUrl}{${fileNamesFormatted}}'`;
+      const fileNamesFormatted = fileNames.map(fileName => `/${this.encodeFilenameForUrl(fileName)}`).join(',');
+      this.command = `curl -O "${baseUrl}{${fileNamesFormatted}}"`;
     }
+  }
+
+  /**
+   * Encode a filename for use in a URL path segment.
+   * Encodes special characters (spaces, parentheses, +, etc.) using percent-encoding.
+   */
+  private encodeFilenameForUrl(filename: string): string {
+    return encodeURIComponent(filename).replace(/[()]/g, c => '%' + c.charCodeAt(0).toString(16).toUpperCase());
   }
 
   loadDownloadZipConfigProperties() {

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { encodeRFC3986URIComponent } from '../../shared/clarin-shared-util';
 import { Item } from '../../core/shared/item.model';
 import { getAllSucceededRemoteListPayload, getFirstSucceededRemoteDataPayload } from '../../core/shared/operators';
 import { getItemPageRoute } from '../item-page-routing-paths';
@@ -9,7 +8,6 @@ import { Router } from '@angular/router';
 import { HALEndpointService } from '../../core/shared/hal-endpoint.service';
 import { ConfigurationDataService } from '../../core/data/configuration-data.service';
 import { BehaviorSubject } from 'rxjs';
-import { encodeRFC3986URIComponent } from '../../shared/clarin-shared-util';
 
 @Component({
   selector: 'ds-clarin-files-section',
@@ -114,7 +112,12 @@ export class ClarinFilesSectionComponent implements OnInit {
     // with non-ASCII characters on Windows due to code-page limitations.
     const baseUrl = `${this.halService.getRootHref()}/core/bitstreams/handle/${this.itemHandle}`;
     const parts = fileNames.map(name => {
-      const url = `${baseUrl}/${encodeRFC3986URIComponent(name)}`;
+      // Encode the raw filename for use in a URL path segment.
+      // Do NOT use encodeRFC3986URIComponent here — it calls decodeURIComponent first,
+      // which throws URIError on filenames containing literal '%' followed by non-hex chars.
+      const encodedName = encodeURIComponent(name)
+        .replace(/[()]/g, c => '%' + c.charCodeAt(0).toString(16).toUpperCase());
+      const url = `${baseUrl}/${encodedName}`;
       // Escape backslashes and double quotes for safe use inside double-quoted shell strings
       const safeName = name.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
       return `-o "${safeName}" "${url}"`;

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
@@ -9,6 +9,7 @@ import { Router } from '@angular/router';
 import { HALEndpointService } from '../../core/shared/hal-endpoint.service';
 import { ConfigurationDataService } from '../../core/data/configuration-data.service';
 import { BehaviorSubject } from 'rxjs';
+import { encodeRFC3986URIComponent } from '../../shared/clarin-shared-util';
 
 @Component({
   selector: 'ds-clarin-files-section',
@@ -108,20 +109,17 @@ export class ClarinFilesSectionComponent implements OnInit {
       return file.name;
     });
 
-    // Generate curl command for individual bitstream downloads by handle + filename.
-    // Uses the backend endpoint: /api/core/bitstreams/handle/{prefix}/{suffix}/{filename}
-    // -J tells curl to use the filename from the Content-Disposition header (the real name)
-    // instead of the percent-encoded URL path.
+    // Generate curl command using -o "filename" "url" pairs.
+    // This avoids curl -J (Content-Disposition), which cannot create files
+    // with non-ASCII characters on Windows due to code-page limitations.
     const baseUrl = `${this.halService.getRootHref()}/core/bitstreams/handle/${this.itemHandle}`;
-    const fileNamesFormatted = fileNames.map(fileName => `/${this.encodeFilenameForUrl(fileName)}`).join(',');
-    this.command = `curl -OJ "${baseUrl}{${fileNamesFormatted}}"`;
-  }
-
-  /**
-   * Encode a filename for use in a URL path segment using the shared RFC3986 utility.
-   */
-  private encodeFilenameForUrl(filename: string): string {
-    return encodeRFC3986URIComponent(filename);
+    const parts = fileNames.map(name => {
+      const url = `${baseUrl}/${encodeRFC3986URIComponent(name)}`;
+      // Escape backslashes and double quotes for safe use inside double-quoted shell strings
+      const safeName = name.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      return `-o "${safeName}" "${url}"`;
+    });
+    this.command = `curl ${parts.join(' ')}`;
   }
 
   loadDownloadZipConfigProperties() {

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
@@ -107,10 +107,15 @@ export class ClarinFilesSectionComponent implements OnInit {
       return file.name;
     });
 
-    // Generate curl command for individual bitstream downloads
-    const baseUrl = `${this.halService.getRootHref()}/bitstream/${this.itemHandle}`;
-    const fileNamesFormatted = fileNames.map((fileName, index) => `/${index}/${fileName}`).join(',');
-    this.command = `curl -O ${baseUrl}{${fileNamesFormatted}}`;
+    // Generate curl command for individual bitstream downloads by handle + filename.
+    // Uses the backend endpoint: /api/core/bitstreams/handle/{prefix}/{suffix}/{filename}
+    const baseUrl = `${this.halService.getRootHref()}/core/bitstreams/handle/${this.itemHandle}`;
+    if (fileNames.length === 1) {
+      this.command = `curl -o '${fileNames[0]}' '${baseUrl}/${fileNames[0]}'`;
+    } else {
+      const fileNamesFormatted = fileNames.map(fileName => `/${fileName}`).join(',');
+      this.command = `curl -O '${baseUrl}{${fileNamesFormatted}}'`;
+    }
   }
 
   loadDownloadZipConfigProperties() {

--- a/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
+++ b/src/app/item-page/clarin-files-section/clarin-files-section.component.ts
@@ -107,21 +107,19 @@ export class ClarinFilesSectionComponent implements OnInit {
       return file.name;
     });
 
-    // Generate curl command with brace expansion in the URL and -o flags for correct filenames.
-    // Brace expansion: curl expands {/a,/b} into two requests to baseUrl/a and baseUrl/b.
-    // -o flags: one per file, giving curl the real filename to save as (handles UTF-8 correctly
-    // because the shell passes it directly, unlike -J which depends on Content-Disposition parsing).
+    // Generate curl command with -o "filename" "url" pairs for each file.
+    // Each file needs its own -o + URL pair because curl URL globbing ({})
+    // does NOT support per-file -o flags (multiple -o with {} results in
+    // "Got more output options than URLs" and only the first file is saved).
+    // Using -o lets the shell pass the real filename (including UTF-8) directly.
     const baseUrl = `${this.halService.getRootHref()}/core/bitstreams/handle/${this.itemHandle}`;
-    const encodedPaths = fileNames.map(name => {
-      return '/' + encodeURIComponent(name)
+    const parts = fileNames.map(name => {
+      const encodedName = encodeURIComponent(name)
         .replace(/[()]/g, c => '%' + c.charCodeAt(0).toString(16).toUpperCase());
-    });
-    const outputFlags = fileNames.map(name => {
       const safeName = name.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-      return `-o "${safeName}"`;
-    }).join(' ');
-    const braceList = encodedPaths.join(',');
-    this.command = `curl ${outputFlags} "${baseUrl}{${braceList}}"`;
+      return `-o "${safeName}" "${baseUrl}/${encodedName}"`;
+    });
+    this.command = `curl ${parts.join(' ')}`;
   }
 
   loadDownloadZipConfigProperties() {

--- a/src/app/submission/sections/cc-license/submission-section-cc-licenses.component.spec.ts
+++ b/src/app/submission/sections/cc-license/submission-section-cc-licenses.component.spec.ts
@@ -236,11 +236,13 @@ describe('SubmissionSectionCcLicensesComponent', () => {
 
     describe('when all options have a value selected', () => {
 
-      beforeEach(() => {
+      beforeEach(fakeAsync(() => {
         component.selectOption(ccLicence, ccLicence.fields[0], ccLicence.fields[0].enums[1]);
         component.selectOption(ccLicence, ccLicence.fields[1], ccLicence.fields[1].enums[0]);
         fixture.detectChanges();
-      });
+        tick(300); // Wait for debounceTime(300) in ccLicenseLink$ pipeline
+        fixture.detectChanges();
+      }));
 
       it('should call the submission cc licenses data service getCcLicenseLink method', () => {
         expect(submissionCcLicenseUrlDataService.getCcLicenseLink).toHaveBeenCalledWith(

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -9203,6 +9203,9 @@
 
   // "item.page.download.button.command.line": "Download instructions for command line",
   "item.page.download.button.command.line": "Instrukce pro stažení z příkazové řádky",
+  "item.page.download.command.copy": "Kopírovat do schránky",
+  "item.page.download.command.copied": "Zkopírováno!",
+  "item.page.download.command.close": "Zavřít",
 
   // "item.page.download.button.all.files.zip": "Download all files in item",
   "item.page.download.button.all.files.zip": "Stáhnout všechny soubory záznamu",

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -9203,7 +9203,7 @@
 
   // "item.page.download.button.command.line": "Download instructions for command line",
   "item.page.download.button.command.line": "Instrukce pro stažení z příkazové řádky",
-  "item.page.download.command.copy": "Kopírovat do schránky",
+  "item.page.download.command.copy": "Kopírovat",
   "item.page.download.command.copied": "Zkopírováno!",
   "item.page.download.command.close": "Zavřít",
 

--- a/src/assets/i18n/de.json5
+++ b/src/assets/i18n/de.json5
@@ -9308,9 +9308,6 @@
   // "item.page.download.button.command.line": "Download instructions for command line",
   // TODO New key - Add a translation
   "item.page.download.button.command.line": "Download instructions for command line",
-  "item.page.download.command.copy": "Copy to clipboard",
-  "item.page.download.command.copied": "Copied!",
-  "item.page.download.command.close": "Close",
 
   // "item.page.download.button.all.files.zip": "Download all files in item",
   // TODO New key - Add a translation

--- a/src/assets/i18n/de.json5
+++ b/src/assets/i18n/de.json5
@@ -9308,6 +9308,9 @@
   // "item.page.download.button.command.line": "Download instructions for command line",
   // TODO New key - Add a translation
   "item.page.download.button.command.line": "Download instructions for command line",
+  "item.page.download.command.copy": "Copy to clipboard",
+  "item.page.download.command.copied": "Copied!",
+  "item.page.download.command.close": "Close",
 
   // "item.page.download.button.all.files.zip": "Download all files in item",
   // TODO New key - Add a translation

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -6099,6 +6099,9 @@
   "item.page.files.head": "Files in this item",
 
   "item.page.download.button.command.line": "Download instructions for command line",
+  "item.page.download.command.copy": "Copy to clipboard",
+  "item.page.download.command.copied": "Copied!",
+  "item.page.download.command.close": "Close",
 
   "item.page.download.button.all.files.zip": "Download all files in item",
 


### PR DESCRIPTION
## Problem description
Updates the curl command generation to use the new backend endpoint GET /api/core/bitstreams/handle/{prefix}/{suffix}/{filename} instead of the non-existent /api/bitstream/{handle}/{seq}/{filename}.

Key changes:
- Uses correct backend endpoint path: /core/bitstreams/handle/{handle}/
- Removes unnecessary sequence index from URLs (uses filename only)
- Quotes the URL to prevent shell brace expansion

Fixes: #1210

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [x] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [x] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [x] Requested review from Copilot