### PR TITLE
UFAL/Updated components to display `dc.description` instead of `dc.description.abstract`

### DIFF
--- a/src/app/shared/object-grid/search-result-grid-element/item-search-result/item/item-search-result-grid-element.component.html
+++ b/src/app/shared/object-grid/search-result-grid-element/item-search-result/item/item-search-result-grid-element.component.html
@@ -29,9 +29,9 @@
                     </span>
                 </p>
             </ds-truncatable-part>
-            <ds-truncatable-part *ngIf="dso.hasMetadata('dc.description.abstract')" [id]="dso.id" [minLines]="3">
+            <ds-truncatable-part *ngIf="dso.hasMetadata('dc.description')" [id]="dso.id" [minLines]="3">
                 <p class="item-abstract card-text">
-                    <span [innerHTML]="firstMetadataValue('dc.description.abstract')"></span>
+                    <span [innerHTML]="firstMetadataValue('dc.description')"></span>
                 </p>
             </ds-truncatable-part>
         </ds-truncatable>

--- a/src/app/shared/object-grid/search-result-grid-element/item-search-result/item/item-search-result-grid-element.component.spec.ts
+++ b/src/app/shared/object-grid/search-result-grid-element/item-search-result/item/item-search-result-grid-element.component.spec.ts
@@ -205,62 +205,7 @@ mockItemWithoutMetadata.indexableObject = Object.assign(new Item(), {
   }
 });
 
-describe('ItemGridElementComponent', getEntityGridElementTestComponent(ItemSearchResultGridElementComponent, mockItemWithMetadata, mockItemWithoutMetadata, ['authors', 'date', 'abstract']));
-
-describe('ItemGridElementComponent with legacy abstract metadata', () => {
-  let comp;
-  let fixture;
-
-  const truncatableServiceStub: any = {
-    isCollapsed: () => observableOf(true),
-  };
-
-  const mockBitstreamDataService = {
-    getThumbnailFor(): Observable<RemoteData<Bitstream>> {
-      return createSuccessfulRemoteDataObject$(new Bitstream());
-    }
-  };
-
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        NoopAnimationsModule,
-        TranslateModule.forRoot()
-      ],
-      declarations: [ItemSearchResultGridElementComponent, TruncatePipe],
-      providers: [
-        { provide: TruncatableService, useValue: truncatableServiceStub },
-        { provide: ObjectCacheService, useValue: {} },
-        { provide: UUIDService, useValue: {} },
-        { provide: Store, useValue: {} },
-        { provide: RemoteDataBuildService, useValue: {} },
-        { provide: CommunityDataService, useValue: {} },
-        { provide: HALEndpointService, useValue: {} },
-        { provide: HttpClient, useValue: {} },
-        { provide: DSOChangeAnalyzer, useValue: {} },
-        { provide: NotificationsService, useValue: {} },
-        { provide: DefaultChangeAnalyzer, useValue: {} },
-        { provide: BitstreamDataService, useValue: mockBitstreamDataService },
-      ],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).overrideComponent(ItemSearchResultGridElementComponent, {
-      set: { changeDetection: ChangeDetectionStrategy.Default }
-    }).compileComponents();
-  }));
-
-  beforeEach(waitForAsync(() => {
-    fixture = TestBed.createComponent(ItemSearchResultGridElementComponent);
-    comp = fixture.componentInstance;
-  }));
-
-  it('should not show abstract field when only dc.description.abstract is available', () => {
-    comp.object = mockItemWithAbstractOnly;
-    fixture.detectChanges();
-
-    const abstractField = fixture.debugElement.query(By.css('.item-abstract'));
-    expect(abstractField).toBeNull();
-  });
-});
+describe('ItemGridElementComponent', getEntityGridElementTestComponent(ItemSearchResultGridElementComponent, mockItemWithMetadata, mockItemWithoutMetadata, ['authors', 'date', 'abstract'], mockItemWithAbstractOnly));
 
 /**
  * Create test cases for a grid component of an entity.
@@ -271,7 +216,13 @@ describe('ItemGridElementComponent with legacy abstract metadata', () => {
  *                                      For example: If one of the fields to check is labeled "authors", the html template should contain at least one element with class ".item-authors" that's
  *                                      present when the author metadata is available.
  */
-export function getEntityGridElementTestComponent(component, searchResultWithMetadata: ItemSearchResult, searchResultWithoutMetadata: ItemSearchResult, fieldsToCheck: string[]) {
+export function getEntityGridElementTestComponent(
+  component,
+  searchResultWithMetadata: ItemSearchResult,
+  searchResultWithoutMetadata: ItemSearchResult,
+  fieldsToCheck: string[],
+  searchResultWithAbstractOnly?: ItemSearchResult,
+) {
   return () => {
     let comp;
     let fixture;
@@ -317,6 +268,20 @@ export function getEntityGridElementTestComponent(component, searchResultWithMet
       fixture = TestBed.createComponent(component);
       comp = fixture.componentInstance;
     }));
+
+    if (searchResultWithAbstractOnly) {
+      describe('when the item has only dc.description.abstract metadata', () => {
+        beforeEach(() => {
+          comp.object = searchResultWithAbstractOnly;
+          fixture.detectChanges();
+        });
+
+        it('should not show abstract field', () => {
+          const abstractField = fixture.debugElement.query(By.css('.item-abstract'));
+          expect(abstractField).toBeNull();
+        });
+      });
+    }
 
     fieldsToCheck.forEach((field) => {
       describe(`when the item has "${field}" metadata`, () => {

--- a/src/app/shared/object-grid/search-result-grid-element/item-search-result/item/item-search-result-grid-element.component.spec.ts
+++ b/src/app/shared/object-grid/search-result-grid-element/item-search-result/item/item-search-result-grid-element.component.spec.ts
@@ -28,6 +28,8 @@ import { ItemSearchResultGridElementComponent } from './item-search-result-grid-
 
 const mockItemWithMetadata: ItemSearchResult = new ItemSearchResult();
 mockItemWithMetadata.hitHighlights = {};
+const mockItemWithAbstractOnly: ItemSearchResult = new ItemSearchResult();
+mockItemWithAbstractOnly.hitHighlights = {};
 const dcTitle = 'This is just another <em>title</em>';
 mockItemWithMetadata.indexableObject = Object.assign(new Item(), {
   hitHighlights: {
@@ -55,10 +57,27 @@ mockItemWithMetadata.indexableObject = Object.assign(new Item(), {
         value: '2015-06-26'
       }
     ],
-    'dc.description.abstract': [
+    'dc.description': [
       {
         language: 'en_US',
         value: 'This is an abstract'
+      }
+    ]
+  }
+});
+mockItemWithAbstractOnly.indexableObject = Object.assign(new Item(), {
+  bundles: createSuccessfulRemoteDataObject$(buildPaginatedList(new PageInfo(), [])),
+  metadata: {
+    'dc.title': [
+      {
+        language: 'en_US',
+        value: dcTitle
+      }
+    ],
+    'dc.description.abstract': [
+      {
+        language: 'en_US',
+        value: 'Legacy abstract only'
       }
     ]
   }
@@ -98,7 +117,7 @@ const mockPerson: ItemSearchResult = Object.assign(new ItemSearchResult(), {
             value: '2015-06-26'
           }
         ],
-        'dc.description.abstract': [
+        'dc.description': [
           {
             language: 'en_US',
             value: 'This is the abstract'
@@ -152,7 +171,7 @@ const mockOrgUnit: ItemSearchResult = Object.assign(new ItemSearchResult(), {
             value: '2015-06-26'
           }
         ],
-        'dc.description.abstract': [
+        'dc.description': [
           {
             language: 'en_US',
             value: 'This is the abstract'
@@ -187,6 +206,61 @@ mockItemWithoutMetadata.indexableObject = Object.assign(new Item(), {
 });
 
 describe('ItemGridElementComponent', getEntityGridElementTestComponent(ItemSearchResultGridElementComponent, mockItemWithMetadata, mockItemWithoutMetadata, ['authors', 'date', 'abstract']));
+
+describe('ItemGridElementComponent with legacy abstract metadata', () => {
+  let comp;
+  let fixture;
+
+  const truncatableServiceStub: any = {
+    isCollapsed: () => observableOf(true),
+  };
+
+  const mockBitstreamDataService = {
+    getThumbnailFor(): Observable<RemoteData<Bitstream>> {
+      return createSuccessfulRemoteDataObject$(new Bitstream());
+    }
+  };
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule,
+        TranslateModule.forRoot()
+      ],
+      declarations: [ItemSearchResultGridElementComponent, TruncatePipe],
+      providers: [
+        { provide: TruncatableService, useValue: truncatableServiceStub },
+        { provide: ObjectCacheService, useValue: {} },
+        { provide: UUIDService, useValue: {} },
+        { provide: Store, useValue: {} },
+        { provide: RemoteDataBuildService, useValue: {} },
+        { provide: CommunityDataService, useValue: {} },
+        { provide: HALEndpointService, useValue: {} },
+        { provide: HttpClient, useValue: {} },
+        { provide: DSOChangeAnalyzer, useValue: {} },
+        { provide: NotificationsService, useValue: {} },
+        { provide: DefaultChangeAnalyzer, useValue: {} },
+        { provide: BitstreamDataService, useValue: mockBitstreamDataService },
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).overrideComponent(ItemSearchResultGridElementComponent, {
+      set: { changeDetection: ChangeDetectionStrategy.Default }
+    }).compileComponents();
+  }));
+
+  beforeEach(waitForAsync(() => {
+    fixture = TestBed.createComponent(ItemSearchResultGridElementComponent);
+    comp = fixture.componentInstance;
+  }));
+
+  it('should not show abstract field when only dc.description.abstract is available', () => {
+    comp.object = mockItemWithAbstractOnly;
+    fixture.detectChanges();
+
+    const abstractField = fixture.debugElement.query(By.css('.item-abstract'));
+    expect(abstractField).toBeNull();
+  });
+});
 
 /**
  * Create test cases for a grid component of an entity.

--- a/src/app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component.html
+++ b/src/app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component.html
@@ -36,9 +36,9 @@
           </span>
         </ds-truncatable-part>
       </span>
-      <div *ngIf="dso.firstMetadataValue('dc.description.abstract')" class="item-list-abstract">
+      <div *ngIf="dso.firstMetadataValue('dc.description')" class="item-list-abstract">
         <ds-truncatable-part [id]="dso.id" [minLines]="3"><span
-          [innerHTML]="firstMetadataValue('dc.description.abstract')"></span>
+          [innerHTML]="firstMetadataValue('dc.description')"></span>
         </ds-truncatable-part>
       </div>
     </ds-truncatable>

--- a/src/app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component.spec.ts
+++ b/src/app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component.spec.ts
@@ -48,10 +48,24 @@ const mockItemWithMetadata: ItemSearchResult = Object.assign(new ItemSearchResul
             value: '2015-06-26'
           }
         ],
-        'dc.description.abstract': [
+        'dc.description': [
           {
             language: 'en_US',
             value: 'This is the abstract'
+          }
+        ]
+      }
+    })
+});
+const mockItemWithAbstractOnly: ItemSearchResult = Object.assign(new ItemSearchResult(), {
+  indexableObject:
+    Object.assign(new Item(), {
+      bundles: observableOf({}),
+      metadata: {
+        'dc.description.abstract': [
+          {
+            language: 'en_US',
+            value: 'Legacy abstract only'
           }
         ]
       }
@@ -99,7 +113,7 @@ const mockPerson: ItemSearchResult = Object.assign(new ItemSearchResult(), {
             value: '2015-06-26'
           }
         ],
-        'dc.description.abstract': [
+        'dc.description': [
           {
             language: 'en_US',
             value: 'This is the abstract'
@@ -153,7 +167,7 @@ const mockOrgUnit: ItemSearchResult = Object.assign(new ItemSearchResult(), {
             value: '2015-06-26'
           }
         ],
-        'dc.description.abstract': [
+        'dc.description': [
           {
             language: 'en_US',
             value: 'This is the abstract'
@@ -308,6 +322,18 @@ describe('ItemSearchResultListElementComponent', () => {
   describe('When the item has no abstract', () => {
     beforeEach(() => {
       publicationListElementComponent.object = mockItemWithoutMetadata;
+      fixture.detectChanges();
+    });
+
+    it('should not show the abstract span', () => {
+      const abstractField = fixture.debugElement.query(By.css('div.item-list-abstract'));
+      expect(abstractField).toBeNull();
+    });
+  });
+
+  describe('When the item has only dc.description.abstract metadata', () => {
+    beforeEach(() => {
+      publicationListElementComponent.object = mockItemWithAbstractOnly;
       fixture.detectChanges();
     });
 


### PR DESCRIPTION
## Problem description
The issue: https://github.com/dataquest-dev/dspace-angular/issues/1290

## Analysis
(Write here, if there is needed describe some specific problem. Erase it, when it is not needed.)
## Problems
(Write here, if some unexpected problems occur during solving issues. Erase it, when it is not needed.) 

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [x] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [x] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)
Test `22` in the https://github.com/dataquest-dev/dspace-customers/issues/411

### Copilot review
- [x] Requested review from Copilot