### PR TITLE
fix: add Slovak flag icon to CLARIN top navbar

### DIFF
--- a/src/app/clarin-navbar-top/clarin-navbar-top.component.html
+++ b/src/app/clarin-navbar-top/clarin-navbar-top.component.html
@@ -7,6 +7,9 @@
       <span class="language-icon pl-1" (click)="setLanguage('cs')">
         <img src="./assets/images/cs.png" alt="{{'language.czech' | translate}}" title="{{'language.czech' | translate}}">
       </span>
+      <span class="language-icon pl-1" (click)="setLanguage('sk')">
+        <img src="./assets/images/flags/sk.png" alt="Slovak" title="Slovak">
+      </span>
     </div>
     <div class="ml-auto pr-3">
       <div *ngIf="authenticatedUser == null" class="badge clarin-login-badge px-2 py-1">

--- a/src/app/clarin-navbar-top/clarin-navbar-top.component.spec.ts
+++ b/src/app/clarin-navbar-top/clarin-navbar-top.component.spec.ts
@@ -65,6 +65,17 @@ describe('ClarinNavbarTopComponent', () => {
       });
   });
 
+  it('should render slovak language icon and call setLanguage on click', () => {
+    spyOn(component, 'setLanguage');
+    fixture.detectChanges();
+
+    const languageIcons = fixture.nativeElement.querySelectorAll('.language-icon');
+    expect(languageIcons.length).toBe(3);
+
+    languageIcons[2].click();
+    expect(component.setLanguage).toHaveBeenCalledWith('sk');
+  });
+
   function getMockLocaleService(): LocaleService {
     return jasmine.createSpyObj('LocaleService', {
       setCurrentLanguageCode: jasmine.createSpy('setCurrentLanguageCode'),


### PR DESCRIPTION
## Summary
- adds a third language icon (Slovak flag) to the CLARIN top navbar, next to existing English and Czech flags
- wires the new icon to `setLanguage('sk')` for consistent language-switch behavior
- adds a component unit test to verify the Slovak icon is rendered and clicking it triggers Slovak language selection

## Root Cause
- the top navbar template only rendered English and Czech language icons

## Validation
- `yarn install --frozen-lockfile` -> pass
- `yarn run lint --quiet` -> pass
- `yarn run check-circ-deps` -> PowerShell parsing issue in script command; equivalent command run with stop-parsing form passed:
  - `npx --% madge --exclude "(bitstream|bundle|collection|config-submission-form|eperson|item|version)\.model\.ts$" --circular --extensions ts ./` -> pass (`No circular dependency found`)
- `yarn run build:prod` -> pass (with pre-existing warnings)
- `yarn run test:headless` -> pass (`5328 SUCCESS`, `4 skipped`)
- `yarn run test:headless --include='**/clarin-navbar-top.component.spec.ts'` -> pass

## Risk and Rollback
- low risk: isolated UI/template change and focused unit test in one component
- rollback: revert commit `2a762b6adb`

Fixes dataquest-dev/dspace-customers#589
