### PR TITLE
ZCU-PUB/Rest tests call

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,38 +70,13 @@ jobs:
     secrets: inherit
 
   rest-tests-after-deploy4:
-    runs-on: ubuntu-latest
     needs: playwright-after-deploy4
-    timeout-minutes: 120
-    steps:
-      - name: run rest-tests
-        run: |
-          curl -H "Accept: application/vnd.github.everest-preview+json" \
-          -H "Authorization: token ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}" \
-          --request POST \
-          https://api.github.com/repos/dataquest-dev/\
-          dspace-rest-test/actions/workflows/run_unittests.yml/dispatches \
-          --data "{\"ref\":\"refs/heads/master\"}" 2> /dev/null
-
-          # wait for it to start
-          sleep 30s
-
-          # get result of last job
-          RES=$(curl -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}" https://api.github.com/repos/dataquest-dev/dspace-rest-test/actions/workflows/run_unittests.yml/runs?per_page=1 2> /dev/null | jq .workflow_runs[0].conclusion)
-
-          # while job did not finish, sleep
-          while [[ $RES == 'null' ]]; do
-            sleep 10s
-            RES=$(curl -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}" https://api.github.com/repos/dataquest-dev/dspace-rest-test/actions/workflows/run_unittests.yml/runs?per_page=1 2> /dev/null | jq .workflow_runs[0].conclusion)
-          done;
-
-          echo $RES
-          # if last result is not success, return -1 and fail
-          if [[ $RES != \"success\" ]]; then
-            echo "rest-tests have failed! check appropriate action run"
-            exit 1
-          fi;
-
+    if: '!inputs.IMPORT'
+    uses: dataquest-dev/dspace-rest-test/.github/workflows/run_unittests.yml@master
+    with:
+      CUSTOMER: ${{ github.ref_name }}
+      URL: http://dev-5.pc:84/server/api
+    secrets: inherit
 
   playwright-after-import4:
     needs: import-4
@@ -110,37 +85,12 @@ jobs:
     secrets: inherit
 
   rest-tests-after-import4:
-    runs-on: ubuntu-latest
     needs: playwright-after-import4
-    timeout-minutes: 120
-    steps:
-      - name: run rest-tests
-        run: |
-          curl -H "Accept: application/vnd.github.everest-preview+json" \
-          -H "Authorization: token ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}" \
-          --request POST \
-          https://api.github.com/repos/dataquest-dev/\
-          dspace-rest-test/actions/workflows/run_unittests.yml/dispatches \
-          --data "{\"ref\":\"refs/heads/master\"}" 2> /dev/null
-
-          # wait for it to start
-          sleep 30s
-
-          # get result of last job
-          RES=$(curl -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}" https://api.github.com/repos/dataquest-dev/dspace-rest-test/actions/workflows/run_unittests.yml/runs?per_page=1 2> /dev/null | jq .workflow_runs[0].conclusion)
-
-          # while job did not finish, sleep
-          while [[ $RES == 'null' ]]; do
-            sleep 10s
-            RES=$(curl -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}" https://api.github.com/repos/dataquest-dev/dspace-rest-test/actions/workflows/run_unittests.yml/runs?per_page=1 2> /dev/null | jq .workflow_runs[0].conclusion)
-          done;
-
-          echo $RES
-          # if last result is not success, return -1 and fail
-          if [[ $RES != \"success\" ]]; then
-            echo "rest-tests have failed! check appropriate action run"
-            exit 1
-          fi;
+    uses: dataquest-dev/dspace-rest-test/.github/workflows/run_unittests.yml@master
+    with:
+      CUSTOMER: ${{ github.ref_name }}
+      URL: http://dev-5.pc:84/server/api
+    secrets: inherit
 
   import-4:
     runs-on: dspace-dep-1


### PR DESCRIPTION
## Problem description
Deploy should be update (how are the rest tests called)
Issue: https://github.com/dataquest-dev/dspace-customers/issues/467

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot