### PR TITLE
UFAL/Separate CLARIN license payload from sections.license

### DIFF
--- a/cypress/e2e/submission-ui.cy.ts
+++ b/cypress/e2e/submission-ui.cy.ts
@@ -283,6 +283,12 @@ describe('Create a new submission', () => {
     // DON'T upload any file - just check the license section is accessible
     createItemProcess.checkLicenseSelectionValue('Select a License ...');
 
+    // Allow frontend to propagate the initial section status (no file => valid)
+    // before asserting the header icon. Mirrors the pattern used in the
+    // sibling "license validation when file is uploaded" test above.
+    cy.wait(1000);
+    cy.get('div[id="section_clarin-license"]').find('.card-header').should('be.visible');
+
     // Verify warning and error icons do NOT exist
     cy.get('div[id="section_clarin-license"]')
       .find('.card-header')
@@ -294,9 +300,11 @@ describe('Create a new submission', () => {
       .find('.fa-exclamation-circle.text-danger')
       .should('not.exist');
 
+    // Green check must eventually appear (retry-ability with a longer timeout
+    // handles any remaining async settle of the section status observable).
     cy.get('div[id="section_clarin-license"]')
       .find('.card-header')
-      .find('.fa-check-circle.text-success')
+      .find('.fa-check-circle.text-success', { timeout: 15000 })
       .should('be.visible');
   });
 

--- a/src/app/submission/sections/clarin-license-resource/section-license.component.spec.ts
+++ b/src/app/submission/sections/clarin-license-resource/section-license.component.spec.ts
@@ -27,6 +27,7 @@ import { FormComponent } from '../../../shared/form/form.component';
 import { SubmissionSectionClarinLicenseComponent } from './section-license.component';
 import { CollectionDataService } from '../../../core/data/collection-data.service';
 import { JsonPatchOperationsBuilder } from '../../../core/json-patch/builder/json-patch-operations-builder';
+import { JsonPatchOperationPathCombiner } from '../../../core/json-patch/builder/json-patch-operation-path-combiner';
 import { SectionFormOperationsService } from '../form/section-form-operations.service';
 import { Collection } from '../../../core/shared/collection.model';
 import { License } from '../../../core/shared/license.model';
@@ -191,11 +192,12 @@ describe('ClarinSubmissionSectionLicenseComponent test suite', () => {
       expect(app).toBeDefined();
     }));
 
-    it('sendRequest should PATCH /sections/<sectionId>/name (Riesenie B)',
+    it('sendRequest should PATCH /sections/<sectionId>/select',
       inject([SubmissionSectionClarinLicenseComponent], (app: SubmissionSectionClarinLicenseComponent) => {
         // Arrange: enable validation flow so sendRequest actually executes
         (app as any).couldShowValidationErrors = true;
         (app as any).sectionData = { id: 'clarin-license' } as any;
+        (app as any).pathCombiner = new JsonPatchOperationPathCombiner('sections', 'clarin-license');
 
         const wsiId = 42;
         const baseHref = 'http://localhost/api/submission/workspaceitems';
@@ -219,7 +221,7 @@ describe('ClarinSubmissionSectionLicenseComponent test suite', () => {
           const body: any[] = (sentRequest as any).body;
           expect(body.length).toBe(1);
           expect(body[0].op).toBe('replace');
-          expect(body[0].path).toBe('/sections/clarin-license/name');
+          expect(body[0].path).toBe('/sections/clarin-license/select');
           expect(body[0].value).toBe('My CLARIN License');
         });
       }));

--- a/src/app/submission/sections/clarin-license-resource/section-license.component.spec.ts
+++ b/src/app/submission/sections/clarin-license-resource/section-license.component.spec.ts
@@ -37,6 +37,7 @@ import { HALEndpointService } from '../../../core/shared/hal-endpoint.service';
 import { RemoteDataBuildService } from '../../../core/cache/builders/remote-data-build.service';
 import { ConfigurationDataService } from '../../../core/data/configuration-data.service';
 import { RequestService } from '../../../core/data/request.service';
+import { PatchRequest } from '../../../core/data/request.models';
 import { SubmissionFormsConfigDataService } from 'src/app/core/config/submission-forms-config-data.service';
 
 const collectionId = mockSubmissionCollectionId;
@@ -189,6 +190,39 @@ describe('ClarinSubmissionSectionLicenseComponent test suite', () => {
     it('should create ClarinSubmissionSectionLicenseComponent', inject([SubmissionSectionClarinLicenseComponent], (app: SubmissionSectionClarinLicenseComponent) => {
       expect(app).toBeDefined();
     }));
+
+    it('sendRequest should PATCH /sections/<sectionId>/name (Riesenie B)',
+      inject([SubmissionSectionClarinLicenseComponent], (app: SubmissionSectionClarinLicenseComponent) => {
+        // Arrange: enable validation flow so sendRequest actually executes
+        (app as any).couldShowValidationErrors = true;
+        (app as any).sectionData = { id: 'clarin-license' } as any;
+
+        const wsiId = 42;
+        const baseHref = 'http://localhost/api/submission/workspaceitems';
+
+        spyOn(app as any, 'getActualWorkspaceItem').and.returnValue(
+          Promise.resolve({ payload: { id: wsiId } })
+        );
+        spyOn(app as any, 'updateSectionStatus').and.callFake(() => undefined);
+
+        mockRequestService.generateRequestId.and.returnValue('req-id-1');
+        mockRequestService.send.calls.reset();
+        mockHalService.getEndpoint.and.returnValue(of(baseHref));
+        mockRdbService.buildFromRequestUUID.and.returnValue(of({ payload: { sections: {}, errors: [] } } as any));
+
+        // Act
+        return (app as any).sendRequest('My CLARIN License').then(() => {
+          // Assert
+          expect(mockRequestService.send).toHaveBeenCalledTimes(1);
+          const sentRequest = mockRequestService.send.calls.mostRecent().args[0] as PatchRequest;
+          expect(sentRequest.href).toBe(baseHref + '/' + wsiId);
+          const body: any[] = (sentRequest as any).body;
+          expect(body.length).toBe(1);
+          expect(body[0].op).toBe('replace');
+          expect(body[0].path).toBe('/sections/clarin-license/name');
+          expect(body[0].value).toBe('My CLARIN License');
+        });
+      }));
   });
 });
 

--- a/src/app/submission/sections/clarin-license-resource/section-license.component.ts
+++ b/src/app/submission/sections/clarin-license-resource/section-license.component.ts
@@ -278,15 +278,11 @@ export class SubmissionSectionClarinLicenseComponent extends SectionModelCompone
         const requestId = this.requestService.generateRequestId();
         const hrefObs = this.halService.getEndpoint(this.workspaceItemService.getLinkPath());
 
-        // Use the section-scoped path so this PATCH is routed through the
-        // `clarin-license` submission step (Riesenie B). The section step
-        // delegates to the same backend logic as the legacy `/license`
-        // top-level path, but it also works for workflow items (which
-        // only accept `/sections/...` patches) and keeps the
-        // `sections.license` (CC) and `sections.clarin-license` payloads
-        // distinct on subsequent GETs.
+        // Route the PATCH through the `clarin-license` submission step so it
+        // works for workflow items too and keeps `sections.license` (CC) and
+        // `sections.clarin-license` payloads separate on subsequent GETs.
         const patchOperation2 = {
-          op: 'replace', path: '/sections/' + this.sectionData.id + '/name', value: licenseNameRest
+          op: 'replace', path: this.pathCombiner.getPath('select').path, value: licenseNameRest
         } as Operation;
 
         hrefObs.pipe(

--- a/src/app/submission/sections/clarin-license-resource/section-license.component.ts
+++ b/src/app/submission/sections/clarin-license-resource/section-license.component.ts
@@ -278,8 +278,15 @@ export class SubmissionSectionClarinLicenseComponent extends SectionModelCompone
         const requestId = this.requestService.generateRequestId();
         const hrefObs = this.halService.getEndpoint(this.workspaceItemService.getLinkPath());
 
+        // Use the section-scoped path so this PATCH is routed through the
+        // `clarin-license` submission step (Riesenie B). The section step
+        // delegates to the same backend logic as the legacy `/license`
+        // top-level path, but it also works for workflow items (which
+        // only accept `/sections/...` patches) and keeps the
+        // `sections.license` (CC) and `sections.clarin-license` payloads
+        // distinct on subsequent GETs.
         const patchOperation2 = {
-          op: 'replace', path: '/license', value: licenseNameRest
+          op: 'replace', path: '/sections/' + this.sectionData.id + '/name', value: licenseNameRest
         } as Operation;
 
         hrefObs.pipe(


### PR DESCRIPTION
## Problem description
Issue: https://github.com/dataquest-dev/dspace-customers/issues/617

## Analysis
(Write here, if there is needed describe some specific problem. Erase it, when it is not needed.)
## Problems
(Write here, if some unexpected problems occur during solving issues. Erase it, when it is not needed.) 

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot