### PR TITLE
VSB-TUO/feat: SAF Import/Update – embargo improvements & item page display

### DIFF
--- a/src/app/item-page/simple/item-types/publication/publication.component.html
+++ b/src/app/item-page/simple/item-types/publication/publication.component.html
@@ -93,6 +93,16 @@
     </ds-generic-item-page-field>
 
     <ds-generic-item-page-field [item]="object"
+                                [fields]="['dc.description.embargo']"
+                                [label]="'item.page.embargo-statement'">
+    </ds-generic-item-page-field>
+
+    <ds-generic-item-page-field [item]="object"
+                                [fields]="['dc.date.embargoend']"
+                                [label]="'item.page.embargo-date'">
+    </ds-generic-item-page-field>
+
+    <ds-generic-item-page-field [item]="object"
                                 [fields]="['dc.subject']"
                                 [separator]="', '"
                                 [label]="'item.page.subject'">

--- a/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -78,6 +78,16 @@
     </ds-generic-item-page-field>
 
     <ds-generic-item-page-field [item]="object"
+      [fields]="['dc.description.embargo']"
+      [label]="'item.page.embargo-statement'">
+    </ds-generic-item-page-field>
+
+    <ds-generic-item-page-field [item]="object"
+      [fields]="['dc.date.embargoend']"
+      [label]="'item.page.embargo-date'">
+    </ds-generic-item-page-field>
+
+    <ds-generic-item-page-field [item]="object"
       [fields]="['dc.subject']"
       [separator]="', '"
       [label]="'item.page.subject'">

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -3747,6 +3747,10 @@
   // "item.page.description": "Description",
   "item.page.description": "Popis",
 
+  "item.page.embargo-statement": "Odložené zveřejnění",
+
+  "item.page.embargo-date": "Zveřejnění",
+
   // "item.page.journal-issn": "Journal ISSN",
   "item.page.journal-issn": "ISSN časopisu",
 

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -3747,8 +3747,10 @@
   // "item.page.description": "Description",
   "item.page.description": "Popis",
 
+  // "item.page.embargo-statement": "Delayed publication",
   "item.page.embargo-statement": "Odložené zveřejnění",
 
+  // "item.page.embargo-date": "Available after",
   "item.page.embargo-date": "Zveřejnění",
 
   // "item.page.journal-issn": "Journal ISSN",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -2505,6 +2505,10 @@
 
   "item.page.description": "Description",
 
+  "item.page.embargo-statement": "Delayed publication",
+
+  "item.page.embargo-date": "Available after",
+
   "item.page.journal-issn": "Journal ISSN",
 
   "item.page.journal-title": "Journal Title",

--- a/src/themes/custom/app/item-page/simple/item-types/publication/publication.component.html
+++ b/src/themes/custom/app/item-page/simple/item-types/publication/publication.component.html
@@ -72,6 +72,16 @@
     </ds-generic-item-page-field>
 
     <ds-generic-item-page-field [item]="object"
+                                [fields]="['dc.description.embargo']"
+                                [label]="'item.page.embargo-statement'">
+    </ds-generic-item-page-field>
+
+    <ds-generic-item-page-field [item]="object"
+                                [fields]="['dc.date.embargoend']"
+                                [label]="'item.page.embargo-date'">
+    </ds-generic-item-page-field>
+
+    <ds-generic-item-page-field [item]="object"
                                 [fields]="['dc.subject']"
                                 [separator]="', '"
                                 [label]="'item.page.subject'">

--- a/src/themes/custom/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/themes/custom/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -58,6 +58,16 @@
     </ds-generic-item-page-field>
 
     <ds-generic-item-page-field [item]="object"
+                                [fields]="['dc.description.embargo']"
+                                [label]="'item.page.embargo-statement'">
+    </ds-generic-item-page-field>
+
+    <ds-generic-item-page-field [item]="object"
+                                [fields]="['dc.date.embargoend']"
+                                [label]="'item.page.embargo-date'">
+    </ds-generic-item-page-field>
+
+    <ds-generic-item-page-field [item]="object"
                                 [fields]="['dc.subject']"
                                 [separator]="', '"
                                 [label]="'item.page.subject'">


### PR DESCRIPTION
## Problem description
1. **Item page – embargo fields** – Added `dc.description.embargo` ("Delayed publication" / "Odložené zveřejnění") and `dc.date.embargoend` ("Available after" / "Zveřejnění") to all 4 item view templates.

### FE modified files
- `untyped-item.component.html` (×2), `publication.component.html` (×2)
- `en.json5`, `cs.json5`

## Analysis
(Write here, if there is needed describe some specific problem. Erase it, when it is not needed.)
## Problems
(Write here, if some unexpected problems occur during solving issues. Erase it, when it is not needed.) 

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot