### PR TITLE
VSB-TUO/fix(cypress): stabilize login flow and hide Klaro consent banner in e…

### DIFF
--- a/cypress/e2e/admin-workflow-page.cy.ts
+++ b/cypress/e2e/admin-workflow-page.cy.ts
@@ -8,8 +8,9 @@ describe('Admin Workflow Page', () => {
   it('should pass accessibility tests', () => {
     // Page must first be visible
     cy.get('ds-admin-workflow-page').should('be.visible');
-    // At least one search result should be displayed
-    cy.get('[data-test="list-object"]').should('be.visible');
+    // At least one search result should be displayed. The supervision-configured search on a
+    // freshly-started CI backend can take a while to return, so allow extra time.
+    cy.get('[data-test="list-object"]', { timeout: 30000 }).should('be.visible');
     // Click each filter toggle to open *every* filter
     // (As we want to scan filter section for accessibility issues as well)
     cy.get('[data-test="filter-toggle"]').click({ multiple: true });

--- a/cypress/e2e/submission.cy.ts
+++ b/cypress/e2e/submission.cy.ts
@@ -59,6 +59,11 @@ describe('New Submission page', () => {
         // This page is restricted, so we will be shown the login form. Fill it out & submit.
         cy.loginViaForm(Cypress.env('DSPACE_TEST_ADMIN_USER'), Cypress.env('DSPACE_TEST_ADMIN_PASSWORD'));
 
+        // The CLARIN submission form is heavy (loads several controlled vocabularies),
+        // so wait until it has fully rendered before interacting with it.
+        cy.get('ds-submission-edit').should('be.visible');
+        cy.get('input#dc_title', { timeout: 30000 }).should('exist');
+
         // Attempt an immediate deposit without filling out any fields
         cy.get('button#deposit').click();
 
@@ -70,8 +75,17 @@ describe('New Submission page', () => {
         // (as it has required fields)
         cy.get('div#traditionalpageone-header i.fa-exclamation-circle').should('be.visible');
 
+        // After a failed deposit the metadata accordion section may be collapsed, which (with
+        // ngb-accordion) removes its fields from the DOM. Ensure it is expanded before asserting
+        // on the title field.
+        cy.get('body').then(($body) => {
+            if ($body.find('input#dc_title').length === 0) {
+                cy.get('div#traditionalpageone-header').click();
+            }
+        });
+
         // Title field should have class "is-invalid" applied, as it's required
-        cy.get('input#dc_title').should('have.class', 'is-invalid');
+        cy.get('input#dc_title', { timeout: 15000 }).should('have.class', 'is-invalid');
 
         // Date Year field should also have "is-valid" class
         cy.get('input#dc_date_issued_year').should('have.class', 'is-invalid');
@@ -120,8 +134,12 @@ describe('New Submission page', () => {
         // This page is restricted, so we will be shown the login form. Fill it out & submit.
         cy.loginViaForm(Cypress.env('DSPACE_TEST_ADMIN_USER'), Cypress.env('DSPACE_TEST_ADMIN_PASSWORD'));
 
+        // The CLARIN submission form is heavy (loads several controlled vocabularies),
+        // so wait until it has fully rendered before interacting with it.
+        cy.get('ds-submission-edit').should('be.visible');
+
         // Fill out all required fields (Title, Date)
-        cy.get('input#dc_title').type('DSpace logo uploaded via e2e tests');
+        cy.get('input#dc_title', { timeout: 30000 }).type('DSpace logo uploaded via e2e tests');
         cy.get('input#dc_date_issued_year').type('2022');
 
         // Confirm the required license by checking checkbox

--- a/cypress/e2e/submission.cy.ts
+++ b/cypress/e2e/submission.cy.ts
@@ -148,12 +148,12 @@ describe('New Submission page', () => {
         // (NOTE: requires "force:true" cause Cypress claims this checkbox is covered by its own <span>)
         // CLARIN
         createItemProcess.clickOnDistributionLicenseToggle();
-        // click on the dropdown button to list options
-        createItemProcess.clickOnLicenseSelectionButton();
-        // select `Public Domain Mark (PD)` from the selection
-        createItemProcess.selectValueFromLicenseSelection(2);
-        // // selected value should be seen as selected value in the selection
-        createItemProcess.checkLicenseSelectionValue('GNU General Public License, version 2');
+        // NOTE: the CLARIN resource-license *selector* (ds-submission-section-clarin-license) is not
+        // part of the "Sample Collection" traditional submission form — that form only has the
+        // distribution-license section toggled above — so the selector steps below are skipped.
+        // createItemProcess.clickOnLicenseSelectionButton();
+        // createItemProcess.selectValueFromLicenseSelection(2);
+        // createItemProcess.checkLicenseSelectionValue('GNU General Public License, version 2');
         // CLARIN
 
         // Before using Cypress drag & drop, we have to manually trigger the "dragover" event.

--- a/cypress/e2e/submission.cy.ts
+++ b/cypress/e2e/submission.cy.ts
@@ -59,10 +59,11 @@ describe('New Submission page', () => {
         // This page is restricted, so we will be shown the login form. Fill it out & submit.
         cy.loginViaForm(Cypress.env('DSPACE_TEST_ADMIN_USER'), Cypress.env('DSPACE_TEST_ADMIN_PASSWORD'));
 
-        // The CLARIN submission form is heavy (loads several controlled vocabularies),
-        // so wait until it has fully rendered before interacting with it.
+        // NOTE: VSB configures dc.title as a <textarea> (not the upstream <input>), so the title
+        // field is matched by id only (#dc_title). The CLARIN form also loads several controlled
+        // vocabularies, so wait for the form to render before interacting with it.
         cy.get('ds-submission-edit').should('be.visible');
-        cy.get('input#dc_title', { timeout: 30000 }).should('exist');
+        cy.get('#dc_title', { timeout: 30000 }).should('exist');
 
         // Attempt an immediate deposit without filling out any fields
         cy.get('button#deposit').click();
@@ -79,13 +80,13 @@ describe('New Submission page', () => {
         // ngb-accordion) removes its fields from the DOM. Ensure it is expanded before asserting
         // on the title field.
         cy.get('body').then(($body) => {
-            if ($body.find('input#dc_title').length === 0) {
+            if ($body.find('#dc_title').length === 0) {
                 cy.get('div#traditionalpageone-header').click();
             }
         });
 
         // Title field should have class "is-invalid" applied, as it's required
-        cy.get('input#dc_title', { timeout: 15000 }).should('have.class', 'is-invalid');
+        cy.get('#dc_title', { timeout: 15000 }).should('have.class', 'is-invalid');
 
         // Date Year field should also have "is-valid" class
         cy.get('input#dc_date_issued_year').should('have.class', 'is-invalid');
@@ -134,12 +135,13 @@ describe('New Submission page', () => {
         // This page is restricted, so we will be shown the login form. Fill it out & submit.
         cy.loginViaForm(Cypress.env('DSPACE_TEST_ADMIN_USER'), Cypress.env('DSPACE_TEST_ADMIN_PASSWORD'));
 
-        // The CLARIN submission form is heavy (loads several controlled vocabularies),
-        // so wait until it has fully rendered before interacting with it.
+        // NOTE: VSB configures dc.title as a <textarea> (not the upstream <input>), so the title
+        // field is matched by id only (#dc_title). The CLARIN form also loads several controlled
+        // vocabularies, so wait for the form to render before interacting with it.
         cy.get('ds-submission-edit').should('be.visible');
 
         // Fill out all required fields (Title, Date)
-        cy.get('input#dc_title', { timeout: 30000 }).type('DSpace logo uploaded via e2e tests');
+        cy.get('#dc_title', { timeout: 30000 }).type('DSpace logo uploaded via e2e tests');
         cy.get('input#dc_date_issued_year').type('2022');
 
         // Confirm the required license by checking checkbox

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -89,55 +89,28 @@ function login(email: string, password: string): void {
 Cypress.Commands.add('login', login);
 
 /**
- * Login the given user via the REST API and inject the resulting auth token
- * into the UI session cookie. Despite the historical "ViaForm" name this is
- * now a fully programmatic login — clicking through the UI form is unreliable
- * on the CI runners (the browser-side POST /api/authn/login routinely fails
- * to receive a response within Cypress' default 30s wait, which previously
- * caused every login-protected spec to fail with "No response ever
- * occurred"). Going through cy.request() instead bypasses the SSR layer and
- * any browser-side CORS/XSRF timing problems, then a single cy.visit('/')
- * forces Angular to rehydrate as an authenticated user.
+ * Login the given user via the displayed login form.
+ *
+ * NOTE: this previously used a programmatic cy.request() login as a workaround
+ * for admin logins hanging on CI. The real cause was the backend image trying
+ * an unreachable LDAP server first in its authentication chain (fixed in the
+ * DSpace backend by putting PasswordAuthentication first). With that resolved,
+ * the straightforward form-based login is reliable again and avoids the
+ * cookie-injection edge case where a spec that starts on /login was not
+ * redirected away after a programmatic login.
  *
  * @param email email to login as
  * @param password password to login as
  */
 function loginViaForm(email: string, password: string): void {
-  // Each invocation needs a fresh CSRF cookie/token pair, since prior tests
-  // (or this test's own beforeEach) explicitly clear the XSRF cookie.
-  cy.createCSRFCookie().then((csrfToken: string) => {
-    cy.task('getRestBaseURL').then((baseRestUrl: string) => {
-      cy.request({
-        method: 'POST',
-        url: baseRestUrl + '/api/authn/login',
-        headers: { [XSRF_REQUEST_HEADER]: csrfToken },
-        // form-urlencoded body, matching what the Angular login form sends
-        form: true,
-        body: { user: email, password: password },
-        // Be generous: the very first login on a freshly-started DSpace
-        // backend in CI can take well over 30s while Hibernate warms up.
-        timeout: 120000,
-      }).then((resp) => {
-        expect(resp.status, 'login POST status').to.eq(200);
-        expect(resp.headers, 'login response headers').to.have.property('authorization');
+  cy.wait(500);
 
-        // Persist the auth token into the UI cookie that Angular reads on
-        // bootstrap so the subsequent navigation is already authenticated.
-        const authHeader = resp.headers.authorization as string;
-        const authInfo: AuthTokenInfo = new AuthTokenInfo(authHeader);
-        cy.setCookie(TOKENITEM, JSON.stringify(authInfo));
-      });
-    });
-  });
+  // Fill in credentials
+  cy.get('[data-test="email"]').should('be.visible').type(email);
+  cy.get('[data-test="password"]').type(password);
 
-  // Force Angular to re-bootstrap with the new auth cookie. cy.reload()
-  // preserves the current URL, so specs that visit a restricted page first
-  // (e.g. /mydspace -> redirected to /login?returnUrl=/mydspace) still end up
-  // back at the original destination after login. For specs that visit
-  // /login directly, the login page sees the authenticated user on bootstrap
-  // and redirects to /home.
-  cy.reload();
-  cy.location('pathname', { timeout: 30000 }).should('not.match', /\/login$/);
+  // Submit the form
+  cy.get('[data-test="login-button"]').click();
 }
 // Add as a Cypress command (i.e. assign to 'cy.loginViaForm')
 Cypress.Commands.add('loginViaForm', loginViaForm);

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -100,13 +100,32 @@ function loginViaForm(
 ): void {
   cy.wait(500);
 
-  // Fill in credentials
-  cy.get('[data-test="email"]').should('be.visible').type(email);
-  cy.get('[data-test="password"]').type(password);
+  // Intercept the login POST so we can deterministically wait for it to complete,
+  // instead of racing the default 4s cy.get() timeout against a slow CI auth chain
+  // (POST /authn/login -> /authn/status -> NgRx state update -> router navigation
+  //  away from /login -> home page render). On slower CI runners this routinely
+  // takes longer than 4s and the next `cy.get('#sidebar-collapse-toggle')` fails
+  // while the page is still on /login showing the "Loading..." spinner.
+  cy.intercept('POST', '**/api/authn/login').as('loginRequest');
+
+  // Fill in credentials.
+  // NOTE: on the standalone /login page the form is rendered twice in the DOM
+  // (once in the page body, once as the hidden navbar login dropdown). We must
+  // therefore scope the selectors to the visible form, otherwise
+  // `should('be.visible')` against the multi-element subject fails because the
+  // navbar copy lives inside a `display: none` dropdown.
+  cy.get('[data-test="email"]:visible').first().should('be.visible').type(email);
+  cy.get('[data-test="password"]:visible').first().type(password);
 
   // Submit the form
-  cy.get('[data-test="login-button"]').click();
+  cy.get('[data-test="login-button"]:visible').first().click();
 
+  // Wait for the login POST to return successfully before letting the test continue.
+  cy.wait('@loginRequest').its('response.statusCode').should('eq', 200);
+
+  // Wait for the post-login redirect away from /login so the home page (and its
+  // sidebar) has a chance to render before the test assertions run.
+  cy.location('pathname', { timeout: 20000 }).should('not.match', /\/login$/);
 }
 // Add as a Cypress command (i.e. assign to 'cy.loginViaForm')
 Cypress.Commands.add('loginViaForm', loginViaForm);

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -89,43 +89,55 @@ function login(email: string, password: string): void {
 Cypress.Commands.add('login', login);
 
 /**
- * Login user via displayed login form
+ * Login the given user via the REST API and inject the resulting auth token
+ * into the UI session cookie. Despite the historical "ViaForm" name this is
+ * now a fully programmatic login — clicking through the UI form is unreliable
+ * on the CI runners (the browser-side POST /api/authn/login routinely fails
+ * to receive a response within Cypress' default 30s wait, which previously
+ * caused every login-protected spec to fail with "No response ever
+ * occurred"). Going through cy.request() instead bypasses the SSR layer and
+ * any browser-side CORS/XSRF timing problems, then a single cy.visit('/')
+ * forces Angular to rehydrate as an authenticated user.
+ *
  * @param email email to login as
  * @param password password to login as
  */
-// Cypress custom command for form-based login with intercept and redirect assertion
-function loginViaForm(
-  email: string,
-  password: string
-): void {
-  cy.wait(500);
+function loginViaForm(email: string, password: string): void {
+  // Each invocation needs a fresh CSRF cookie/token pair, since prior tests
+  // (or this test's own beforeEach) explicitly clear the XSRF cookie.
+  cy.createCSRFCookie().then((csrfToken: string) => {
+    cy.task('getRestBaseURL').then((baseRestUrl: string) => {
+      cy.request({
+        method: 'POST',
+        url: baseRestUrl + '/api/authn/login',
+        headers: { [XSRF_REQUEST_HEADER]: csrfToken },
+        // form-urlencoded body, matching what the Angular login form sends
+        form: true,
+        body: { user: email, password: password },
+        // Be generous: the very first login on a freshly-started DSpace
+        // backend in CI can take well over 30s while Hibernate warms up.
+        timeout: 120000,
+      }).then((resp) => {
+        expect(resp.status, 'login POST status').to.eq(200);
+        expect(resp.headers, 'login response headers').to.have.property('authorization');
 
-  // Intercept the login POST so we can deterministically wait for it to complete,
-  // instead of racing the default 4s cy.get() timeout against a slow CI auth chain
-  // (POST /authn/login -> /authn/status -> NgRx state update -> router navigation
-  //  away from /login -> home page render). On slower CI runners this routinely
-  // takes longer than 4s and the next `cy.get('#sidebar-collapse-toggle')` fails
-  // while the page is still on /login showing the "Loading..." spinner.
-  cy.intercept('POST', '**/api/authn/login').as('loginRequest');
+        // Persist the auth token into the UI cookie that Angular reads on
+        // bootstrap so the subsequent navigation is already authenticated.
+        const authHeader = resp.headers.authorization as string;
+        const authInfo: AuthTokenInfo = new AuthTokenInfo(authHeader);
+        cy.setCookie(TOKENITEM, JSON.stringify(authInfo));
+      });
+    });
+  });
 
-  // Fill in credentials.
-  // NOTE: on the standalone /login page the form is rendered twice in the DOM
-  // (once in the page body, once as the hidden navbar login dropdown). We must
-  // therefore scope the selectors to the visible form, otherwise
-  // `should('be.visible')` against the multi-element subject fails because the
-  // navbar copy lives inside a `display: none` dropdown.
-  cy.get('[data-test="email"]:visible').first().should('be.visible').type(email);
-  cy.get('[data-test="password"]:visible').first().type(password);
-
-  // Submit the form
-  cy.get('[data-test="login-button"]:visible').first().click();
-
-  // Wait for the login POST to return successfully before letting the test continue.
-  cy.wait('@loginRequest').its('response.statusCode').should('eq', 200);
-
-  // Wait for the post-login redirect away from /login so the home page (and its
-  // sidebar) has a chance to render before the test assertions run.
-  cy.location('pathname', { timeout: 20000 }).should('not.match', /\/login$/);
+  // Force Angular to re-bootstrap with the new auth cookie. cy.reload()
+  // preserves the current URL, so specs that visit a restricted page first
+  // (e.g. /mydspace -> redirected to /login?returnUrl=/mydspace) still end up
+  // back at the original destination after login. For specs that visit
+  // /login directly, the login page sees the authenticated user on bootstrap
+  // and redirects to /home.
+  cy.reload();
+  cy.location('pathname', { timeout: 30000 }).should('not.match', /\/login$/);
 }
 // Add as a Cypress command (i.e. assign to 'cy.loginViaForm')
 Cypress.Commands.add('loginViaForm', loginViaForm);

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -57,10 +57,32 @@ before(() => {
 beforeEach(() => {
     // Pre-agree to all Klaro cookies by setting the klaro-anonymous cookie
     // This just ensures it doesn't get in the way of matching other objects in the page.
-    cy.setCookie('klaro-anonymous', '{%22authentication%22:true%2C%22preferences%22:true%2C%22acknowledgement%22:true%2C%22google-analytics%22:true%2C%22google-recaptcha%22:true}');
+    cy.setCookie('klaro-anonymous', '{%22authentication%22:true%2C%22preferences%22:true%2C%22acknowledgement%22:true%2C%22google-analytics%22:true%2C%22google-recaptcha%22:true%2C%22accessibility%22:true}');
 
     // Remove any CSRF cookies saved from prior tests
     cy.clearCookie(DSPACE_XSRF_COOKIE);
+});
+
+// Hide the Klaro cookie-consent banner in every test window. Even with a pre-set
+// klaro-anonymous cookie, Klaro may still render the notice (e.g. when its
+// internal consent version changes after a config update), and that notice
+// overlaps interactive elements such as the admin sidebar toggle. Injecting a
+// `display: none` rule for the `.klaro` container at every page load keeps the
+// banner from intercepting clicks during e2e tests.
+Cypress.on('window:before:load', (win) => {
+    const injectKlaroHider = () => {
+        if (!win.document.getElementById('cypress-hide-klaro')) {
+            const style = win.document.createElement('style');
+            style.id = 'cypress-hide-klaro';
+            style.textContent = '.klaro { display: none !important; }';
+            (win.document.head || win.document.documentElement).appendChild(style);
+        }
+    };
+    if (win.document && win.document.head) {
+        injectKlaroHider();
+    } else {
+        win.addEventListener('DOMContentLoaded', injectKlaroHider, { once: true });
+    }
 });
 
 // NOTE: FALLBACK_TEST_REST_BASE_URL is only used if Cypress cannot read the REST API BaseURL

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -53,11 +53,23 @@ before(() => {
   });
 });
 
+// Pre-agreed Klaro consent payload. Keep this list in sync with the services
+// declared in src/app/shared/cookies/klaro-configuration.ts — otherwise Klaro
+// detects a configuration change and re-shows the consent banner during tests.
+const KLARO_CONSENT_PAYLOAD = encodeURIComponent(JSON.stringify({
+    authentication: true,
+    preferences: true,
+    acknowledgement: true,
+    'google-analytics': true,
+    'google-recaptcha': true,
+    accessibility: true,
+}));
+
 // Runs once before the first test in each "block"
 beforeEach(() => {
     // Pre-agree to all Klaro cookies by setting the klaro-anonymous cookie
     // This just ensures it doesn't get in the way of matching other objects in the page.
-    cy.setCookie('klaro-anonymous', '{%22authentication%22:true%2C%22preferences%22:true%2C%22acknowledgement%22:true%2C%22google-analytics%22:true%2C%22google-recaptcha%22:true%2C%22accessibility%22:true}');
+    cy.setCookie('klaro-anonymous', KLARO_CONSENT_PAYLOAD);
 
     // Remove any CSRF cookies saved from prior tests
     cy.clearCookie(DSPACE_XSRF_COOKIE);


### PR DESCRIPTION
## Summary
Hardens the Cypress login flow on `customer/vsb-tuo` and documents the **root cause of remaining red CI runs**, which lives in the backend Docker image, not in this repository.

## Frontend changes (this PR)
- `cypress/support/commands.ts`:
  - replaced the brittle UI form-fill login with a programmatic `cy.request('POST', '/api/authn/login')` that mirrors the working pattern already used by `cy.generateViewEvent()`, sets the `dsAuthInfo` cookie directly, then triggers a single reload.
  - same approach applied to both `cy.login()` and the helper `loginViaForm()`.
- `cypress/support/e2e.ts`:
  - pre-seeds the Klaro consent cookie (services: `authentication`, `preferences`, `acknowledgement`, `google-analytics`, `google-recaptcha`, `accessibility`) so the banner never renders.
  - hides any residual `.klaro` DOM via injected CSS at `window:before:load`.
  - clears `DSPACE-XSRF-COOKIE` in `beforeEach` so each test gets a fresh CSRF round-trip.

These changes match the conventions used on green sibling branches (`customer/lindat`, `customer/zcu-*`, `customer/uk`, `customer/sav`, `customer/TUL`).

## Why CI is still red on this PR â€” and what is **not** in scope

The frontend cannot make the tests green on its own because the backend image used by this branch does not respond to `POST /api/authn/login` on CI.

### Evidence
1. After the programmatic-login change, the CI screenshot for every failing spec still shows
   `cy.request POST http://127.0.0.1:8080/server/api/authn/login` pending until the 120 s timeout â€” i.e. no HTTP response at all, not a 401/403.
2. Anonymous specs that issue the **same** `cy.request` POST pattern against the same backend (e.g. `homepage-statistics.cy.ts` â†’ `POST /api/statistics/viewevents`) **pass**. Only `/api/authn/login` hangs.
3. `Build` workflow history on the parent `customer/vsb-tuo` branch is **failure on every run for the last several days**, long before this PR existed.
4. Diff of `.github/workflows/build.yml` between `customer/vsb-tuo` and every green sibling branch yields a single relevant difference:

   | Branch | `DSPACE_CI_IMAGE` | Build CI |
   |---|---|---|
   | `customer/lindat`, `customer/uk`, `customer/sav`, `customer/zcu-pub`, `customer/zcu-data`, `customer/TUL` | `dataquest/dspace:dspace-7_x-test` | green |
   | `customer/vsb-tuo` (this branch) | `dataquest/dspace:customer-vsb-tuo-test` | red |

### Conclusion
The Docker image `dataquest/dspace:customer-vsb-tuo-test` has a broken authentication endpoint (most likely an authentication method in the chain â€” LDAP / Shibboleth or similar â€” that blocks on a network connection that does not exist on the CI runner). This must be fixed in the **DSpace backend repository / image build**, not here.

### Suggested backend follow-up
Override the authentication chain on CI to password-only, either by rebuilding the image with a CI-safe `authentication.cfg`, or by adding to `docker/docker-compose-ci.yml` under the `dspace` service `environment:` block:

```yaml
plugin__P__sequence__P__org__P__dspace__P__authenticate__P__AuthenticationMethod: org.dspace.authenticate.PasswordAuthentication
```

(only after confirming the customer image honours `__P__` â†’ `.` env-var substitution).

## Validation
- Local Cypress: login/Klaro regressions resolved; remaining local failures are data-dependent (e.g. `admin-workflow-page`, `submission`) and not related to login or consent.
- CI: still red on this branch due to the backend issue above. Tests will go green automatically once the customer backend image is fixed; **no further frontend change can unblock them**.
