### PR TITLE
Use `dspace:dspace` permissions for the assetstore - not ubuntu:ubuntu

### DIFF
--- a/.github/actions/import-db/action.yml
+++ b/.github/actions/import-db/action.yml
@@ -62,7 +62,7 @@ runs:
             echo Location of assetstore folder is empty. Not copping assetstore
           else
             docker cp ${{ inputs.ASSETSTORE }} dspace${{ inputs.INSTANCE }}:/dspace/
-            docker exec dspace${{ inputs.INSTANCE }} chown -R dspace:dspace /dspace/assetstore
+            docker exec -u root dspace${{ inputs.INSTANCE }} chown -R dspace:dspace /dspace/assetstore
           fi
           echo "====="
           cd ../

--- a/.github/actions/import-db/action.yml
+++ b/.github/actions/import-db/action.yml
@@ -62,6 +62,7 @@ runs:
             echo Location of assetstore folder is empty. Not copping assetstore
           else
             docker cp ${{ inputs.ASSETSTORE }} dspace${{ inputs.INSTANCE }}:/dspace/
+            docker exec dspace${{ inputs.INSTANCE }} chown -R dspace:dspace /dspace/assetstore
           fi
           echo "====="
           cd ../

--- a/build-scripts/run/start.sh
+++ b/build-scripts/run/start.sh
@@ -48,6 +48,7 @@ popd
 echo "====="
 echo "Copy assetstore"
 docker cp assetstore dspace${INSTANCE}:/dspace/
+docker exec dspace${INSTANCE} chown -R dspace:dspace /dspace/assetstore
 
 echo "====="
 echo "Finished start.sh"

--- a/build-scripts/run/start.sh
+++ b/build-scripts/run/start.sh
@@ -48,7 +48,7 @@ popd
 echo "====="
 echo "Copy assetstore"
 docker cp assetstore dspace${INSTANCE}:/dspace/
-docker exec dspace${INSTANCE} chown -R dspace:dspace /dspace/assetstore
+docker exec -u root dspace${INSTANCE} chown -R dspace:dspace /dspace/assetstore
 
 echo "====="
 echo "Finished start.sh"


### PR DESCRIPTION
## Problem description
docker cp in start.sh and import-db/action.yml copies the host's assetstore into the container, preserving the host's file ownership (ubuntu:ubuntu). Since erase-db deletes all Docker volumes first, the image's original dspace:dspace ownership is lost and replaced by the host copy.

**Fix**
Add chown after each docker cp:
```
docker exec dspace${INSTANCE} chown -R dspace:dspace /dspace/assetstore
```
Two places to patch:

build-scripts/run/start.sh — after the docker cp assetstore line
.github/actions/import-db/action.yml — after the docker cp $ASSETSTORE line

## Analysis
(Write here, if there is needed describe some specific problem. Erase it, when it is not needed.)
## Problems
(Write here, if some unexpected problems occur during solving issues. Erase it, when it is not needed.) 

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot