### PR TITLE
ZCU-PUB/Partial match for community/collection search

### DIFF
--- a/src/app/shared/dso-selector/dso-selector/authorized-collection-selector/authorized-collection-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/dso-selector/authorized-collection-selector/authorized-collection-selector.component.spec.ts
@@ -11,25 +11,40 @@ import { createPaginatedList } from '../../../testing/utils.test';
 import { Collection } from '../../../../core/shared/collection.model';
 import { DSpaceObjectType } from '../../../../core/shared/dspace-object-type.model';
 import { NotificationsService } from '../../../notifications/notifications.service';
+import { DSONameService } from '../../../../core/breadcrumbs/dso-name.service';
 
 describe('AuthorizedCollectionSelectorComponent', () => {
   let component: AuthorizedCollectionSelectorComponent;
   let fixture: ComponentFixture<AuthorizedCollectionSelectorComponent>;
 
   let collectionService;
-  let collection;
-
+  let dsoNameService: jasmine.SpyObj<DSONameService>;
   let notificationsService: NotificationsService;
 
+  function createCollection(id: string, name: string): Collection {
+    return Object.assign(new Collection(), { id, name });
+  }
+
+  const collectionTest       = createCollection('col-test',      'test');
+  const collectionTestSuite  = createCollection('col-suite',     'test suite');
+  const collectionCollection = createCollection('col-collection', 'collection');
+
   beforeEach(waitForAsync(() => {
-    collection = Object.assign(new Collection(), {
-      id: 'authorized-collection'
-    });
-    collectionService = jasmine.createSpyObj('collectionService', {
-      getAuthorizedCollection: createSuccessfulRemoteDataObject$(createPaginatedList([collection])),
-      getAuthorizedCollectionByEntityType: createSuccessfulRemoteDataObject$(createPaginatedList([collection]))
-    });
+    dsoNameService = jasmine.createSpyObj('dsoNameService', ['getName']);
+    dsoNameService.getName.and.callFake((dso: any) => dso?.name ?? '');
+
     notificationsService = jasmine.createSpyObj('notificationsService', ['error']);
+
+    // Use callFake so createSuccessfulRemoteDataObject$ is called lazily at spy invocation time
+    // (not at setup time), avoiding issues with environment not being available during beforeEach.
+    collectionService = jasmine.createSpyObj('collectionService', ['getAuthorizedCollection', 'getAuthorizedCollectionByEntityType']);
+    collectionService.getAuthorizedCollection.and.callFake(() =>
+      createSuccessfulRemoteDataObject$(createPaginatedList([collectionTest]))
+    );
+    collectionService.getAuthorizedCollectionByEntityType.and.callFake(() =>
+      createSuccessfulRemoteDataObject$(createPaginatedList([collectionTest]))
+    );
+
     TestBed.configureTestingModule({
       declarations: [AuthorizedCollectionSelectorComponent, VarDirective],
       imports: [TranslateModule.forRoot(), RouterTestingModule.withRoutes([])],
@@ -37,6 +52,7 @@ describe('AuthorizedCollectionSelectorComponent', () => {
         { provide: SearchService, useValue: {} },
         { provide: CollectionDataService, useValue: collectionService },
         { provide: NotificationsService, useValue: notificationsService },
+        { provide: DSONameService, useValue: dsoNameService },
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
@@ -51,24 +67,60 @@ describe('AuthorizedCollectionSelectorComponent', () => {
 
   describe('search', () => {
     describe('when has no entity type', () => {
-      it('should call getAuthorizedCollection and return the authorized collection in a SearchResult', (done) => {
-      component.search('', 1).subscribe((resultRD) => {
+      it('should call getAuthorizedCollection and return the collection wrapped in a SearchResult', (done) => {
+        component.search('', 1).subscribe((resultRD) => {
           expect(collectionService.getAuthorizedCollection).toHaveBeenCalled();
-        expect(resultRD.payload.page.length).toEqual(1);
-        expect(resultRD.payload.page[0].indexableObject).toEqual(collection);
+          expect(resultRD.payload.page.length).toEqual(1);
+          expect(resultRD.payload.page[0].indexableObject).toEqual(collectionTest);
           done();
         });
       });
     });
 
     describe('when has entity type', () => {
-      it('should call getAuthorizedCollectionByEntityType and return the authorized collection in a SearchResult', (done) => {
-        component.entityType = 'test';
+      it('should call getAuthorizedCollectionByEntityType and return the collection wrapped in a SearchResult', (done) => {
+        component.entityType = 'Publication';
         fixture.detectChanges();
         component.search('', 1).subscribe((resultRD) => {
           expect(collectionService.getAuthorizedCollectionByEntityType).toHaveBeenCalled();
           expect(resultRD.payload.page.length).toEqual(1);
-          expect(resultRD.payload.page[0].indexableObject).toEqual(collection);
+          expect(resultRD.payload.page[0].indexableObject).toEqual(collectionTest);
+          done();
+        });
+      });
+    });
+
+    describe('title prefix filtering', () => {
+      beforeEach(() => {
+        // Override to return all three collections so we can test client-side filtering
+        collectionService.getAuthorizedCollection.and.callFake(() =>
+          createSuccessfulRemoteDataObject$(
+            createPaginatedList([collectionTest, collectionTestSuite, collectionCollection])
+          )
+        );
+      });
+
+      it('should return all collections when query is empty', (done) => {
+        component.search('', 1).subscribe((resultRD) => {
+          expect(resultRD.payload.page.length).toEqual(3);
+          done();
+        });
+      });
+
+      it('should return only collections whose title starts with the query', (done) => {
+        component.search('test', 1).subscribe((resultRD) => {
+          const names = resultRD.payload.page.map((r: any) => r.indexableObject.name);
+          expect(names).toEqual(['test', 'test suite']);
+          expect(names).not.toContain('collection');
+          done();
+        });
+      });
+
+      it('should be case-insensitive', (done) => {
+        component.search('TEST', 1).subscribe((resultRD) => {
+          const names = resultRD.payload.page.map((r: any) => r.indexableObject.name);
+          expect(names).toContain('test');
+          expect(names).toContain('test suite');
           done();
         });
       });

--- a/src/app/shared/dso-selector/dso-selector/authorized-collection-selector/authorized-collection-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/authorized-collection-selector/authorized-collection-selector.component.ts
@@ -11,7 +11,7 @@ import { DSpaceObject } from '../../../../core/shared/dspace-object.model';
 import { buildPaginatedList, PaginatedList } from '../../../../core/data/paginated-list.model';
 import { followLink } from '../../../utils/follow-link-config.model';
 import { RemoteData } from '../../../../core/data/remote-data';
-import { hasValue } from '../../../empty.util';
+import { hasValue, isNotEmpty } from '../../../empty.util';
 import { NotificationsService } from '../../../notifications/notifications.service';
 import { TranslateService } from '@ngx-translate/core';
 import { Collection } from '../../../../core/shared/collection.model';
@@ -74,9 +74,27 @@ export class AuthorizedCollectionSelectorComponent extends DSOSelectorComponent 
     }
     return searchListService$.pipe(
       getFirstCompletedRemoteData(),
-      map((rd) => Object.assign(new RemoteData(null, null, null, null), rd, {
-        payload: hasValue(rd.payload) ? buildPaginatedList(rd.payload.pageInfo, rd.payload.page.map((col) => Object.assign(new CollectionSearchResult(), { indexableObject: col }))) : null,
-      }))
+      map((rd) => {
+        if (!hasValue(rd.payload)) {
+          return Object.assign(new RemoteData(null, null, null, null), rd, { payload: null });
+        }
+        let searchResults = rd.payload.page.map((col) =>
+          Object.assign(new CollectionSearchResult(), { indexableObject: col })
+        );
+        // The findSubmitAuthorized endpoint does full-text search across all fields,
+        // which returns false positives. Apply client-side title prefix filtering
+        // to match the same behavior as community/collection creation selectors.
+        if (isNotEmpty(query)) {
+          const lowerQuery = query.trim().toLowerCase();
+          searchResults = searchResults.filter((result) => {
+            const name = this.dsoNameService.getName(result.indexableObject);
+            return hasValue(name) && name.toLowerCase().startsWith(lowerQuery);
+          });
+        }
+        return Object.assign(new RemoteData(null, null, null, null), rd, {
+          payload: buildPaginatedList(rd.payload.pageInfo, searchResults),
+        });
+      })
     );
   }
 }

--- a/src/app/shared/dso-selector/dso-selector/authorized-collection-selector/authorized-collection-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/authorized-collection-selector/authorized-collection-selector.component.ts
@@ -11,12 +11,15 @@ import { DSpaceObject } from '../../../../core/shared/dspace-object.model';
 import { buildPaginatedList, PaginatedList } from '../../../../core/data/paginated-list.model';
 import { followLink } from '../../../utils/follow-link-config.model';
 import { RemoteData } from '../../../../core/data/remote-data';
-import { hasValue, isNotEmpty } from '../../../empty.util';
+import { hasNoValue, hasValue, isNotEmpty } from '../../../empty.util';
 import { NotificationsService } from '../../../notifications/notifications.service';
 import { TranslateService } from '@ngx-translate/core';
 import { Collection } from '../../../../core/shared/collection.model';
 import { DSONameService } from '../../../../core/breadcrumbs/dso-name.service';
 import { FindListOptions } from '../../../../core/data/find-list-options.model';
+import { NotificationType } from '../../../notifications/models/notification-type';
+import { ListableNotificationObject } from '../../../object-list/listable-notification-object/listable-notification-object.model';
+import { LISTABLE_NOTIFICATION_OBJECT } from '../../../object-list/listable-notification-object/listable-notification-object.resource-type';
 
 @Component({
   selector: 'ds-authorized-collection-selector',
@@ -81,9 +84,6 @@ export class AuthorizedCollectionSelectorComponent extends DSOSelectorComponent 
         let searchResults = rd.payload.page.map((col) =>
           Object.assign(new CollectionSearchResult(), { indexableObject: col })
         );
-        // The findSubmitAuthorized endpoint does full-text search across all fields,
-        // which returns false positives. Apply client-side title prefix filtering
-        // to match the same behavior as community/collection creation selectors.
         if (isNotEmpty(query)) {
           const lowerQuery = query.trim().toLowerCase();
           searchResults = searchResults.filter((result) => {
@@ -96,5 +96,31 @@ export class AuthorizedCollectionSelectorComponent extends DSOSelectorComponent 
         });
       })
     );
+  }
+
+  /**
+   * Override updateList to derive hasNextPage from page-based pagination
+   * (currentPage < totalPages) instead of totalElements, because client-side
+   * filtering makes totalElements unreliable for next-page detection.
+   */
+  updateList(rd: RemoteData<PaginatedList<SearchResult<DSpaceObject>>>) {
+    this.loading = false;
+    const currentEntries = this.listEntries$.getValue();
+    if (rd.hasSucceeded) {
+      if (hasNoValue(currentEntries)) {
+        this.listEntries$.next(rd.payload.page);
+      } else {
+        this.listEntries$.next([...currentEntries, ...rd.payload.page]);
+      }
+      // Use page-based check: currentPage is 0-based, totalPages is 1-based
+      const pageInfo = rd.payload.pageInfo;
+      this.hasNextPage = hasValue(pageInfo) && pageInfo.currentPage < (pageInfo.totalPages - 1);
+    } else {
+      this.listEntries$.next([
+        ...(hasNoValue(currentEntries) ? [] : this.listEntries$.getValue()),
+        new ListableNotificationObject(NotificationType.Error, 'dso-selector.results-could-not-be-retrieved', LISTABLE_NOTIFICATION_OBJECT.value)
+      ]);
+      this.hasNextPage = false;
+    }
   }
 }

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.spec.ts
@@ -235,6 +235,24 @@ describe('DSOSelectorComponent', () => {
       });
     });
 
+    describe('for COMMUNITY/COLLECTION types', () => {
+      beforeEach(() => {
+        component.types = [DSpaceObjectType.COMMUNITY];
+      });
+
+      it('should pass through internal resource ID queries unchanged', () => {
+        component.search('search.resourceid:test-uuid-ford-sose', 1);
+
+        expect(searchService.search).toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            query: 'search.resourceid:test-uuid-ford-sose'
+          }),
+          null,
+          true
+        );
+      });
+    });
+
     describe('for ITEM types', () => {
       beforeEach(() => {
         component.types = [DSpaceObjectType.ITEM];

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.spec.ts
@@ -193,11 +193,11 @@ describe('DSOSelectorComponent', () => {
       });
 
       it('should escape special Lucene characters in query terms', () => {
-        component.search('test+query [with] special:chars', 1);
+        component.search('test+query [with] special:chars/paths', 1);
 
         expect(searchService.search).toHaveBeenCalledWith(
           jasmine.objectContaining({
-            query: 'dc.title:("test\\+query" AND "\\[with\\]" AND special\\:chars*)'
+            query: 'dc.title:("test\\+query" AND "\\[with\\]" AND special\\:chars\\/paths*)'
           }),
           null,
           true
@@ -288,12 +288,17 @@ describe('DSOSelectorComponent', () => {
         component.types = [DSpaceObjectType.COMMUNITY];
       });
 
-      it('should handle whitespace-only query', () => {
+      it('should handle whitespace-only query as empty query', () => {
+        component.sort = new SortOptions('dc.title', SortDirection.ASC);
         component.search('   ', 1);
 
         expect(searchService.search).toHaveBeenCalledWith(
           jasmine.objectContaining({
-            query: '   '
+            query: '',
+            sort: jasmine.objectContaining({
+              field: 'dc.title',
+              direction: SortDirection.ASC,
+            })
           }),
           null,
           true
@@ -301,11 +306,33 @@ describe('DSOSelectorComponent', () => {
       });
 
       it('should handle empty string query', () => {
+        component.sort = new SortOptions('dc.title', SortDirection.ASC);
         component.search('', 1);
 
         expect(searchService.search).toHaveBeenCalledWith(
           jasmine.objectContaining({
-            query: ''
+            query: '',
+            sort: jasmine.objectContaining({
+              field: 'dc.title',
+              direction: SortDirection.ASC,
+            })
+          }),
+          null,
+          true
+        );
+      });
+
+      it('should handle null query', () => {
+        component.sort = new SortOptions('dc.title', SortDirection.ASC);
+        component.search(null, 1);
+
+        expect(searchService.search).toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            query: '',
+            sort: jasmine.objectContaining({
+              field: 'dc.title',
+              direction: SortDirection.ASC,
+            })
           }),
           null,
           true

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.spec.ts
@@ -194,24 +194,6 @@ describe('DSOSelectorComponent', () => {
       });
     });
 
-    describe('for COMMUNITY/COLLECTION types', () => {
-      beforeEach(() => {
-        component.types = [DSpaceObjectType.COMMUNITY];
-      });
-
-      it('should pass through internal resource ID queries unchanged', () => {
-        component.search('search.resourceid:test-uuid-ford-sose', 1);
-
-        expect(searchService.search).toHaveBeenCalledWith(
-          jasmine.objectContaining({
-            query: 'search.resourceid:test-uuid-ford-sose'
-          }),
-          null,
-          true
-        );
-      });
-    });
-
     describe('for ITEM types', () => {
       beforeEach(() => {
         component.types = [DSpaceObjectType.ITEM];
@@ -235,14 +217,17 @@ describe('DSOSelectorComponent', () => {
         component.types = [DSpaceObjectType.COMMUNITY];
       });
 
-      it('should handle whitespace-only query with raw semantics', () => {
+      it('should treat whitespace-only query as empty and apply default sort', () => {
         component.sort = new SortOptions('dc.title', SortDirection.ASC);
         component.search('   ', 1);
 
         expect(searchService.search).toHaveBeenCalledWith(
           jasmine.objectContaining({
-            query: '   ',
-            sort: null
+            query: '',
+            sort: jasmine.objectContaining({
+              field: 'dc.title',
+              direction: SortDirection.ASC,
+            }),
           }),
           null,
           true

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.spec.ts
@@ -203,6 +203,19 @@ describe('DSOSelectorComponent', () => {
           true
         );
       });
+
+      it('should pass through internal resource ID queries unchanged', () => {
+        const resourceIdQuery = component.getCurrentDSOQuery();
+        component.search(resourceIdQuery, 1);
+
+        expect(searchService.search).toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            query: resourceIdQuery  // Should not be processed through title field logic
+          }),
+          null,
+          true
+        );
+      });
     });
 
     describe('for COLLECTION types', () => {
@@ -233,6 +246,19 @@ describe('DSOSelectorComponent', () => {
           true
         );
       });
+
+      it('should pass through internal resource ID queries unchanged', () => {
+        const resourceIdQuery = component.getCurrentDSOQuery();
+        component.search(resourceIdQuery, 1);
+
+        expect(searchService.search).toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            query: resourceIdQuery  // Should not be processed through title field logic
+          }),
+          null,
+          true
+        );
+      });
     });
 
     describe('for ITEM types', () => {
@@ -240,12 +266,12 @@ describe('DSOSelectorComponent', () => {
         component.types = [DSpaceObjectType.ITEM];
       });
 
-      it('should add wildcard for single character queries', () => {
+      it('should pass through single character queries unchanged', () => {
         component.search('a', 1);
 
         expect(searchService.search).toHaveBeenCalledWith(
           jasmine.objectContaining({
-            query: 'a*'
+            query: 'a'
           }),
           null,
           true
@@ -288,17 +314,14 @@ describe('DSOSelectorComponent', () => {
         component.types = [DSpaceObjectType.COMMUNITY];
       });
 
-      it('should handle whitespace-only query as empty query', () => {
+      it('should handle whitespace-only query with raw semantics', () => {
         component.sort = new SortOptions('dc.title', SortDirection.ASC);
         component.search('   ', 1);
 
         expect(searchService.search).toHaveBeenCalledWith(
           jasmine.objectContaining({
-            query: '',
-            sort: jasmine.objectContaining({
-              field: 'dc.title',
-              direction: SortDirection.ASC,
-            })
+            query: '   ',
+            sort: null  // Raw query semantics: whitespace is considered a query, so no default sort
           }),
           null,
           true

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.spec.ts
@@ -132,7 +132,7 @@ describe('DSOSelectorComponent', () => {
 
       expect(searchService.search).toHaveBeenCalledWith(
         jasmine.objectContaining({
-          query: undefined,
+          query: '',
           sort: jasmine.objectContaining({
             field: 'dc.title',
             direction: SortDirection.ASC,

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.spec.ts
@@ -158,6 +158,174 @@ describe('DSOSelectorComponent', () => {
     });
   });
 
+  describe('query processing', () => {
+    beforeEach(() => {
+      spyOn(searchService, 'search').and.callThrough();
+    });
+
+    describe('for COMMUNITY types', () => {
+      beforeEach(() => {
+        component.types = [DSpaceObjectType.COMMUNITY];
+      });
+
+      it('should create title field query with wildcard for single term', () => {
+        component.search('test', 1);
+
+        expect(searchService.search).toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            query: 'dc.title:test*'
+          }),
+          null,
+          true
+        );
+      });
+
+      it('should create grouped title field query for multiple terms with wildcard on last term', () => {
+        component.search('test community name', 1);
+
+        expect(searchService.search).toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            query: 'dc.title:("test" AND "community" AND name*)'
+          }),
+          null,
+          true
+        );
+      });
+
+      it('should escape special Lucene characters in query terms', () => {
+        component.search('test+query [with] special:chars', 1);
+
+        expect(searchService.search).toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            query: 'dc.title:("test\\+query" AND "\\[with\\]" AND special\\:chars*)'
+          }),
+          null,
+          true
+        );
+      });
+    });
+
+    describe('for COLLECTION types', () => {
+      beforeEach(() => {
+        component.types = [DSpaceObjectType.COLLECTION];
+      });
+
+      it('should create title field query with wildcard for single term', () => {
+        component.search('documents', 1);
+
+        expect(searchService.search).toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            query: 'dc.title:documents*'
+          }),
+          null,
+          true
+        );
+      });
+
+      it('should create grouped title field query for multiple terms', () => {
+        component.search('research papers collection', 1);
+
+        expect(searchService.search).toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            query: 'dc.title:("research" AND "papers" AND collection*)'
+          }),
+          null,
+          true
+        );
+      });
+    });
+
+    describe('for ITEM types', () => {
+      beforeEach(() => {
+        component.types = [DSpaceObjectType.ITEM];
+      });
+
+      it('should add wildcard for single character queries', () => {
+        component.search('a', 1);
+
+        expect(searchService.search).toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            query: 'a*'
+          }),
+          null,
+          true
+        );
+      });
+
+      it('should pass through multi-character queries unchanged', () => {
+        component.search('test query', 1);
+
+        expect(searchService.search).toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            query: 'test query'
+          }),
+          null,
+          true
+        );
+      });
+    });
+
+    describe('for mixed types (COMMUNITY and ITEM)', () => {
+      beforeEach(() => {
+        component.types = [DSpaceObjectType.COMMUNITY, DSpaceObjectType.ITEM];
+      });
+
+      it('should use title field search when communities are included', () => {
+        component.search('mixed search', 1);
+
+        expect(searchService.search).toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            query: 'dc.title:("mixed" AND search*)'
+          }),
+          null,
+          true
+        );
+      });
+    });
+
+    describe('edge cases', () => {
+      beforeEach(() => {
+        component.types = [DSpaceObjectType.COMMUNITY];
+      });
+
+      it('should handle whitespace-only query', () => {
+        component.search('   ', 1);
+
+        expect(searchService.search).toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            query: '   '
+          }),
+          null,
+          true
+        );
+      });
+
+      it('should handle empty string query', () => {
+        component.search('', 1);
+
+        expect(searchService.search).toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            query: ''
+          }),
+          null,
+          true
+        );
+      });
+
+      it('should trim whitespace and handle single term', () => {
+        component.search('  test  ', 1);
+
+        expect(searchService.search).toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            query: 'dc.title:test*'
+          }),
+          null,
+          true
+        );
+      });
+    });
+  });
+
   describe('when search returns an error', () => {
     beforeEach(() => {
       spyOn(searchService, 'search').and.returnValue(createFailedRemoteDataObject$());

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.spec.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.spec.ts
@@ -163,36 +163,12 @@ describe('DSOSelectorComponent', () => {
       spyOn(searchService, 'search').and.callThrough();
     });
 
-    describe('for COMMUNITY types', () => {
+    describe('for COMMUNITY/COLLECTION types', () => {
       beforeEach(() => {
         component.types = [DSpaceObjectType.COMMUNITY];
       });
 
-      it('should create title field query with wildcard for single term', () => {
-        component.search('test', 1);
-
-        expect(searchService.search).toHaveBeenCalledWith(
-          jasmine.objectContaining({
-            query: 'dc.title:test*'
-          }),
-          null,
-          true
-        );
-      });
-
-      it('should create grouped title field query for multiple terms with wildcard on last term', () => {
-        component.search('test community name', 1);
-
-        expect(searchService.search).toHaveBeenCalledWith(
-          jasmine.objectContaining({
-            query: 'dc.title:("test" AND "community" AND name*)'
-          }),
-          null,
-          true
-        );
-      });
-
-      it('should escape special Lucene characters in query terms', () => {
+      it('should create title field query with escaping and wildcards', () => {
         component.search('test+query [with] special:chars/paths', 1);
 
         expect(searchService.search).toHaveBeenCalledWith(
@@ -210,50 +186,7 @@ describe('DSOSelectorComponent', () => {
 
         expect(searchService.search).toHaveBeenCalledWith(
           jasmine.objectContaining({
-            query: resourceIdQuery  // Should not be processed through title field logic
-          }),
-          null,
-          true
-        );
-      });
-    });
-
-    describe('for COLLECTION types', () => {
-      beforeEach(() => {
-        component.types = [DSpaceObjectType.COLLECTION];
-      });
-
-      it('should create title field query with wildcard for single term', () => {
-        component.search('documents', 1);
-
-        expect(searchService.search).toHaveBeenCalledWith(
-          jasmine.objectContaining({
-            query: 'dc.title:documents*'
-          }),
-          null,
-          true
-        );
-      });
-
-      it('should create grouped title field query for multiple terms', () => {
-        component.search('research papers collection', 1);
-
-        expect(searchService.search).toHaveBeenCalledWith(
-          jasmine.objectContaining({
-            query: 'dc.title:("research" AND "papers" AND collection*)'
-          }),
-          null,
-          true
-        );
-      });
-
-      it('should pass through internal resource ID queries unchanged', () => {
-        const resourceIdQuery = component.getCurrentDSOQuery();
-        component.search(resourceIdQuery, 1);
-
-        expect(searchService.search).toHaveBeenCalledWith(
-          jasmine.objectContaining({
-            query: resourceIdQuery  // Should not be processed through title field logic
+            query: resourceIdQuery
           }),
           null,
           true
@@ -266,42 +199,12 @@ describe('DSOSelectorComponent', () => {
         component.types = [DSpaceObjectType.ITEM];
       });
 
-      it('should pass through single character queries unchanged', () => {
-        component.search('a', 1);
-
-        expect(searchService.search).toHaveBeenCalledWith(
-          jasmine.objectContaining({
-            query: 'a'
-          }),
-          null,
-          true
-        );
-      });
-
-      it('should pass through multi-character queries unchanged', () => {
+      it('should pass through queries unchanged', () => {
         component.search('test query', 1);
 
         expect(searchService.search).toHaveBeenCalledWith(
           jasmine.objectContaining({
             query: 'test query'
-          }),
-          null,
-          true
-        );
-      });
-    });
-
-    describe('for mixed types (COMMUNITY and ITEM)', () => {
-      beforeEach(() => {
-        component.types = [DSpaceObjectType.COMMUNITY, DSpaceObjectType.ITEM];
-      });
-
-      it('should use title field search when communities are included', () => {
-        component.search('mixed search', 1);
-
-        expect(searchService.search).toHaveBeenCalledWith(
-          jasmine.objectContaining({
-            query: 'dc.title:("mixed" AND search*)'
           }),
           null,
           true
@@ -321,53 +224,7 @@ describe('DSOSelectorComponent', () => {
         expect(searchService.search).toHaveBeenCalledWith(
           jasmine.objectContaining({
             query: '   ',
-            sort: null  // Raw query semantics: whitespace is considered a query, so no default sort
-          }),
-          null,
-          true
-        );
-      });
-
-      it('should handle empty string query', () => {
-        component.sort = new SortOptions('dc.title', SortDirection.ASC);
-        component.search('', 1);
-
-        expect(searchService.search).toHaveBeenCalledWith(
-          jasmine.objectContaining({
-            query: '',
-            sort: jasmine.objectContaining({
-              field: 'dc.title',
-              direction: SortDirection.ASC,
-            })
-          }),
-          null,
-          true
-        );
-      });
-
-      it('should handle null query', () => {
-        component.sort = new SortOptions('dc.title', SortDirection.ASC);
-        component.search(null, 1);
-
-        expect(searchService.search).toHaveBeenCalledWith(
-          jasmine.objectContaining({
-            query: '',
-            sort: jasmine.objectContaining({
-              field: 'dc.title',
-              direction: SortDirection.ASC,
-            })
-          }),
-          null,
-          true
-        );
-      });
-
-      it('should trim whitespace and handle single term', () => {
-        component.search('  test  ', 1);
-
-        expect(searchService.search).toHaveBeenCalledWith(
-          jasmine.objectContaining({
-            query: 'dc.title:test*'
+            sort: null
           }),
           null,
           true

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -227,15 +227,17 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
    * @param useCache Whether or not to use the cache
    */
   search(query: string, page: number, useCache: boolean = true): Observable<RemoteData<PaginatedList<SearchResult<DSpaceObject>>>> {
-    // Normalize query once and use consistently for both sort selection and query processing
-    const trimmedQuery = query?.trim() ?? '';
-    const hasQuery = isNotEmpty(trimmedQuery);
-    // default sort is only used when there is no query
+    // Keep raw query semantics aligned with other component logic (isEmpty/isNotEmpty checks)
+    const rawQuery = query ?? '';
+    const trimmedQuery = rawQuery.trim();
+    const hasQuery = isNotEmpty(rawQuery);
+
+    // default sort is only used when there is no query according to raw input semantics
     let effectiveSort = hasQuery ? null : this.sort;
 
-    // Enable partial matching by adding wildcard for any non-empty query
-    let processedQuery = trimmedQuery;
-    if (hasQuery) {
+    // Enable partial matching by adding wildcard for any trimmed non-empty query
+    let processedQuery = rawQuery;
+    if (isNotEmpty(trimmedQuery)) {
       // For communities and collections, search only at the beginning of titles
       if (this.types.includes(DSpaceObjectType.COMMUNITY) || this.types.includes(DSpaceObjectType.COLLECTION)) {
         // Use title field with prefix matching to match only at the beginning
@@ -254,12 +256,8 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
           processedQuery = `dc.title:(${allButLast} AND ${lastTerm}*)`;
         }
       } else {
-        // For items and other types, use the query as-is but consider wildcards for very short queries
-        if (trimmedQuery.length === 1) {
-          processedQuery = trimmedQuery + '*';
-        } else {
-          processedQuery = trimmedQuery;
-        }
+        // For items and other types, use the trimmed query as-is without wildcard modification
+        processedQuery = trimmedQuery;
       }
     }
 

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -121,6 +121,11 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
   @ViewChildren('listEntryElement') listElements: QueryList<ElementRef>;
 
   /**
+   * The Solr/Lucene field used for title-based prefix queries
+   */
+  protected readonly TITLE_FIELD = 'dc.title';
+
+  /**
    * Time to wait before sending a search request to the server when a user types something
    */
   debounceTime = 500;
@@ -335,11 +340,11 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
       const terms = escapedQuery.split(/\s+/).filter(term => term.length > 0);
 
       if (terms.length === 1) {
-        return `dc.title:${terms[0]}*`;
+        return `${this.TITLE_FIELD}:${terms[0]}*`;
       } else {
         const allButLast = terms.slice(0, -1).map(term => `"${term}"`).join(' AND ');
         const lastTerm = terms[terms.length - 1];
-        return `dc.title:(${allButLast} AND ${lastTerm}*)`;
+        return `${this.TITLE_FIELD}:(${allButLast} AND ${lastTerm}*)`;
       }
     }
     return query;

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -121,7 +121,7 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
   @ViewChildren('listEntryElement') listElements: QueryList<ElementRef>;
 
   /**
-   * The Solr/Lucene field used for title-based prefix queries
+   * Field used for title-based prefix queries
    */
   protected readonly TITLE_FIELD = 'dc.title';
 
@@ -243,9 +243,9 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
 
     let processedQuery = trimmedQuery;
     if (isNotEmpty(trimmedQuery)) {
-      // Bypass query rewriting for internal Solr field queries (e.g. search.resourceid:<uuid>)
-      const isInternalSolrQuery = /^\w[\w.]*:/.test(trimmedQuery);
-      if (isInternalSolrQuery) {
+      // Bypass query rewriting for internal field queries (e.g. search.resourceid:<uuid>)
+      const isInternalFieldQuery  = /^\w[\w.]*:/.test(trimmedQuery);
+      if (isInternalFieldQuery ) {
         processedQuery = trimmedQuery;
       } else if (this.types.includes(DSpaceObjectType.COMMUNITY) || this.types.includes(DSpaceObjectType.COLLECTION)) {
         processedQuery = this.buildTitlePrefixQuery(trimmedQuery);
@@ -336,7 +336,7 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
   protected buildTitlePrefixQuery(query: string): string {
     if (hasValue(query) && query.trim().length > 0) {
       const trimmedQuery = query.trim();
-      const escapedQuery = this.escapeLuceneSpecialCharacters(trimmedQuery);
+      const escapedQuery = this.escapeQuerySpecialCharacters(trimmedQuery);
       const terms = escapedQuery.split(/\s+/).filter(term => term.length > 0);
 
       if (terms.length === 1) {
@@ -351,12 +351,12 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Escapes special Lucene/Solr characters in user input to prevent query syntax errors
+   * Escapes special query characters in user input to prevent syntax errors
    * @param query The user input query to escape
    * @returns The escaped query string
    */
-  private escapeLuceneSpecialCharacters(query: string): string {
-    // Escape special Lucene characters: + - && || ! ( ) { } [ ] ^ " ~ * ? : \ /
+  private escapeQuerySpecialCharacters(query: string): string {
+    // Escape special characters used in query syntax
     return query.replace(/[+\-!(){}[\]^"~*?:\\\/]/g, '\\$&')
                 .replace(/&&/g, '\\&&')
                 .replace(/\|\|/g, '\\||');

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -242,11 +242,9 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
       const isInternalSolrQuery = /^\w[\w.]*:/.test(trimmedQuery);
       if (isInternalSolrQuery) {
         processedQuery = trimmedQuery;
-      // For communities and collections, search only at the beginning of titles
       } else if (this.types.includes(DSpaceObjectType.COMMUNITY) || this.types.includes(DSpaceObjectType.COLLECTION)) {
         processedQuery = this.buildTitlePrefixQuery(trimmedQuery);
       } else {
-        // For items and other types, use the trimmed query as-is without wildcard modification
         processedQuery = trimmedQuery;
       }
     }

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -238,7 +238,19 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
       if (this.types.includes(DSpaceObjectType.COMMUNITY) || this.types.includes(DSpaceObjectType.COLLECTION)) {
         // Use title field with prefix matching to match only at the beginning
         // This searches specifically in the title field for words that start with the query
-        processedQuery = `dc.title:${trimmedQuery}*`;
+        // Properly escape and group multi-term queries to ensure all terms are scoped to dc.title
+        const escapedQuery = this.escapeLuceneSpecialCharacters(trimmedQuery);
+        const terms = escapedQuery.split(/\s+/).filter(term => term.length > 0);
+
+        if (terms.length === 1) {
+          // Single term: apply wildcard directly
+          processedQuery = `dc.title:${terms[0]}*`;
+        } else {
+          // Multiple terms: group all terms and apply wildcard only to the last term
+          const allButLast = terms.slice(0, -1).map(term => `"${term}"`).join(' AND ');
+          const lastTerm = terms[terms.length - 1];
+          processedQuery = `dc.title:(${allButLast} AND ${lastTerm}*)`;
+        }
       } else {
         // For items and other types, use the query as-is but consider wildcards for very short queries
         if (trimmedQuery.length === 1) {
@@ -247,7 +259,6 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
           processedQuery = trimmedQuery;
         }
       }
-      console.log(`DSO Selector: Searching with query "${processedQuery}" for types:`, this.types);
     }
 
     return this.searchService.search(
@@ -320,6 +331,18 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
         this.updateList(rd);
       });
     }
+  }
+
+  /**
+   * Escapes special Lucene/Solr characters in user input to prevent query syntax errors
+   * @param query The user input query to escape
+   * @returns The escaped query string
+   */
+  private escapeLuceneSpecialCharacters(query: string): string {
+    // Escape special Lucene characters: + - && || ! ( ) { } [ ] ^ " ~ * ? : \ /
+    return query.replace(/[+\-!(){}[\]^"~*?:\\]/g, '\\$&')
+                .replace(/&&/g, '\\&&')
+                .replace(/\|\|/g, '\\||');
   }
 
   getName(listableObject: ListableObject): string {

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -234,7 +234,6 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
     let processedQuery = query;
     if (hasValue(query) && query.trim().length > 0) {
       const trimmedQuery = query.trim();
-      
       // For communities and collections, search only at the beginning of titles
       if (this.types.includes(DSpaceObjectType.COMMUNITY) || this.types.includes(DSpaceObjectType.COLLECTION)) {
         // Use title field with prefix matching to match only at the beginning
@@ -248,7 +247,6 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
           processedQuery = trimmedQuery;
         }
       }
-      
       console.log(`DSO Selector: Searching with query "${processedQuery}" for types:`, this.types);
     }
 

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -234,8 +234,13 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
     let processedQuery = query;
     if (hasValue(query) && query.trim().length > 0) {
       const trimmedQuery = query.trim();
+      // Bypass query rewriting for internal Solr field queries (e.g. search.resourceid:<uuid>)
+      // so that getCurrentDSOQuery() results are passed through unchanged.
+      const isInternalSolrQuery = /^\w[\w.]*:/.test(trimmedQuery);
+      if (isInternalSolrQuery) {
+        processedQuery = trimmedQuery;
       // For communities and collections, search only at the beginning of titles
-      if (this.types.includes(DSpaceObjectType.COMMUNITY) || this.types.includes(DSpaceObjectType.COLLECTION)) {
+      } else if (this.types.includes(DSpaceObjectType.COMMUNITY) || this.types.includes(DSpaceObjectType.COLLECTION)) {
         // Use title field with prefix matching to match only at the beginning
         // This searches specifically in the title field for words that start with the query
         // Properly escape and group multi-term queries to ensure all terms are scoped to dc.title

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -241,21 +241,7 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
         processedQuery = trimmedQuery;
       // For communities and collections, search only at the beginning of titles
       } else if (this.types.includes(DSpaceObjectType.COMMUNITY) || this.types.includes(DSpaceObjectType.COLLECTION)) {
-        // Use title field with prefix matching to match only at the beginning
-        // This searches specifically in the title field for words that start with the query
-        // Properly escape and group multi-term queries to ensure all terms are scoped to dc.title
-        const escapedQuery = this.escapeLuceneSpecialCharacters(trimmedQuery);
-        const terms = escapedQuery.split(/\s+/).filter(term => term.length > 0);
-
-        if (terms.length === 1) {
-          // Single term: apply wildcard directly
-          processedQuery = `dc.title:${terms[0]}*`;
-        } else {
-          // Multiple terms: group all terms and apply wildcard only to the last term
-          const allButLast = terms.slice(0, -1).map(term => `"${term}"`).join(' AND ');
-          const lastTerm = terms[terms.length - 1];
-          processedQuery = `dc.title:(${allButLast} AND ${lastTerm}*)`;
-        }
+        processedQuery = this.buildTitlePrefixQuery(trimmedQuery);
       } else {
         // For items and other types, use the query as-is but consider wildcards for very short queries
         if (trimmedQuery.length === 1) {
@@ -336,6 +322,30 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
         this.updateList(rd);
       });
     }
+  }
+
+  /**
+   * Builds a dc.title partial matching query with wildcard support.
+   * Single term: dc.title:term*
+   * Multiple terms: dc.title:("term1" AND term2*)
+   * @param query The raw user input query
+   * @returns The processed query string with dc.title prefix matching, or the original query if empty
+   */
+  protected buildTitlePrefixQuery(query: string): string {
+    if (hasValue(query) && query.trim().length > 0) {
+      const trimmedQuery = query.trim();
+      const escapedQuery = this.escapeLuceneSpecialCharacters(trimmedQuery);
+      const terms = escapedQuery.split(/\s+/).filter(term => term.length > 0);
+
+      if (terms.length === 1) {
+        return `dc.title:${terms[0]}*`;
+      } else {
+        const allButLast = terms.slice(0, -1).map(term => `"${term}"`).join(' AND ');
+        const lastTerm = terms[terms.length - 1];
+        return `dc.title:(${allButLast} AND ${lastTerm}*)`;
+      }
+    }
+    return query;
   }
 
   /**

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -229,9 +229,32 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
   search(query: string, page: number, useCache: boolean = true): Observable<RemoteData<PaginatedList<SearchResult<DSpaceObject>>>> {
     // default sort is only used when there is not query
     let efectiveSort = query ? null : this.sort;
+
+    // Enable partial matching by adding wildcard for any non-empty query
+    let processedQuery = query;
+    if (hasValue(query) && query.trim().length > 0) {
+      const trimmedQuery = query.trim();
+      
+      // For communities and collections, search only at the beginning of titles
+      if (this.types.includes(DSpaceObjectType.COMMUNITY) || this.types.includes(DSpaceObjectType.COLLECTION)) {
+        // Use title field with prefix matching to match only at the beginning
+        // This searches specifically in the title field for words that start with the query
+        processedQuery = `dc.title:${trimmedQuery}*`;
+      } else {
+        // For items and other types, use the query as-is but consider wildcards for very short queries
+        if (trimmedQuery.length === 1) {
+          processedQuery = trimmedQuery + '*';
+        } else {
+          processedQuery = trimmedQuery;
+        }
+      }
+      
+      console.log(`DSO Selector: Searching with query "${processedQuery}" for types:`, this.types);
+    }
+
     return this.searchService.search(
       new PaginatedSearchOptions({
-        query: query,
+        query: processedQuery,
         dsoTypes: this.types,
         pagination: Object.assign({}, this.defaultPagination, {
           currentPage: page

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -227,20 +227,15 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
    * @param useCache Whether or not to use the cache
    */
   search(query: string, page: number, useCache: boolean = true): Observable<RemoteData<PaginatedList<SearchResult<DSpaceObject>>>> {
-    // Keep raw query semantics aligned with other component logic (isEmpty/isNotEmpty checks)
     const rawQuery = query ?? '';
     const trimmedQuery = rawQuery.trim();
     const hasQuery = isNotEmpty(rawQuery);
 
-    // default sort is only used when there is no query according to raw input semantics
     let effectiveSort = hasQuery ? null : this.sort;
 
-    // Enable partial matching by adding wildcard for any trimmed non-empty query
     let processedQuery = rawQuery;
     if (isNotEmpty(trimmedQuery)) {
-      // For communities and collections, search only at the beginning of titles
       if (this.types.includes(DSpaceObjectType.COMMUNITY) || this.types.includes(DSpaceObjectType.COLLECTION)) {
-        // Use title field with prefix matching to match only at the beginning
         // This searches specifically in the title field for words that start with the query
         // Properly escape and group multi-term queries to ensure all terms are scoped to dc.title
         const escapedQuery = this.escapeLuceneSpecialCharacters(trimmedQuery);

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -231,12 +231,12 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
     const trimmedQuery = rawQuery.trim();
     const hasQuery = isNotEmpty(rawQuery);
 
-    // Enable partial matching by adding wildcard for any non-empty query
-    let processedQuery = query;
-    if (hasValue(query) && query.trim().length > 0) {
-      const trimmedQuery = query.trim();
+    // default sort is only used when there is no query
+    let effectiveSort = hasQuery ? null : this.sort;
+
+    let processedQuery = rawQuery;
+    if (isNotEmpty(trimmedQuery)) {
       // Bypass query rewriting for internal Solr field queries (e.g. search.resourceid:<uuid>)
-      // so that getCurrentDSOQuery() results are passed through unchanged.
       const isInternalSolrQuery = /^\w[\w.]*:/.test(trimmedQuery);
       if (isInternalSolrQuery) {
         processedQuery = trimmedQuery;

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -205,8 +205,10 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
       } else {
         this.listEntries$.next([...currentEntries, ...rd.payload.page]);
       }
-      // Check if there are more pages available after the current one
-      this.hasNextPage = rd.payload.totalElements > this.listEntries$.getValue().length;
+      // Check if the server reports a next page, using page-based comparison so that
+      // client-side filtering (which reduces list length without changing totalPages)
+      // does not cause repeated fetching past the server's last page.
+      this.hasNextPage = rd.payload.currentPage < rd.payload.totalPages;
     } else {
       this.listEntries$.next([...(hasNoValue(currentEntries) ? [] : this.listEntries$.getValue()), new ListableNotificationObject(NotificationType.Error, 'dso-selector.results-could-not-be-retrieved', LISTABLE_NOTIFICATION_OBJECT.value)]);
       this.hasNextPage = false;
@@ -229,12 +231,12 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
   search(query: string, page: number, useCache: boolean = true): Observable<RemoteData<PaginatedList<SearchResult<DSpaceObject>>>> {
     const rawQuery = query ?? '';
     const trimmedQuery = rawQuery.trim();
-    const hasQuery = isNotEmpty(rawQuery);
+    const hasQuery = isNotEmpty(trimmedQuery);
 
     // default sort is only used when there is no query
     let effectiveSort = hasQuery ? null : this.sort;
 
-    let processedQuery = rawQuery;
+    let processedQuery = trimmedQuery;
     if (isNotEmpty(trimmedQuery)) {
       // Bypass query rewriting for internal Solr field queries (e.g. search.resourceid:<uuid>)
       const isInternalSolrQuery = /^\w[\w.]*:/.test(trimmedQuery);

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -228,7 +228,7 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
    */
   search(query: string, page: number, useCache: boolean = true): Observable<RemoteData<PaginatedList<SearchResult<DSpaceObject>>>> {
     // default sort is only used when there is not query
-    let efectiveSort = query ? null : this.sort;
+    let effectiveSort = query ? null : this.sort;
 
     // Enable partial matching by adding wildcard for any non-empty query
     let processedQuery = query;
@@ -268,7 +268,7 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
         pagination: Object.assign({}, this.defaultPagination, {
           currentPage: page
         }),
-        sort: efectiveSort
+        sort: effectiveSort
       }),
       null,
       useCache,

--- a/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
+++ b/src/app/shared/dso-selector/dso-selector/dso-selector.component.ts
@@ -227,13 +227,15 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
    * @param useCache Whether or not to use the cache
    */
   search(query: string, page: number, useCache: boolean = true): Observable<RemoteData<PaginatedList<SearchResult<DSpaceObject>>>> {
-    // default sort is only used when there is not query
-    let effectiveSort = query ? null : this.sort;
+    // Normalize query once and use consistently for both sort selection and query processing
+    const trimmedQuery = query?.trim() ?? '';
+    const hasQuery = isNotEmpty(trimmedQuery);
+    // default sort is only used when there is no query
+    let effectiveSort = hasQuery ? null : this.sort;
 
     // Enable partial matching by adding wildcard for any non-empty query
-    let processedQuery = query;
-    if (hasValue(query) && query.trim().length > 0) {
-      const trimmedQuery = query.trim();
+    let processedQuery = trimmedQuery;
+    if (hasQuery) {
       // For communities and collections, search only at the beginning of titles
       if (this.types.includes(DSpaceObjectType.COMMUNITY) || this.types.includes(DSpaceObjectType.COLLECTION)) {
         // Use title field with prefix matching to match only at the beginning
@@ -340,7 +342,7 @@ export class DSOSelectorComponent implements OnInit, OnDestroy {
    */
   private escapeLuceneSpecialCharacters(query: string): string {
     // Escape special Lucene characters: + - && || ! ( ) { } [ ] ^ " ~ * ? : \ /
-    return query.replace(/[+\-!(){}[\]^"~*?:\\]/g, '\\$&')
+    return query.replace(/[+\-!(){}[\]^"~*?:\\\/]/g, '\\$&')
                 .replace(/&&/g, '\\&&')
                 .replace(/\|\|/g, '\\||');
   }


### PR DESCRIPTION
## Problem description
The DSO selector search only matched whole words, preventing users from finding communities/collections with partial text input (e.g., typing "t" wouldn't find "test" community).

**@vidiecan This is a potential upstream PR.**

## Solution
Implemented partial prefix matching for communities and collections using [dc.title:query*](vscode-file://vscode-app/c:/Users/MichaelaPaurikova/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) search format, enabling single character and partial text searches to find relevant results from the beginning of titles.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot