### PR TITLE
UFAL/Fix: preserve namespace in OAI link rewrite on static pages (#1226)

### DIFF
--- a/src/app/static-page/static-page.component.spec.ts
+++ b/src/app/static-page/static-page.component.spec.ts
@@ -60,7 +60,7 @@ describe('StaticPageComponent', () => {
 
   it('should rewrite OAI link with rest.baseUrl', async () => {
     const oaiHtml = '<a href="/server/oai/request?verb=ListSets">OAI</a>';
-    const { fixture, component } = await setupTest(oaiHtml, 'https://api.example.org/rest');
+    const { fixture, component } = await setupTest(oaiHtml, 'https://api.example.org/server');
 
     await component.ngOnInit();
     fixture.detectChanges();
@@ -83,18 +83,31 @@ describe('StaticPageComponent', () => {
 
   it('should avoid double slashes when rest.baseUrl ends with slash', async () => {
     const oaiHtml = '<a href="/server/oai/request?verb=ListRecords">OAI</a>';
-    const { fixture, component } = await setupTest(oaiHtml, 'https://api.example.org/rest/');
+    const { fixture, component } = await setupTest(oaiHtml, 'https://api.example.org/server/');
 
     await component.ngOnInit();
     fixture.detectChanges();
 
     expect(component.htmlContent.value).toContain('https://api.example.org/server/oai/request?verb=ListRecords');
-    expect(component.htmlContent.value).not.toContain('//server');
+    expect(component.htmlContent.value).not.toContain('//oai');
+  });
+
+  it('should include namespace in OAI link when rest.baseUrl has namespace prefix', async () => {
+    const oaiHtml = '<a href="/server/oai/request?verb=ListMetadataFormats">full list</a>';
+    const { fixture, component } = await setupTest(oaiHtml, 'https://api.example.org/repository/server');
+
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    const rewritten = 'https://api.example.org/repository/server/oai/request?verb=ListMetadataFormats';
+    expect(component.htmlContent.value).toContain(rewritten);
+    const anchor = fixture.nativeElement.querySelector('a');
+    expect(anchor.getAttribute('href')).toBe(rewritten);
   });
 
   it('should leave content unchanged when no OAI link is present', async () => {
     const otherHtml = '<a href="/server/other">Other</a>';
-    const { fixture, component } = await setupTest(otherHtml, 'https://api.example.org/rest');
+    const { fixture, component } = await setupTest(otherHtml, 'https://api.example.org/server');
 
     await component.ngOnInit();
     fixture.detectChanges();

--- a/src/app/static-page/static-page.component.ts
+++ b/src/app/static-page/static-page.component.ts
@@ -31,7 +31,7 @@ export class StaticPageComponent implements OnInit {
     let htmlContent = await this.htmlContentService.getHmtlContentByPathAndLocale(this.htmlFileName);
     if (isNotEmpty(htmlContent)) {
       const restBase = this.appConfig?.rest?.baseUrl;
-      const oaiUrl = restBase ? new URL('/server/oai', restBase).href : '/server/oai';
+      const oaiUrl = restBase ? restBase.replace(/\/+$/, '') + '/oai' : '/server/oai';
       htmlContent = htmlContent.replace(/href="\/server\/oai/gi, 'href="' + oaiUrl);
 
       this.htmlContent.next(htmlContent);


### PR DESCRIPTION
## Problem description
Fixes #1226

The OAI link rewrite in static pages used [new URL('/server/oai', restBase)](vscode-file://vscode-app/c:/Users/MilanMajchr%C3%A1k/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) which discarded the namespace prefix (e.g. /repository) from [rest.baseUrl](vscode-file://vscode-app/c:/Users/MilanMajchr%C3%A1k/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html). Replaced with direct string append so the full path is preserved.

Added test for namespace-prefixed baseUrl scenario.

## Analysis
(Write here, if there is needed describe some specific problem. Erase it, when it is not needed.)
## Problems
(Write here, if some unexpected problems occur during solving issues. Erase it, when it is not needed.) 

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot