### PR TITLE
ZCU-DATA/Cherry-pick Fix duplicate id

### DIFF
--- a/cypress/e2e/header.cy.ts
+++ b/cypress/e2e/header.cy.ts
@@ -12,7 +12,6 @@ describe('Header', () => {
         // testA11y({
         //     include: ['ds-header'],
         //     exclude: [
-        //         ['#search-navbar-container'], // search in navbar has duplicative ID. Will be fixed in #1174
         //         ['.dropdownLogin']            // "Log in" link has color contrast issues. Will be fixed in #1149
         //     ],
         // });

--- a/src/app/search-navbar/search-navbar.component.html
+++ b/src/app/search-navbar/search-navbar.component.html
@@ -1,4 +1,4 @@
-<div id="search-navbar-container" [title]="'nav.search' | translate" (dsClickOutside)="collapse()">
+<div class="search-navbar-container" [title]="'nav.search' | translate" (dsClickOutside)="collapse()">
   <div class="d-inline-block position-relative">
     <form [formGroup]="searchForm" (ngSubmit)="onSubmit(searchForm.value)" autocomplete="on" class="d-flex">
       <input #searchInput [@toggleAnimation]="isExpanded" [attr.aria-label]="('nav.search' | translate)" name="query"

--- a/src/app/search-navbar/search-navbar.component.spec.ts
+++ b/src/app/search-navbar/search-navbar.component.spec.ts
@@ -72,7 +72,7 @@ describe('SearchNavbarComponent', () => {
       spyOn(component, 'expand').and.callThrough();
       spyOn(component, 'onSubmit').and.callThrough();
       spyOn(router, 'navigate');
-      const searchIcon = fixture.debugElement.query(By.css('#search-navbar-container form .submit-icon'));
+      const searchIcon = fixture.debugElement.query(By.css('.search-navbar-container form .submit-icon'));
       searchIcon.triggerEventHandler('click', {
         preventDefault: () => {/**/
         }
@@ -88,7 +88,7 @@ describe('SearchNavbarComponent', () => {
     describe('empty query', () => {
       describe('press submit button', () => {
         beforeEach(fakeAsync(() => {
-          const searchIcon = fixture.debugElement.query(By.css('#search-navbar-container form .submit-icon'));
+          const searchIcon = fixture.debugElement.query(By.css('.search-navbar-container form .submit-icon'));
           searchIcon.triggerEventHandler('click', {
             preventDefault: () => {/**/
             }
@@ -109,14 +109,14 @@ describe('SearchNavbarComponent', () => {
       beforeEach(async () => {
         await fixture.whenStable();
         fixture.detectChanges();
-        searchInput = fixture.debugElement.query(By.css('#search-navbar-container form input'));
+        searchInput = fixture.debugElement.query(By.css('.search-navbar-container form input'));
         searchInput.nativeElement.value = 'test';
         searchInput.nativeElement.dispatchEvent(new Event('input'));
         fixture.detectChanges();
       });
       describe('press submit button', () => {
         beforeEach(fakeAsync(() => {
-          const searchIcon = fixture.debugElement.query(By.css('#search-navbar-container form .submit-icon'));
+          const searchIcon = fixture.debugElement.query(By.css('.search-navbar-container form .submit-icon'));
           searchIcon.triggerEventHandler('click', null);
           tick();
           fixture.detectChanges();

--- a/src/app/submission/sections/clarin-license-resource/section-license.component.html
+++ b/src/app/submission/sections/clarin-license-resource/section-license.component.html
@@ -64,11 +64,11 @@
               <li class="dropdown-item clarin-dropdown-item pt-2" value="0" (click)="selectLicense(0)">
                 <b>{{'submission.sections.clarin-license.head.license-select-default-value' | translate}}</b>
               </li>
-              <li class="dropdown-item clarin-dropdown-item pt-2"
+              <li class="dropdown-item clarin-dropdown-item pt-2 license-option"
                   *ngFor="let license of filteredLicenses4Selector"
                   (click)="selectLicense(license.id)"
                   [value]="license.id"
-                  id="license_option">
+                  [id]="'license_option_' + license.id">
                 <span [class]="'label label-default label-' + license.licenseLabel">{{license.licenseLabel}}</span>
                 <b class="pl-1">{{license.name}}</b>
               </li>


### PR DESCRIPTION
## Problem description
Found duplicate id in html
```
Error: Found duplicate IDs on http://dev-5.pc:89/home and many other subpages:
    search-navbar-container (2x)

    expect(received).toHaveLength(expected)

    Expected length: 0
    Received length: 1
    Received array:  ["search-navbar-container (2x)"]
```

and

```
Error: Found duplicate IDs on http://dev-5.pc:89/workspaceitems/1240/edit:
    search-navbar-container (2x)
    license_option (34x)

    expect(received).toHaveLength(expected)

    Expected length: 0
    Received length: 2
    Received array:  ["search-navbar-container (2x)", "license_option (34x)"]
```
### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [x] Requested review from Copilot