### PR TITLE
UFAL/Broken matomo tracking with custom dimensions

### DIFF
--- a/src/app/statistics/angulartics/dspace/view-tracker-resolver.service.spec.ts
+++ b/src/app/statistics/angulartics/dspace/view-tracker-resolver.service.spec.ts
@@ -1,0 +1,144 @@
+import { ViewTrackerResolverService } from './view-tracker-resolver.service';
+import { Angulartics2 } from 'angulartics2';
+import { ReferrerService } from '../../../core/services/referrer.service';
+import { ActivatedRouteSnapshot, ResolveEnd, Router, RouterStateSnapshot } from '@angular/router';
+import { of as observableOf, Subject } from 'rxjs';
+
+describe('ViewTrackerResolverService', () => {
+  let service: ViewTrackerResolverService;
+  let angulartics2: Angulartics2;
+  let referrerService: jasmine.SpyObj<ReferrerService>;
+  let router: any;
+  let routerEvents$: Subject<any>;
+
+  const mockDso = {
+    firstMetadataValue: jasmine.createSpy('firstMetadataValue').and.returnValue('http://hdl.handle.net/123456789/1'),
+  };
+
+  const mockReferrer = 'https://www.referrer.com';
+
+  beforeEach(() => {
+    routerEvents$ = new Subject();
+
+    angulartics2 = {
+      eventTrack: new Subject(),
+    } as any;
+
+    referrerService = jasmine.createSpyObj('ReferrerService', ['getReferrer']);
+    referrerService.getReferrer.and.returnValue(observableOf(mockReferrer));
+
+    router = {
+      events: routerEvents$.asObservable(),
+    };
+
+    service = new ViewTrackerResolverService(angulartics2, referrerService, router);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should include dc_identifier in event properties when dso has dc.identifier.uri metadata', () => {
+    const routeSnapshot = {
+      data: {
+        dso: {
+          payload: mockDso,
+        },
+      },
+    } as any as ActivatedRouteSnapshot;
+    const stateSnapshot = {} as RouterStateSnapshot;
+
+    let emittedEvent: any;
+    (angulartics2.eventTrack as Subject<any>).subscribe(event => {
+      emittedEvent = event;
+    });
+
+    service.resolve(routeSnapshot, stateSnapshot);
+
+    // Simulate ResolveEnd event to trigger the subscription
+    routerEvents$.next(new ResolveEnd(1, '/', '/', {} as any));
+
+    expect(emittedEvent).toBeDefined();
+    expect(emittedEvent.action).toBe('page_view');
+    expect(emittedEvent.properties.object).toBe(mockDso);
+    expect(emittedEvent.properties.referrer).toBe(mockReferrer);
+    expect(emittedEvent.properties.dc_identifier).toBe('http://hdl.handle.net/123456789/1');
+    expect(mockDso.firstMetadataValue).toHaveBeenCalledWith('dc.identifier.uri');
+  });
+
+  it('should set dc_identifier to undefined when dso does not have dc.identifier.uri metadata', () => {
+    const mockDsoWithoutMetadata = {
+      firstMetadataValue: jasmine.createSpy('firstMetadataValue').and.returnValue(undefined),
+    };
+
+    const routeSnapshot = {
+      data: {
+        dso: {
+          payload: mockDsoWithoutMetadata,
+        },
+      },
+    } as any as ActivatedRouteSnapshot;
+    const stateSnapshot = {} as RouterStateSnapshot;
+
+    let emittedEvent: any;
+    (angulartics2.eventTrack as Subject<any>).subscribe(event => {
+      emittedEvent = event;
+    });
+
+    service.resolve(routeSnapshot, stateSnapshot);
+    routerEvents$.next(new ResolveEnd(1, '/', '/', {} as any));
+
+    expect(emittedEvent).toBeDefined();
+    expect(emittedEvent.action).toBe('page_view');
+    expect(emittedEvent.properties.dc_identifier).toBeUndefined();
+  });
+
+  it('should handle missing dso gracefully (dc_identifier undefined)', () => {
+    const routeSnapshot = {
+      data: {
+        dso: {
+          payload: undefined,
+        },
+      },
+    } as any as ActivatedRouteSnapshot;
+    const stateSnapshot = {} as RouterStateSnapshot;
+
+    let emittedEvent: any;
+    (angulartics2.eventTrack as Subject<any>).subscribe(event => {
+      emittedEvent = event;
+    });
+
+    service.resolve(routeSnapshot, stateSnapshot);
+    routerEvents$.next(new ResolveEnd(1, '/', '/', {} as any));
+
+    expect(emittedEvent).toBeDefined();
+    expect(emittedEvent.action).toBe('page_view');
+    expect(emittedEvent.properties.dc_identifier).toBeUndefined();
+  });
+
+  it('should use custom dsoPath from route data when provided', () => {
+    const mockDsoCustom = {
+      firstMetadataValue: jasmine.createSpy('firstMetadataValue').and.returnValue('http://hdl.handle.net/custom/42'),
+    };
+
+    const routeSnapshot = {
+      data: {
+        dsoPath: 'myCustomDso',
+        myCustomDso: mockDsoCustom,
+      },
+    } as any as ActivatedRouteSnapshot;
+    const stateSnapshot = {} as RouterStateSnapshot;
+
+    let emittedEvent: any;
+    (angulartics2.eventTrack as Subject<any>).subscribe(event => {
+      emittedEvent = event;
+    });
+
+    service.resolve(routeSnapshot, stateSnapshot);
+    routerEvents$.next(new ResolveEnd(1, '/', '/', {} as any));
+
+    expect(emittedEvent).toBeDefined();
+    expect(emittedEvent.properties.object).toBe(mockDsoCustom);
+    expect(emittedEvent.properties.dc_identifier).toBe('http://hdl.handle.net/custom/42');
+  });
+});

--- a/src/app/statistics/angulartics/dspace/view-tracker-resolver.service.spec.ts
+++ b/src/app/statistics/angulartics/dspace/view-tracker-resolver.service.spec.ts
@@ -1,7 +1,7 @@
 import { ViewTrackerResolverService } from './view-tracker-resolver.service';
 import { Angulartics2 } from 'angulartics2';
 import { ReferrerService } from '../../../core/services/referrer.service';
-import { ActivatedRouteSnapshot, ResolveEnd, Router, RouterStateSnapshot } from '@angular/router';
+import { ActivatedRouteSnapshot, ResolveEnd, RouterStateSnapshot } from '@angular/router';
 import { of as observableOf, Subject } from 'rxjs';
 
 describe('ViewTrackerResolverService', () => {
@@ -10,15 +10,15 @@ describe('ViewTrackerResolverService', () => {
   let referrerService: jasmine.SpyObj<ReferrerService>;
   let router: any;
   let routerEvents$: Subject<any>;
-
-  const mockDso = {
-    firstMetadataValue: jasmine.createSpy('firstMetadataValue').and.returnValue('http://hdl.handle.net/123456789/1'),
-  };
+  let mockDso: { firstMetadataValue: jasmine.Spy };
 
   const mockReferrer = 'https://www.referrer.com';
 
   beforeEach(() => {
     routerEvents$ = new Subject();
+    mockDso = {
+      firstMetadataValue: jasmine.createSpy('firstMetadataValue').and.returnValue('http://hdl.handle.net/123456789/1'),
+    };
 
     angulartics2 = {
       eventTrack: new Subject(),

--- a/src/app/statistics/angulartics/dspace/view-tracker-resolver.service.ts
+++ b/src/app/statistics/angulartics/dspace/view-tracker-resolver.service.ts
@@ -29,11 +29,14 @@ export class ViewTrackerResolverService {
       switchMap(() =>
         this.referrerService.getReferrer().pipe(take(1))))
       .subscribe((referrer: string) => {
+        const object = this.getNestedProperty(routeSnapshot.data, dsoPath);
+        const dc_identifier = object?.firstMetadataValue?.('dc.identifier.uri');
         this.angulartics2.eventTrack.next({
           action: 'page_view',
           properties: {
-            object: this.getNestedProperty(routeSnapshot.data, dsoPath),
+            object,
             referrer,
+            dc_identifier,
           },
         });
       });


### PR DESCRIPTION
## Problem description

When `ViewTrackerComponent` was replaced by `ViewTrackerResolverService` (route resolver), the `dc_identifier` property was dropped from angulartics2 event properties. This broke Matomo custom dimension tracking — `browser-init.service.ts` checks `properties.dc_identifier` to call `setCustomDimension`, but it was always `undefined`.

## Fix

Extract `dc.identifier.uri` from the resolved DSO and include it as `dc_identifier` in the event properties, restoring the behavior of the original component.

## Analysis
(Write here, if there is needed describe some specific problem. Erase it, when it is not needed.)
## Problems
(Write here, if some unexpected problems occur during solving issues. Erase it, when it is not needed.) 

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot