### PR TITLE
UFAL/Use gh cli dispatch for rest tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,33 +80,33 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # - uses: ./.github/actions/erase-db
-      #   if: inputs.ERASE_DB
-      #   with:
-      #     INSTANCE: ${{ env.INSTANCE }}
-      #     NAME: dspace-${{ env.INSTANCE }}
+      - uses: ./.github/actions/erase-db
+        if: inputs.ERASE_DB
+        with:
+          INSTANCE: ${{ env.INSTANCE }}
+          NAME: dspace-${{ env.INSTANCE }}
 
-      # - name: deploy dspace-import on dev-5
-      #   working-directory: build-scripts/run/
-      #   run: |
-      #     ./start.sh dspace-$INSTANCE
-      #     cd ../..
-      #     # this is not necessary, since extra.yml doesn't contain any new images that weren't pulled within script above
-      #     # docker compose --env-file $ENVFILE -p dspace-$INSTANCE -f docker/docker-compose.yml -f docker/docker-compose-rest.yml -f /opt/dspace-envs/8/extra.yml pull
-      #     docker compose --env-file $ENVFILE -p dspace-$INSTANCE -f docker/docker-compose.yml -f docker/docker-compose-rest.yml -f /opt/dspace-envs/8/extra.yml up -d --no-build
+      - name: deploy dspace-import on dev-5
+        working-directory: build-scripts/run/
+        run: |
+          ./start.sh dspace-$INSTANCE
+          cd ../..
+          # this is not necessary, since extra.yml doesn't contain any new images that weren't pulled within script above
+          # docker compose --env-file $ENVFILE -p dspace-$INSTANCE -f docker/docker-compose.yml -f docker/docker-compose-rest.yml -f /opt/dspace-envs/8/extra.yml pull
+          docker compose --env-file $ENVFILE -p dspace-$INSTANCE -f docker/docker-compose.yml -f docker/docker-compose-rest.yml -f /opt/dspace-envs/8/extra.yml up -d --no-build
 
-      #     # this must be here and not in the start.sh, because extra.yml replaces dspace container
-      #     ## !!!!! please remove this section if you do not want handle server !!!!!!!
-      #     echo "====="
-      #     echo "installing handle server"
-      #     docker exec dspace${INSTANCE} /dspace/bin/make-handle-config
-      #     echo "made handle config:"
-      #     docker exec dspace${INSTANCE} cat /dspace/handle-server/config.dct
-      #     docker exec dspace${INSTANCE} /dspace/bin/start-handle-server
-      #     echo "started handle server"
-      #     # this seems to be the easiest solution for now
-      #     docker restart dockerized-nginx-with-shibboleth-nginx-1
-      #     /bin/bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://dev-5.pc:8$INSTANCE/repository/server/api)" != "200" ]]; do sleep 5; done'
+          # this must be here and not in the start.sh, because extra.yml replaces dspace container
+          ## !!!!! please remove this section if you do not want handle server !!!!!!!
+          echo "====="
+          echo "installing handle server"
+          docker exec dspace${INSTANCE} /dspace/bin/make-handle-config
+          echo "made handle config:"
+          docker exec dspace${INSTANCE} cat /dspace/handle-server/config.dct
+          docker exec dspace${INSTANCE} /dspace/bin/start-handle-server
+          echo "started handle server"
+          # this seems to be the easiest solution for now
+          docker restart dockerized-nginx-with-shibboleth-nginx-1
+          /bin/bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://dev-5.pc:8$INSTANCE/repository/server/api)" != "200" ]]; do sleep 5; done'
 
 
   import-5:
@@ -193,16 +193,15 @@ jobs:
           echo "dspace healthcheck:"
           docker exec $DNAME /bin/bash -c "cd /dspace/bin && ./dspace healthcheck -v"
 
-  # playwright-after-deploy8:
-  #   needs: deploy-8
-  #   if: '!inputs.IMPORT'
-  #   uses: ./.github/workflows/playwright-tests.yml
-  #   secrets: inherit
+  playwright-after-deploy8:
+    needs: deploy-8
+    if: '!inputs.IMPORT'
+    uses: ./.github/workflows/playwright-tests.yml
+    secrets: inherit
 
   rest-tests-after-deploy8:
     runs-on: ubuntu-latest
-    # needs: playwright-after-deploy8
-    needs: deploy-8
+    needs: playwright-after-deploy8
     if: '!inputs.IMPORT'
     timeout-minutes: 120
     env:
@@ -312,6 +311,6 @@ jobs:
             exit 1
           fi
 
-          # Watch the run until it completes (polls every 30s, shows live status)
+          # Watch the run until it completes
           echo "Watching run: https://github.com/$REPO/actions/runs/$RUN_ID"
           gh run watch "$RUN_ID" --repo "$REPO" --interval 30 --exit-status

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -212,46 +212,22 @@ jobs:
           REPO="dataquest-dev/dspace-rest-test"
           WORKFLOW="run_unittests.yml"
 
-          # Record time before dispatch to find the correct run later
-          TRIGGER_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          echo "Triggering REST tests at $TRIGGER_TIME"
-
-          # Trigger the workflow with inputs
           gh workflow run "$WORKFLOW" \
             --repo "$REPO" \
             --ref master \
             -f CUSTOMER="${{ github.ref_name }}" \
             -f URL="http://dev-5.pc:88/repository/server/api"
 
-          echo "Workflow dispatch triggered, waiting for run to appear..."
           sleep 15
 
-          # Find the run we just triggered
-          RUN_ID=""
-          for i in $(seq 1 12); do
-            RUN_ID=$(gh run list \
-              --repo "$REPO" \
-              --workflow "$WORKFLOW" \
-              --event workflow_dispatch \
-              --created ">=$TRIGGER_TIME" \
-              --limit 1 \
-              --json databaseId,createdAt \
-              --jq 'sort_by(.createdAt) | .[0].databaseId // empty')
+          RUN_ID=$(gh run list \
+            --repo "$REPO" \
+            --workflow "$WORKFLOW" \
+            --event workflow_dispatch \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId')
 
-            if [[ -n "$RUN_ID" ]]; then
-              echo "Found workflow run: $RUN_ID"
-              break
-            fi
-            echo "Attempt $i: Run not found yet, waiting 15s..."
-            sleep 15
-          done
-
-          if [[ -z "$RUN_ID" ]]; then
-            echo "::error::Could not find the triggered workflow run after 3 minutes"
-            exit 1
-          fi
-
-          # Watch the run until it completes (polls every 30s, shows live status)
           echo "Watching run: https://github.com/$REPO/actions/runs/$RUN_ID"
           gh run watch "$RUN_ID" --repo "$REPO" --interval 30 --exit-status
 
@@ -269,50 +245,26 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}
     steps:
-      - name: Trigger and watch REST tests
+      - name: run rest-tests
         run: |
           REPO="dataquest-dev/dspace-rest-test"
           WORKFLOW="run_unittests.yml"
 
-          # Record time before dispatch to find the correct run later
-          TRIGGER_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          echo "Triggering REST tests at $TRIGGER_TIME"
-
-          # Trigger the workflow with inputs
           gh workflow run "$WORKFLOW" \
             --repo "$REPO" \
             --ref master \
             -f CUSTOMER="${{ github.ref_name }}" \
             -f URL="http://dev-5.pc:88/repository/server/api"
 
-          echo "Workflow dispatch triggered, waiting for run to appear..."
           sleep 15
 
-          # Find the run we just triggered (oldest after TRIGGER_TIME)
-          RUN_ID=""
-          for i in $(seq 1 12); do
-            RUN_ID=$(gh run list \
-              --repo "$REPO" \
-              --workflow "$WORKFLOW" \
-              --event workflow_dispatch \
-              --created ">=$TRIGGER_TIME" \
-              --limit 1 \
-              --json databaseId,createdAt \
-              --jq 'sort_by(.createdAt) | .[0].databaseId // empty')
+          RUN_ID=$(gh run list \
+            --repo "$REPO" \
+            --workflow "$WORKFLOW" \
+            --event workflow_dispatch \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId')
 
-            if [[ -n "$RUN_ID" ]]; then
-              echo "Found workflow run: $RUN_ID"
-              break
-            fi
-            echo "Attempt $i: Run not found yet, waiting 15s..."
-            sleep 15
-          done
-
-          if [[ -z "$RUN_ID" ]]; then
-            echo "::error::Could not find the triggered workflow run after 3 minutes"
-            exit 1
-          fi
-
-          # Watch the run until it completes
           echo "Watching run: https://github.com/$REPO/actions/runs/$RUN_ID"
           gh run watch "$RUN_ID" --repo "$REPO" --interval 30 --exit-status

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,33 +80,33 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: ./.github/actions/erase-db
-        if: inputs.ERASE_DB
-        with:
-          INSTANCE: ${{ env.INSTANCE }}
-          NAME: dspace-${{ env.INSTANCE }}
+      # - uses: ./.github/actions/erase-db
+      #   if: inputs.ERASE_DB
+      #   with:
+      #     INSTANCE: ${{ env.INSTANCE }}
+      #     NAME: dspace-${{ env.INSTANCE }}
 
-      - name: deploy dspace-import on dev-5
-        working-directory: build-scripts/run/
-        run: |
-          ./start.sh dspace-$INSTANCE
-          cd ../..
-          # this is not necessary, since extra.yml doesn't contain any new images that weren't pulled within script above
-          # docker compose --env-file $ENVFILE -p dspace-$INSTANCE -f docker/docker-compose.yml -f docker/docker-compose-rest.yml -f /opt/dspace-envs/8/extra.yml pull
-          docker compose --env-file $ENVFILE -p dspace-$INSTANCE -f docker/docker-compose.yml -f docker/docker-compose-rest.yml -f /opt/dspace-envs/8/extra.yml up -d --no-build
+      # - name: deploy dspace-import on dev-5
+      #   working-directory: build-scripts/run/
+      #   run: |
+      #     ./start.sh dspace-$INSTANCE
+      #     cd ../..
+      #     # this is not necessary, since extra.yml doesn't contain any new images that weren't pulled within script above
+      #     # docker compose --env-file $ENVFILE -p dspace-$INSTANCE -f docker/docker-compose.yml -f docker/docker-compose-rest.yml -f /opt/dspace-envs/8/extra.yml pull
+      #     docker compose --env-file $ENVFILE -p dspace-$INSTANCE -f docker/docker-compose.yml -f docker/docker-compose-rest.yml -f /opt/dspace-envs/8/extra.yml up -d --no-build
 
-          # this must be here and not in the start.sh, because extra.yml replaces dspace container
-          ## !!!!! please remove this section if you do not want handle server !!!!!!!
-          echo "====="
-          echo "installing handle server"
-          docker exec dspace${INSTANCE} /dspace/bin/make-handle-config
-          echo "made handle config:"
-          docker exec dspace${INSTANCE} cat /dspace/handle-server/config.dct
-          docker exec dspace${INSTANCE} /dspace/bin/start-handle-server
-          echo "started handle server"
-          # this seems to be the easiest solution for now
-          docker restart dockerized-nginx-with-shibboleth-nginx-1
-          /bin/bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://dev-5.pc:8$INSTANCE/repository/server/api)" != "200" ]]; do sleep 5; done'
+      #     # this must be here and not in the start.sh, because extra.yml replaces dspace container
+      #     ## !!!!! please remove this section if you do not want handle server !!!!!!!
+      #     echo "====="
+      #     echo "installing handle server"
+      #     docker exec dspace${INSTANCE} /dspace/bin/make-handle-config
+      #     echo "made handle config:"
+      #     docker exec dspace${INSTANCE} cat /dspace/handle-server/config.dct
+      #     docker exec dspace${INSTANCE} /dspace/bin/start-handle-server
+      #     echo "started handle server"
+      #     # this seems to be the easiest solution for now
+      #     docker restart dockerized-nginx-with-shibboleth-nginx-1
+      #     /bin/bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://dev-5.pc:8$INSTANCE/repository/server/api)" != "200" ]]; do sleep 5; done'
 
 
   import-5:
@@ -193,40 +193,46 @@ jobs:
           echo "dspace healthcheck:"
           docker exec $DNAME /bin/bash -c "cd /dspace/bin && ./dspace healthcheck -v"
 
-  playwright-after-deploy8:
-    needs: deploy-8
-    if: '!inputs.IMPORT'
-    uses: ./.github/workflows/playwright-tests.yml
-    secrets: inherit
+  # playwright-after-deploy8:
+  #   needs: deploy-8
+  #   if: '!inputs.IMPORT'
+  #   uses: ./.github/workflows/playwright-tests.yml
+  #   secrets: inherit
 
   rest-tests-after-deploy8:
     runs-on: ubuntu-latest
-    needs: playwright-after-deploy8
+    # needs: playwright-after-deploy8
+    needs: deploy-8
     if: '!inputs.IMPORT'
     timeout-minutes: 120
     env:
       GH_TOKEN: ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}
+      REPO: dataquest-dev/dspace-rest-test
+      WORKFLOW: run_unittests.yml
     steps:
       - name: run rest-tests
         run: |
-          REPO="dataquest-dev/dspace-rest-test"
-          WORKFLOW="run_unittests.yml"
-
-          gh workflow run "$WORKFLOW" \
+          OUTPUT=$(gh workflow run "$WORKFLOW" \
             --repo "$REPO" \
             --ref master \
             -f CUSTOMER="${{ github.ref_name }}" \
-            -f URL="http://dev-5.pc:88/repository/server/api"
+            -f URL="http://dev-5.pc:88/repository/server/api" 2>&1)
+
+          echo "$OUTPUT"
+
+          RUN_ID=$(echo "$OUTPUT" | grep -oE '/runs/[0-9]+' | grep -oE '[0-9]+')
+
+          echo "Run ID: $RUN_ID"
 
           sleep 15
 
-          RUN_ID=$(gh run list \
-            --repo "$REPO" \
-            --workflow "$WORKFLOW" \
-            --event workflow_dispatch \
-            --limit 1 \
-            --json databaseId \
-            --jq '.[0].databaseId')
+          # RUN_ID=$(gh run list \
+          #   --repo "$REPO" \
+          #   --workflow "$WORKFLOW" \
+          #   --event workflow_dispatch \
+          #   --limit 1 \
+          #   --json databaseId \
+          #   --jq '.[0].databaseId')
 
           echo "Watching run: https://github.com/$REPO/actions/runs/$RUN_ID"
           gh run watch "$RUN_ID" --repo "$REPO" --interval 30 --exit-status
@@ -244,12 +250,11 @@ jobs:
     timeout-minutes: 120
     env:
       GH_TOKEN: ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}
+      REPO: dataquest-dev/dspace-rest-test
+      WORKFLOW: run_unittests.yml
     steps:
       - name: run rest-tests
         run: |
-          REPO="dataquest-dev/dspace-rest-test"
-          WORKFLOW="run_unittests.yml"
-
           gh workflow run "$WORKFLOW" \
             --repo "$REPO" \
             --ref master \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -218,21 +218,7 @@ jobs:
             -f CUSTOMER="${{ github.ref_name }}" \
             -f URL="http://dev-5.pc:88/repository/server/api" 2>&1)
 
-          echo "$OUTPUT"
-
           RUN_ID=$(echo "$OUTPUT" | grep -oE '/runs/[0-9]+' | grep -oE '[0-9]+')
-
-          echo "Run ID: $RUN_ID"
-
-          sleep 15
-
-          # RUN_ID=$(gh run list \
-          #   --repo "$REPO" \
-          #   --workflow "$WORKFLOW" \
-          #   --event workflow_dispatch \
-          #   --limit 1 \
-          #   --json databaseId \
-          #   --jq '.[0].databaseId')
 
           echo "Watching run: https://github.com/$REPO/actions/runs/$RUN_ID"
           gh run watch "$RUN_ID" --repo "$REPO" --interval 30 --exit-status
@@ -255,21 +241,13 @@ jobs:
     steps:
       - name: run rest-tests
         run: |
-          gh workflow run "$WORKFLOW" \
+          OUTPUT=$(gh workflow run "$WORKFLOW" \
             --repo "$REPO" \
             --ref master \
             -f CUSTOMER="${{ github.ref_name }}" \
-            -f URL="http://dev-5.pc:88/repository/server/api"
+            -f URL="http://dev-5.pc:88/repository/server/api" 2>&1)
 
-          sleep 15
-
-          RUN_ID=$(gh run list \
-            --repo "$REPO" \
-            --workflow "$WORKFLOW" \
-            --event workflow_dispatch \
-            --limit 1 \
-            --json databaseId \
-            --jq '.[0].databaseId')
+          RUN_ID=$(echo "$OUTPUT" | grep -oE '/runs/[0-9]+' | grep -oE '[0-9]+')
 
           echo "Watching run: https://github.com/$REPO/actions/runs/$RUN_ID"
           gh run watch "$RUN_ID" --repo "$REPO" --interval 30 --exit-status

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -234,8 +234,9 @@ jobs:
               --workflow "$WORKFLOW" \
               --event workflow_dispatch \
               --created ">=$TRIGGER_TIME" \
-              --json databaseId \
-              --jq '.[0].databaseId // empty')
+              --limit 1 \
+              --json databaseId,createdAt \
+              --jq 'sort_by(.createdAt) | .[0].databaseId // empty')
 
             if [[ -n "$RUN_ID" ]]; then
               echo "Found workflow run: $RUN_ID"
@@ -287,7 +288,7 @@ jobs:
           echo "Workflow dispatch triggered, waiting for run to appear..."
           sleep 15
 
-          # Find the run we just triggered
+          # Find the run we just triggered (oldest after TRIGGER_TIME)
           RUN_ID=""
           for i in $(seq 1 12); do
             RUN_ID=$(gh run list \
@@ -295,8 +296,9 @@ jobs:
               --workflow "$WORKFLOW" \
               --event workflow_dispatch \
               --created ">=$TRIGGER_TIME" \
-              --json databaseId \
-              --jq '.[0].databaseId // empty')
+              --limit 1 \
+              --json databaseId,createdAt \
+              --jq 'sort_by(.createdAt) | .[0].databaseId // empty')
 
             if [[ -n "$RUN_ID" ]]; then
               echo "Found workflow run: $RUN_ID"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,33 +80,33 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # - uses: ./.github/actions/erase-db
-      #   if: inputs.ERASE_DB
-      #   with:
-      #     INSTANCE: ${{ env.INSTANCE }}
-      #     NAME: dspace-${{ env.INSTANCE }}
+      - uses: ./.github/actions/erase-db
+        if: inputs.ERASE_DB
+        with:
+          INSTANCE: ${{ env.INSTANCE }}
+          NAME: dspace-${{ env.INSTANCE }}
 
-      # - name: deploy dspace-import on dev-5
-      #   working-directory: build-scripts/run/
-      #   run: |
-      #     ./start.sh dspace-$INSTANCE
-      #     cd ../..
-      #     # this is not necessary, since extra.yml doesn't contain any new images that weren't pulled within script above
-      #     # docker compose --env-file $ENVFILE -p dspace-$INSTANCE -f docker/docker-compose.yml -f docker/docker-compose-rest.yml -f /opt/dspace-envs/8/extra.yml pull
-      #     docker compose --env-file $ENVFILE -p dspace-$INSTANCE -f docker/docker-compose.yml -f docker/docker-compose-rest.yml -f /opt/dspace-envs/8/extra.yml up -d --no-build
+      - name: deploy dspace-import on dev-5
+        working-directory: build-scripts/run/
+        run: |
+          ./start.sh dspace-$INSTANCE
+          cd ../..
+          # this is not necessary, since extra.yml doesn't contain any new images that weren't pulled within script above
+          # docker compose --env-file $ENVFILE -p dspace-$INSTANCE -f docker/docker-compose.yml -f docker/docker-compose-rest.yml -f /opt/dspace-envs/8/extra.yml pull
+          docker compose --env-file $ENVFILE -p dspace-$INSTANCE -f docker/docker-compose.yml -f docker/docker-compose-rest.yml -f /opt/dspace-envs/8/extra.yml up -d --no-build
 
-      #     # this must be here and not in the start.sh, because extra.yml replaces dspace container
-      #     ## !!!!! please remove this section if you do not want handle server !!!!!!!
-      #     echo "====="
-      #     echo "installing handle server"
-      #     docker exec dspace${INSTANCE} /dspace/bin/make-handle-config
-      #     echo "made handle config:"
-      #     docker exec dspace${INSTANCE} cat /dspace/handle-server/config.dct
-      #     docker exec dspace${INSTANCE} /dspace/bin/start-handle-server
-      #     echo "started handle server"
-      #     # this seems to be the easiest solution for now
-      #     docker restart dockerized-nginx-with-shibboleth-nginx-1
-      #     /bin/bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://dev-5.pc:8$INSTANCE/repository/server/api)" != "200" ]]; do sleep 5; done'
+          # this must be here and not in the start.sh, because extra.yml replaces dspace container
+          ## !!!!! please remove this section if you do not want handle server !!!!!!!
+          echo "====="
+          echo "installing handle server"
+          docker exec dspace${INSTANCE} /dspace/bin/make-handle-config
+          echo "made handle config:"
+          docker exec dspace${INSTANCE} cat /dspace/handle-server/config.dct
+          docker exec dspace${INSTANCE} /dspace/bin/start-handle-server
+          echo "started handle server"
+          # this seems to be the easiest solution for now
+          docker restart dockerized-nginx-with-shibboleth-nginx-1
+          /bin/bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://dev-5.pc:8$INSTANCE/repository/server/api)" != "200" ]]; do sleep 5; done'
 
 
   import-5:
@@ -193,16 +193,15 @@ jobs:
           echo "dspace healthcheck:"
           docker exec $DNAME /bin/bash -c "cd /dspace/bin && ./dspace healthcheck -v"
 
-  # playwright-after-deploy8:
-  #   needs: deploy-8
-  #   if: '!inputs.IMPORT'
-  #   uses: ./.github/workflows/playwright-tests.yml
-  #   secrets: inherit
+  playwright-after-deploy8:
+    needs: deploy-8
+    if: '!inputs.IMPORT'
+    uses: ./.github/workflows/playwright-tests.yml
+    secrets: inherit
 
   rest-tests-after-deploy8:
     runs-on: ubuntu-latest
-    # needs: playwright-after-deploy8
-    needs: deploy-8
+    needs: playwright-after-deploy8
     if: '!inputs.IMPORT'
     timeout-minutes: 120
     env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,33 +80,33 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: ./.github/actions/erase-db
-        if: inputs.ERASE_DB
-        with:
-          INSTANCE: ${{ env.INSTANCE }}
-          NAME: dspace-${{ env.INSTANCE }}
+      # - uses: ./.github/actions/erase-db
+      #   if: inputs.ERASE_DB
+      #   with:
+      #     INSTANCE: ${{ env.INSTANCE }}
+      #     NAME: dspace-${{ env.INSTANCE }}
 
-      - name: deploy dspace-import on dev-5
-        working-directory: build-scripts/run/
-        run: |
-          ./start.sh dspace-$INSTANCE
-          cd ../..
-          # this is not necessary, since extra.yml doesn't contain any new images that weren't pulled within script above
-          # docker compose --env-file $ENVFILE -p dspace-$INSTANCE -f docker/docker-compose.yml -f docker/docker-compose-rest.yml -f /opt/dspace-envs/8/extra.yml pull
-          docker compose --env-file $ENVFILE -p dspace-$INSTANCE -f docker/docker-compose.yml -f docker/docker-compose-rest.yml -f /opt/dspace-envs/8/extra.yml up -d --no-build
+      # - name: deploy dspace-import on dev-5
+      #   working-directory: build-scripts/run/
+      #   run: |
+      #     ./start.sh dspace-$INSTANCE
+      #     cd ../..
+      #     # this is not necessary, since extra.yml doesn't contain any new images that weren't pulled within script above
+      #     # docker compose --env-file $ENVFILE -p dspace-$INSTANCE -f docker/docker-compose.yml -f docker/docker-compose-rest.yml -f /opt/dspace-envs/8/extra.yml pull
+      #     docker compose --env-file $ENVFILE -p dspace-$INSTANCE -f docker/docker-compose.yml -f docker/docker-compose-rest.yml -f /opt/dspace-envs/8/extra.yml up -d --no-build
 
-          # this must be here and not in the start.sh, because extra.yml replaces dspace container
-          ## !!!!! please remove this section if you do not want handle server !!!!!!!
-          echo "====="
-          echo "installing handle server"
-          docker exec dspace${INSTANCE} /dspace/bin/make-handle-config
-          echo "made handle config:"
-          docker exec dspace${INSTANCE} cat /dspace/handle-server/config.dct
-          docker exec dspace${INSTANCE} /dspace/bin/start-handle-server
-          echo "started handle server"
-          # this seems to be the easiest solution for now
-          docker restart dockerized-nginx-with-shibboleth-nginx-1
-          /bin/bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://dev-5.pc:8$INSTANCE/repository/server/api)" != "200" ]]; do sleep 5; done'
+      #     # this must be here and not in the start.sh, because extra.yml replaces dspace container
+      #     ## !!!!! please remove this section if you do not want handle server !!!!!!!
+      #     echo "====="
+      #     echo "installing handle server"
+      #     docker exec dspace${INSTANCE} /dspace/bin/make-handle-config
+      #     echo "made handle config:"
+      #     docker exec dspace${INSTANCE} cat /dspace/handle-server/config.dct
+      #     docker exec dspace${INSTANCE} /dspace/bin/start-handle-server
+      #     echo "started handle server"
+      #     # this seems to be the easiest solution for now
+      #     docker restart dockerized-nginx-with-shibboleth-nginx-1
+      #     /bin/bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://dev-5.pc:8$INSTANCE/repository/server/api)" != "200" ]]; do sleep 5; done'
 
 
   import-5:
@@ -193,44 +193,67 @@ jobs:
           echo "dspace healthcheck:"
           docker exec $DNAME /bin/bash -c "cd /dspace/bin && ./dspace healthcheck -v"
 
-  playwright-after-deploy8:
-    needs: deploy-8
-    if: '!inputs.IMPORT'
-    uses: ./.github/workflows/playwright-tests.yml
-    secrets: inherit
+  # playwright-after-deploy8:
+  #   needs: deploy-8
+  #   if: '!inputs.IMPORT'
+  #   uses: ./.github/workflows/playwright-tests.yml
+  #   secrets: inherit
 
   rest-tests-after-deploy8:
     runs-on: ubuntu-latest
-    needs: playwright-after-deploy8
+    # needs: playwright-after-deploy8
+    needs: deploy-8
+    if: '!inputs.IMPORT'
     timeout-minutes: 120
+    env:
+      GH_TOKEN: ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}
     steps:
       - name: run rest-tests
         run: |
-          curl -H "Accept: application/vnd.github.everest-preview+json" \
-          -H "Authorization: token ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}" \
-          --request POST \
-          https://api.github.com/repos/dataquest-dev/\
-          dspace-rest-test/actions/workflows/run_unittests.yml/dispatches \
-          --data "{\"ref\":\"refs/heads/master\"}" 2> /dev/null
+          REPO="dataquest-dev/dspace-rest-test"
+          WORKFLOW="run_unittests.yml"
 
-          # wait for it to start
-          sleep 30s
+          # Record time before dispatch to find the correct run later
+          TRIGGER_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          echo "Triggering REST tests at $TRIGGER_TIME"
 
-          # get result of last job
-          RES=$(curl -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}" https://api.github.com/repos/dataquest-dev/dspace-rest-test/actions/workflows/run_unittests.yml/runs?per_page=1 2> /dev/null | jq .workflow_runs[0].conclusion)
+          # Trigger the workflow with inputs
+          gh workflow run "$WORKFLOW" \
+            --repo "$REPO" \
+            --ref master \
+            -f CUSTOMER="${{ github.ref_name }}" \
+            -f URL="http://dev-5.pc:88/repository/server/api"
 
-          # while job did not finish, sleep
-          while [[ $RES == 'null' ]]; do
-            sleep 10s
-            RES=$(curl -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}" https://api.github.com/repos/dataquest-dev/dspace-rest-test/actions/workflows/run_unittests.yml/runs?per_page=1 2> /dev/null | jq .workflow_runs[0].conclusion)
-          done;
+          echo "Workflow dispatch triggered, waiting for run to appear..."
+          sleep 15
 
-          echo $RES
-          # if last result is not success, return -1 and fail
-          if [[ $RES != \"success\" ]]; then
-            echo "rest-tests have failed! check appropriate action run in the dspace-rest-test repository"
+          # Find the run we just triggered
+          RUN_ID=""
+          for i in $(seq 1 12); do
+            RUN_ID=$(gh run list \
+              --repo "$REPO" \
+              --workflow "$WORKFLOW" \
+              --event workflow_dispatch \
+              --created ">=$TRIGGER_TIME" \
+              --json databaseId \
+              --jq '.[0].databaseId // empty')
+
+            if [[ -n "$RUN_ID" ]]; then
+              echo "Found workflow run: $RUN_ID"
+              break
+            fi
+            echo "Attempt $i: Run not found yet, waiting 15s..."
+            sleep 15
+          done
+
+          if [[ -z "$RUN_ID" ]]; then
+            echo "::error::Could not find the triggered workflow run after 3 minutes"
             exit 1
-          fi;
+          fi
+
+          # Watch the run until it completes (polls every 30s, shows live status)
+          echo "Watching run: https://github.com/$REPO/actions/runs/$RUN_ID"
+          gh run watch "$RUN_ID" --repo "$REPO" --interval 30 --exit-status
 
 
   playwright-after-import8:
@@ -243,31 +266,52 @@ jobs:
     runs-on: ubuntu-latest
     needs: playwright-after-import8
     timeout-minutes: 120
+    env:
+      GH_TOKEN: ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}
     steps:
-      - name: run rest-tests
+      - name: Trigger and watch REST tests
         run: |
-          curl -H "Accept: application/vnd.github.everest-preview+json" \
-          -H "Authorization: token ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}" \
-          --request POST \
-          https://api.github.com/repos/dataquest-dev/\
-          dspace-rest-test/actions/workflows/run_unittests.yml/dispatches \
-          --data "{\"ref\":\"refs/heads/master\"}" 2> /dev/null
+          REPO="dataquest-dev/dspace-rest-test"
+          WORKFLOW="run_unittests.yml"
 
-          # wait for it to start
-          sleep 30s
+          # Record time before dispatch to find the correct run later
+          TRIGGER_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          echo "Triggering REST tests at $TRIGGER_TIME"
 
-          # get result of last job
-          RES=$(curl -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}" https://api.github.com/repos/dataquest-dev/dspace-rest-test/actions/workflows/run_unittests.yml/runs?per_page=1 2> /dev/null | jq .workflow_runs[0].conclusion)
+          # Trigger the workflow with inputs
+          gh workflow run "$WORKFLOW" \
+            --repo "$REPO" \
+            --ref master \
+            -f CUSTOMER="${{ github.ref_name }}" \
+            -f URL="http://dev-5.pc:88/repository/server/api"
 
-          # while job did not finish, sleep
-          while [[ $RES == 'null' ]]; do
-            sleep 10s
-            RES=$(curl -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}" https://api.github.com/repos/dataquest-dev/dspace-rest-test/actions/workflows/run_unittests.yml/runs?per_page=1 2> /dev/null | jq .workflow_runs[0].conclusion)
-          done;
+          echo "Workflow dispatch triggered, waiting for run to appear..."
+          sleep 15
 
-          echo $RES
-          # if last result is not success, return -1 and fail
-          if [[ $RES != \"success\" ]]; then
-            echo "rest-tests have failed! check appropriate action run in the dspace-rest-test repository"
+          # Find the run we just triggered
+          RUN_ID=""
+          for i in $(seq 1 12); do
+            RUN_ID=$(gh run list \
+              --repo "$REPO" \
+              --workflow "$WORKFLOW" \
+              --event workflow_dispatch \
+              --created ">=$TRIGGER_TIME" \
+              --json databaseId \
+              --jq '.[0].databaseId // empty')
+
+            if [[ -n "$RUN_ID" ]]; then
+              echo "Found workflow run: $RUN_ID"
+              break
+            fi
+            echo "Attempt $i: Run not found yet, waiting 15s..."
+            sleep 15
+          done
+
+          if [[ -z "$RUN_ID" ]]; then
+            echo "::error::Could not find the triggered workflow run after 3 minutes"
             exit 1
-          fi;
+          fi
+
+          # Watch the run until it completes (polls every 30s, shows live status)
+          echo "Watching run: https://github.com/$REPO/actions/runs/$RUN_ID"
+          gh run watch "$RUN_ID" --repo "$REPO" --interval 30 --exit-status


### PR DESCRIPTION
## Problem description
We updated rest tests in order to run tests according to specific customers and we have to change the way how it is called from deploy workflow.
Related issues:
https://github.com/dataquest-dev/dspace-customers/issues/467
https://github.com/dataquest-dev/dspace-customers/issues/468

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [x] Requested review from Copilot