### PR TITLE
ZCU-DATA/Fix-author-redirect

### DIFF
--- a/src/app/shared/clarin-shared-util.ts
+++ b/src/app/shared/clarin-shared-util.ts
@@ -84,8 +84,6 @@ export function loadItemAuthors(item, itemAuthors, baseUrl, fields, orcidDomainU
   authorsMV.forEach((authorMV: MetadataValue) => {
     let isOrcid = false;
     let orcidUrl: string;
-    let searchValue: string;
-    let searchOperator: string;
     if (authorMV.authority) {
       const authority = String(authorMV.authority).trim();
       if (ORCID_URL_PATTERN.test(authority)) {
@@ -95,13 +93,10 @@ export function loadItemAuthors(item, itemAuthors, baseUrl, fields, orcidDomainU
         orcidUrl = `${domain}/${authority}`;
         isOrcid = true;
       }
-      searchValue = encodeURIComponent(authorMV.authority);
-      searchOperator = 'authority';
-    } else {
-      searchValue = encodeURIComponent(authorMV.value);
-      searchOperator = 'equals';
     }
-    const authorSearchLink = baseUrl + '/search?f.author=' + searchValue + ',' + searchOperator;
+    // Always redirect search by author name (equals), regardless of authority/ORCID.
+    // The ORCID iD is only used to build the orcidUrl for the ORCID icon link.
+    const authorSearchLink = baseUrl + '/search?f.author=' + encodeURIComponent(authorMV.value) + ',equals';
     const authorNameLink = Object.assign(new AuthorNameLink(), {
       name: authorMV.value,
       url: authorSearchLink,


### PR DESCRIPTION
## Problem description
When clicking on author with orcid id, the redirect should be with name of author not like this:
<img width="613" height="254" alt="image" src="https://github.com/user-attachments/assets/2f9df79c-d75d-480f-8820-1d61740e2065" />
http://dev-5.pc:89/search?f.author=0000-1234-5678-9123,authority

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [x] Requested review from Copilot