### PR TITLE
TUL/Use gh cli dispatch for rest tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,34 +67,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: playwright-after-deploy6
     timeout-minutes: 120
+    env:
+      GH_TOKEN: ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}
+      REPO: dataquest-dev/dspace-rest-test
+      WORKFLOW: run_unittests.yml
     steps:
       - name: run rest-tests
         run: |
-          curl -H "Accept: application/vnd.github.everest-preview+json" \
-          -H "Authorization: token ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}" \
-          --request POST \
-          https://api.github.com/repos/dataquest-dev/\
-          dspace-rest-test/actions/workflows/run_unittests.yml/dispatches \
-          --data "{\"ref\":\"refs/heads/master\"}" 2> /dev/null
+          OUTPUT=$(gh workflow run "$WORKFLOW" \
+            --repo "$REPO" \
+            --ref master \
+            -f CUSTOMER="${{ github.ref_name }}" \
+            -f URL="http://dev-5.pc:86/server/api" 2>&1)
 
-          # wait for it to start
-          sleep 30s
+          RUN_ID=$(echo "$OUTPUT" | grep -oE '/runs/[0-9]+' | grep -oE '[0-9]+')
 
-          # get result of last job
-          RES=$(curl -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}" https://api.github.com/repos/dataquest-dev/dspace-rest-test/actions/workflows/run_unittests.yml/runs?per_page=1 2> /dev/null | jq .workflow_runs[0].conclusion)
-
-          # while job did not finish, sleep
-          while [[ $RES == 'null' ]]; do
-            sleep 10s
-            RES=$(curl -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}" https://api.github.com/repos/dataquest-dev/dspace-rest-test/actions/workflows/run_unittests.yml/runs?per_page=1 2> /dev/null | jq .workflow_runs[0].conclusion)
-          done;
-
-          echo $RES
-          # if last result is not success, return -1 and fail
-          if [[ $RES != \"success\" ]]; then
-            echo "rest-tests have failed! check appropriate action run"
-            exit 1
-          fi;
+          echo "Watching run: https://github.com/$REPO/actions/runs/$RUN_ID"
+          gh run watch "$RUN_ID" --repo "$REPO" --interval 30 --exit-status
 
 
   playwright-after-import6:
@@ -107,34 +96,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: playwright-after-import6
     timeout-minutes: 120
+    env:
+      GH_TOKEN: ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}
+      REPO: dataquest-dev/dspace-rest-test
+      WORKFLOW: run_unittests.yml
     steps:
       - name: run rest-tests
         run: |
-          curl -H "Accept: application/vnd.github.everest-preview+json" \
-          -H "Authorization: token ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}" \
-          --request POST \
-          https://api.github.com/repos/dataquest-dev/\
-          dspace-rest-test/actions/workflows/run_unittests.yml/dispatches \
-          --data "{\"ref\":\"refs/heads/master\"}" 2> /dev/null
+          OUTPUT=$(gh workflow run "$WORKFLOW" \
+            --repo "$REPO" \
+            --ref master \
+            -f CUSTOMER="${{ github.ref_name }}" \
+            -f URL="http://dev-5.pc:86/server/api" 2>&1)
 
-          # wait for it to start
-          sleep 30s
+          RUN_ID=$(echo "$OUTPUT" | grep -oE '/runs/[0-9]+' | grep -oE '[0-9]+')
 
-          # get result of last job
-          RES=$(curl -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}" https://api.github.com/repos/dataquest-dev/dspace-rest-test/actions/workflows/run_unittests.yml/runs?per_page=1 2> /dev/null | jq .workflow_runs[0].conclusion)
-
-          # while job did not finish, sleep
-          while [[ $RES == 'null' ]]; do
-            sleep 10s
-            RES=$(curl -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${{ secrets.DEPLOY_DEV5_GH_ACTION_DISPATCH }}" https://api.github.com/repos/dataquest-dev/dspace-rest-test/actions/workflows/run_unittests.yml/runs?per_page=1 2> /dev/null | jq .workflow_runs[0].conclusion)
-          done;
-
-          echo $RES
-          # if last result is not success, return -1 and fail
-          if [[ $RES != \"success\" ]]; then
-            echo "rest-tests have failed! check appropriate action run"
-            exit 1
-          fi;
+          echo "Watching run: https://github.com/$REPO/actions/runs/$RUN_ID"
+          gh run watch "$RUN_ID" --repo "$REPO" --interval 30 --exit-status
 
   import-6:
     runs-on: dspace-dep-1


### PR DESCRIPTION
## Problem description
From PR: https://github.com/dataquest-dev/dspace-angular/pull/1252
Related issues:
https://github.com/dataquest-dev/dspace-customers/issues/467
https://github.com/dataquest-dev/dspace-customers/issues/468

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot