### PR TITLE
ZCU-PUB/Update author redirect based on configuration

### DIFF
--- a/src/app/shared/object-list/metadata-representation-list-element/plain-text/plain-text-metadata-list-element.component.html
+++ b/src/app/shared/object-list/metadata-representation-list-element/plain-text/plain-text-metadata-list-element.component.html
@@ -8,20 +8,41 @@
     {{mdRepresentation.getValue()}}
   </a>
   <ng-container *ngIf="(mdRepresentation.representationType=='authority_controlled')">
-    <ng-container *ngIf="orcidDomainUrl$ | async as orcidDomainUrl; else noOrcidDomain">
-      <a *ngIf="isOrcidAuthority(orcidDomainUrl); else plainAuthority"
-         class="dont-break-out orcid-author-link"
-         [href]="getOrcidUrl(orcidDomainUrl)"
-         target="_blank"
-         rel="noopener noreferrer">
-        {{mdRepresentation.getValue()}}
-        <i class="fa-brands fa-orcid orcid-icon" aria-hidden="true"></i>
-      </a>
-      <ng-template #plainAuthority>
-        <span class="dont-break-out">{{mdRepresentation.getValue()}}</span>
+    <ng-container *ngIf="isOrcidAuthority(); else plainAuthority">
+      <ng-container *ngIf="(authorOrcidLinkTarget$ | async) === 'orcid'; else searchModeOrcid">
+        <!-- linkTarget === 'orcid': the whole author name + icon link to the ORCID profile. -->
+        <a class="dont-break-out orcid-author-link"
+           [href]="getOrcidUrl()"
+           target="_blank"
+           rel="noopener noreferrer"
+           [title]="'item.view.box.author.preview.orcid-link.title' | translate"
+           [attr.aria-label]="('item.view.box.author.preview.orcid-link.title' | translate) + ' ' + mdRepresentation.getValue()">
+          {{mdRepresentation.getValue()}}
+          <i class="fa-brands fa-orcid orcid-icon" aria-hidden="true"></i>
+        </a>
+      </ng-container>
+      <ng-template #searchModeOrcid>
+        <!-- Default linkTarget === 'browse': author name navigates to the browse-by-author page;
+             the ORCID icon is rendered as a separate link to the ORCID profile. -->
+        <ng-container *ngIf="hasBrowseDefinition(); else searchModeOrcidNoBrowse">
+          <a class="dont-break-out ds-browse-link"
+             [routerLink]="['/browse/', mdRepresentation.browseDefinition.id]"
+             [queryParams]="getAuthorityBrowseQueryParams()">
+            {{mdRepresentation.getValue()}}
+          </a>
+        </ng-container>
+        <ng-template #searchModeOrcidNoBrowse>
+          <span class="dont-break-out">{{mdRepresentation.getValue()}}</span>
+        </ng-template>
+        <a class="orcid-icon-link"
+           [href]="getOrcidUrl()"
+           target="_blank"
+           rel="noopener noreferrer"
+           [title]="'item.view.box.author.preview.orcid-link.title' | translate"><i
+          class="fa-brands fa-orcid orcid-icon" aria-hidden="true"></i></a>
       </ng-template>
     </ng-container>
-    <ng-template #noOrcidDomain>
+    <ng-template #plainAuthority>
       <span class="dont-break-out">{{mdRepresentation.getValue()}}</span>
     </ng-template>
   </ng-container>

--- a/src/app/shared/object-list/metadata-representation-list-element/plain-text/plain-text-metadata-list-element.component.scss
+++ b/src/app/shared/object-list/metadata-representation-list-element/plain-text/plain-text-metadata-list-element.component.scss
@@ -6,6 +6,14 @@
   }
 }
 
+.orcid-icon-link {
+  text-decoration: none;
+
+  &:hover {
+    opacity: 0.8;
+  }
+}
+
 .orcid-icon {
   color: #a6ce39; // Official ORCID green color
   font-size: 1em;

--- a/src/app/shared/object-list/metadata-representation-list-element/plain-text/plain-text-metadata-list-element.component.spec.ts
+++ b/src/app/shared/object-list/metadata-representation-list-element/plain-text/plain-text-metadata-list-element.component.spec.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, NO_ERRORS_SCHEMA } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
 
 import { ConfigurationDataService } from '../../../../core/data/configuration-data.service';
 import { MetadatumRepresentation } from '../../../../core/shared/metadata-representation/metadatum/metadatum-representation.model';
@@ -34,9 +35,12 @@ const mockOrcidWithWhitespaceRepresentation = Object.assign(new MetadatumReprese
 });
 
 const mockConfigurationDataService = {
-  findByPropertyName: jasmine.createSpy('findByPropertyName').and.returnValue(
-    createSuccessfulRemoteDataObject$({ values: ['https://orcid.org'] }),
-  ),
+  findByPropertyName: jasmine.createSpy('findByPropertyName').and.callFake((property: string) => {
+    if (property === 'orcid.author.link-target') {
+      return createSuccessfulRemoteDataObject$({ values: ['browse'] });
+    }
+    return createSuccessfulRemoteDataObject$({ values: ['https://orcid.org'] });
+  }),
 };
 
 describe('PlainTextMetadataListElementComponent', () => {
@@ -45,7 +49,7 @@ describe('PlainTextMetadataListElementComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [],
+      imports: [TranslateModule.forRoot()],
       declarations: [PlainTextMetadataListElementComponent],
       providers: [
         { provide: ConfigurationDataService, useValue: mockConfigurationDataService },
@@ -74,6 +78,7 @@ describe('PlainTextMetadataListElementComponent', () => {
   describe('when metadata has ORCID authority', () => {
     beforeEach(() => {
       comp.mdRepresentation = mockOrcidRepresentation;
+      comp.authorOrcidLinkTarget$.next('orcid');
       fixture.detectChanges();
     });
 
@@ -90,11 +95,11 @@ describe('PlainTextMetadataListElementComponent', () => {
     });
 
     it('isOrcidAuthority should return true', () => {
-      expect(comp.isOrcidAuthority(comp.orcidDomainUrl$.value)).toBeTrue();
+      expect(comp.isOrcidAuthority()).toBeTrue();
     });
 
     it('getOrcidUrl should return full ORCID URL', () => {
-      expect(comp.getOrcidUrl(comp.orcidDomainUrl$.value)).toBe('https://orcid.org/1234-5678-9012-3456');
+      expect(comp.getOrcidUrl()).toBe('https://orcid.org/1234-5678-9012-3456');
     });
   });
 
@@ -116,7 +121,7 @@ describe('PlainTextMetadataListElementComponent', () => {
     });
 
     it('isOrcidAuthority should return false', () => {
-      expect(comp.isOrcidAuthority(comp.orcidDomainUrl$.value)).toBeFalse();
+      expect(comp.isOrcidAuthority()).toBeFalse();
     });
   });
 
@@ -124,13 +129,13 @@ describe('PlainTextMetadataListElementComponent', () => {
     it('should not double-slash when domain URL ends with /', () => {
       comp.orcidDomainUrl$.next('https://orcid.org/');
       comp.mdRepresentation = mockOrcidRepresentation;
-      expect(comp.getOrcidUrl('https://orcid.org/')).toBe('https://orcid.org/1234-5678-9012-3456');
+      expect(comp.getOrcidUrl()).toBe('https://orcid.org/1234-5678-9012-3456');
     });
 
     it('should add slash when domain URL does not end with /', () => {
       comp.orcidDomainUrl$.next('https://sandbox.orcid.org');
       comp.mdRepresentation = mockOrcidRepresentation;
-      expect(comp.getOrcidUrl('https://sandbox.orcid.org')).toBe('https://sandbox.orcid.org/1234-5678-9012-3456');
+      expect(comp.getOrcidUrl()).toBe('https://sandbox.orcid.org/1234-5678-9012-3456');
     });
   });
 
@@ -147,11 +152,11 @@ describe('PlainTextMetadataListElementComponent', () => {
     });
 
     it('isOrcidAuthority should return false', () => {
-      expect(comp.isOrcidAuthority(comp.orcidDomainUrl$.value)).toBeFalse();
+      expect(comp.isOrcidAuthority()).toBeFalse();
     });
 
     it('getOrcidUrl should return empty string', () => {
-      expect(comp.getOrcidUrl(comp.orcidDomainUrl$.value)).toBe('');
+      expect(comp.getOrcidUrl()).toBe('');
     });
   });
 
@@ -159,13 +164,13 @@ describe('PlainTextMetadataListElementComponent', () => {
     it('should return empty string when orcidDomainUrl is null', () => {
       comp.orcidDomainUrl$.next(null);
       comp.mdRepresentation = mockOrcidRepresentation;
-      expect(comp.getOrcidUrl(null)).toBe('');
+      expect(comp.getOrcidUrl()).toBe('');
     });
 
     it('should return empty string when mdRepresentation has no authority', () => {
       comp.orcidDomainUrl$.next('https://orcid.org');
       comp.mdRepresentation = mockMetadataRepresentation;
-      expect(comp.getOrcidUrl('https://orcid.org')).toBe('');
+      expect(comp.getOrcidUrl()).toBe('');
     });
   });
 
@@ -177,11 +182,11 @@ describe('PlainTextMetadataListElementComponent', () => {
     });
 
     it('isOrcidAuthority should return true after trimming', () => {
-      expect(comp.isOrcidAuthority(comp.orcidDomainUrl$.value)).toBeTrue();
+      expect(comp.isOrcidAuthority()).toBeTrue();
     });
 
     it('getOrcidUrl should return trimmed ORCID URL', () => {
-      expect(comp.getOrcidUrl(comp.orcidDomainUrl$.value)).toBe('https://orcid.org/1234-5678-9012-3456');
+      expect(comp.getOrcidUrl()).toBe('https://orcid.org/1234-5678-9012-3456');
     });
   });
 });

--- a/src/app/shared/object-list/metadata-representation-list-element/plain-text/plain-text-metadata-list-element.component.ts
+++ b/src/app/shared/object-list/metadata-representation-list-element/plain-text/plain-text-metadata-list-element.component.ts
@@ -37,7 +37,7 @@ export class PlainTextMetadataListElementComponent extends MetadataRepresentatio
 
   /**
    * Target of the link rendered on the author name for an ORCID author. Loaded from the
-   * backend property `item.author.orcid.link-target`.
+    * backend property `orcid.author.link-target`.
    */
   authorOrcidLinkTarget$ = new BehaviorSubject<AuthorOrcidLinkTarget>(DEFAULT_AUTHOR_ORCID_LINK_TARGET);
 

--- a/src/app/shared/object-list/metadata-representation-list-element/plain-text/plain-text-metadata-list-element.component.ts
+++ b/src/app/shared/object-list/metadata-representation-list-element/plain-text/plain-text-metadata-list-element.component.ts
@@ -4,9 +4,16 @@ import { BehaviorSubject } from 'rxjs';
 import { ConfigurationDataService } from '../../../../core/data/configuration-data.service';
 import { MetadataRepresentationType } from '../../../../core/shared/metadata-representation/metadata-representation.model';
 import { MetadatumRepresentation } from '../../../../core/shared/metadata-representation/metadatum/metadatum-representation.model';
-import { getFirstCompletedRemoteData } from '../../../../core/shared/operators';
 import { VALUE_LIST_BROWSE_DEFINITION } from '../../../../core/shared/value-list-browse-definition.resource-type';
 import { metadataRepresentationComponent } from '../../../metadata-representation/metadata-representation.decorator';
+import {
+  AuthorOrcidLinkTarget,
+  buildOrcidProfileUrl,
+  DEFAULT_AUTHOR_ORCID_LINK_TARGET,
+  isOrcidAuthorityValue,
+  loadAuthorOrcidLinkTarget,
+  loadOrcidDomainUrl,
+} from '../../../utils/orcid-author.util';
 import { MetadataRepresentationListElementComponent } from '../metadata-representation-list-element.component';
 
 @metadataRepresentationComponent('Publication', MetadataRepresentationType.PlainText)
@@ -24,30 +31,23 @@ import { MetadataRepresentationListElementComponent } from '../metadata-represen
 export class PlainTextMetadataListElementComponent extends MetadataRepresentationListElementComponent implements OnInit {
 
   /**
-   * Regex pattern for ORCID identifiers: four groups of four digits separated by hyphens.
-   * The last group may end with an X (checksum digit).
+   * ORCID domain URL loaded from the backend.
    */
-  private static readonly ORCID_PATTERN = /^\d{4}-\d{4}-\d{4}-(\d{3}X|\d{4})$/;
-
   orcidDomainUrl$ = new BehaviorSubject<string | null>(null);
+
+  /**
+   * Target of the link rendered on the author name for an ORCID author. Loaded from the
+   * backend property `item.author.orcid.link-target`.
+   */
+  authorOrcidLinkTarget$ = new BehaviorSubject<AuthorOrcidLinkTarget>(DEFAULT_AUTHOR_ORCID_LINK_TARGET);
 
   constructor(private configurationService: ConfigurationDataService) {
     super();
   }
 
   ngOnInit(): void {
-    this.configurationService.findByPropertyName('orcid.domain-url').pipe(
-      getFirstCompletedRemoteData(),
-    ).subscribe((rd) => {
-      if (rd.hasFailed || !rd.hasSucceeded || !rd.payload?.values?.length) {
-        return;
-      }
-
-      const url = rd.payload.values[0]?.trim();
-      if (url && /^https?:\/\//i.test(url)) {
-        this.orcidDomainUrl$.next(url);
-      }
-    });
+    loadOrcidDomainUrl(this.configurationService).then((url) => this.orcidDomainUrl$.next(url));
+    loadAuthorOrcidLinkTarget(this.configurationService).then((t) => this.authorOrcidLinkTarget$.next(t));
   }
 
   /**
@@ -62,30 +62,46 @@ export class PlainTextMetadataListElementComponent extends MetadataRepresentatio
     return queryParams;
   }
 
-  isOrcidAuthority(orcidDomainUrl: string | null): boolean {
-    if (orcidDomainUrl === null) {
-      return false;
-    }
-    if (this.mdRepresentation instanceof MetadatumRepresentation) {
-      const authority = this.mdRepresentation.authority?.trim();
-      return !!authority && PlainTextMetadataListElementComponent.ORCID_PATTERN.test(authority);
-    }
-    return false;
+  /**
+   * Query parameters for the browse link of an authority-controlled value (e.g. ORCID author).
+   * Passes both `value` and `authority` so the browse page can call the REST endpoint with
+   * `filterValue` + `filterAuthority` and resolve items whose metadata is indexed by authority key.
+   */
+  getAuthorityBrowseQueryParams() {
+    return {
+      value: this.mdRepresentation.getValue(),
+      authority: this.getAuthority(),
+    };
   }
 
-  getOrcidUrl(orcidDomainUrl: string | null): string {
-    if (orcidDomainUrl === null) {
-      return '';
-    }
-    const authority = this.mdRepresentation instanceof MetadatumRepresentation
-      ? this.mdRepresentation.authority?.trim()
-      : undefined;
+  /**
+   * True when the current metadatum carries a browse definition (e.g. `dc.contributor.author`),
+   * which means the value can be rendered as a clickable browse link.
+   */
+  hasBrowseDefinition(): boolean {
+    return !!this.mdRepresentation?.browseDefinition;
+  }
 
-    if (!authority || !PlainTextMetadataListElementComponent.ORCID_PATTERN.test(authority)) {
-      return '';
-    }
+  /**
+   * Check whether the authority value of this metadata is an ORCID identifier.
+   * Accepts either a bare ORCID iD or a full ORCID URL.
+   */
+  isOrcidAuthority(): boolean {
+    return isOrcidAuthorityValue(this.getAuthority(), this.orcidDomainUrl$.value);
+  }
 
-    const base = orcidDomainUrl.endsWith('/') ? orcidDomainUrl : orcidDomainUrl + '/';
-    return `${base}${authority}`;
+  /**
+   * Build the full ORCID profile URL for the current author. Returns an empty string when
+   * the authority is not an ORCID value or when the ORCID domain URL is required but missing.
+   */
+  getOrcidUrl(): string {
+    return buildOrcidProfileUrl(this.getAuthority(), this.orcidDomainUrl$.value);
+  }
+
+  private getAuthority(): string | undefined {
+    if (this.mdRepresentation instanceof MetadatumRepresentation) {
+      return this.mdRepresentation.authority?.trim();
+    }
+    return undefined;
   }
 }

--- a/src/app/shared/utils/orcid-author.util.ts
+++ b/src/app/shared/utils/orcid-author.util.ts
@@ -14,7 +14,7 @@ export const ORCID_ID_PATTERN = /^(\d{4}-){3}\d{3}[\dX]$/i;
 export const ORCID_URL_PATTERN = /^https?:\/\/[^/]+\/((\d{4}-){3}\d{3}[\dX])$/i;
 
 /**
- * Type of the backend property `item.author.orcid.link-target`.
+ * Type of the backend property `orcid.author.link-target`.
  * Controls the target of the link rendered on the author name for an ORCID-authority author.
  * Any unknown / unset value falls back to the default (`browse`).
  */
@@ -24,10 +24,10 @@ export type AuthorOrcidLinkTarget = string;
  * Name of the backend configuration property that controls the author-name link target
  * for ORCID-authority authors.
  */
-export const AUTHOR_ORCID_LINK_TARGET_PROPERTY = 'item.author.orcid.link-target';
+export const AUTHOR_ORCID_LINK_TARGET_PROPERTY = 'orcid.author.link-target';
 
 /**
- * Default value used when `item.author.orcid.link-target` is unset, invalid, or unreachable.
+ * Default value used when `orcid.author.link-target` is unset, invalid, or unreachable.
  */
 export const DEFAULT_AUTHOR_ORCID_LINK_TARGET: AuthorOrcidLinkTarget = 'browse';
 
@@ -49,7 +49,7 @@ export function loadOrcidDomainUrl(
 }
 
 /**
- * Load `item.author.orcid.link-target` from the backend configuration.
+ * Load `orcid.author.link-target` from the backend configuration.
  * Returns the default (`browse`) when the property is unset or invalid.
  */
 export function loadAuthorOrcidLinkTarget(

--- a/src/app/shared/utils/orcid-author.util.ts
+++ b/src/app/shared/utils/orcid-author.util.ts
@@ -66,8 +66,23 @@ export function loadAuthorOrcidLinkTarget(
 }
 
 /**
+ * Extract the lowercase host of an absolute http(s) URL. Returns null on invalid input.
+ */
+function getHost(url: string | null | undefined): string | null {
+  if (!url) {
+    return null;
+  }
+  try {
+    return new URL(url).host.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/**
  * True when the authority string is a recognised ORCID value (bare iD or full URL).
  * Bare iDs require `orcidDomainUrl` so the link can be built without guessing the domain.
+ * URL authorities are only accepted when their host matches the configured ORCID domain.
  */
 export function isOrcidAuthorityValue(authority: string | undefined | null, orcidDomainUrl: string | null): boolean {
   if (!authority) {
@@ -75,7 +90,8 @@ export function isOrcidAuthorityValue(authority: string | undefined | null, orci
   }
   const trimmed = authority.trim();
   if (ORCID_URL_PATTERN.test(trimmed)) {
-    return true;
+    const expectedHost = getHost(orcidDomainUrl);
+    return !!expectedHost && getHost(trimmed) === expectedHost;
   }
   return !!orcidDomainUrl && ORCID_ID_PATTERN.test(trimmed);
 }
@@ -83,6 +99,7 @@ export function isOrcidAuthorityValue(authority: string | undefined | null, orci
 /**
  * Build the full ORCID profile URL for the given authority. Returns an empty string when
  * the authority is not an ORCID value or when the ORCID domain URL is required but missing.
+ * URL authorities are only accepted when their host matches the configured ORCID domain.
  */
 export function buildOrcidProfileUrl(authority: string | undefined | null, orcidDomainUrl: string | null): string {
   if (!authority) {
@@ -90,7 +107,11 @@ export function buildOrcidProfileUrl(authority: string | undefined | null, orcid
   }
   const trimmed = authority.trim();
   if (ORCID_URL_PATTERN.test(trimmed)) {
-    return trimmed;
+    const expectedHost = getHost(orcidDomainUrl);
+    if (expectedHost && getHost(trimmed) === expectedHost) {
+      return trimmed;
+    }
+    return '';
   }
   if (orcidDomainUrl && ORCID_ID_PATTERN.test(trimmed)) {
     const domain = orcidDomainUrl.endsWith('/') ? orcidDomainUrl.slice(0, -1) : orcidDomainUrl;

--- a/src/app/shared/utils/orcid-author.util.ts
+++ b/src/app/shared/utils/orcid-author.util.ts
@@ -1,0 +1,100 @@
+import { ConfigurationDataService } from '../../core/data/configuration-data.service';
+import { getFirstSucceededRemoteDataPayload } from '../../core/shared/operators';
+
+/**
+ * Pattern that matches a bare ORCID iD (16 digits in groups of 4, last char may be X).
+ * Example: `0000-0001-2345-6789` or `0000-0001-2345-678X`.
+ */
+export const ORCID_ID_PATTERN = /^(\d{4}-){3}\d{3}[\dX]$/i;
+
+/**
+ * Pattern that matches a full ORCID URL authority value.
+ * Example: `https://orcid.org/0000-0001-2345-6789`.
+ */
+export const ORCID_URL_PATTERN = /^https?:\/\/[^/]+\/((\d{4}-){3}\d{3}[\dX])$/i;
+
+/**
+ * Type of the backend property `item.author.orcid.link-target`.
+ * Controls the target of the link rendered on the author name for an ORCID-authority author.
+ * Any unknown / unset value falls back to the default (`browse`).
+ */
+export type AuthorOrcidLinkTarget = string;
+
+/**
+ * Name of the backend configuration property that controls the author-name link target
+ * for ORCID-authority authors.
+ */
+export const AUTHOR_ORCID_LINK_TARGET_PROPERTY = 'item.author.orcid.link-target';
+
+/**
+ * Default value used when `item.author.orcid.link-target` is unset, invalid, or unreachable.
+ */
+export const DEFAULT_AUTHOR_ORCID_LINK_TARGET: AuthorOrcidLinkTarget = 'browse';
+
+/**
+ * Load `orcid.domain-url` from the backend configuration. Returns null when unset
+ * or when the value does not look like an absolute http(s) URL.
+ */
+export function loadOrcidDomainUrl(
+  configurationService: ConfigurationDataService,
+): Promise<string | null> {
+  return configurationService.findByPropertyName('orcid.domain-url')
+    .pipe(getFirstSucceededRemoteDataPayload())
+    .toPromise()
+    .then((rd: any) => {
+      const value = rd?.values?.[0]?.trim();
+      return value && /^https?:\/\//i.test(value) ? value : null;
+    })
+    .catch(() => null);
+}
+
+/**
+ * Load `item.author.orcid.link-target` from the backend configuration.
+ * Returns the default (`browse`) when the property is unset or invalid.
+ */
+export function loadAuthorOrcidLinkTarget(
+  configurationService: ConfigurationDataService,
+): Promise<AuthorOrcidLinkTarget> {
+  return configurationService.findByPropertyName(AUTHOR_ORCID_LINK_TARGET_PROPERTY)
+    .pipe(getFirstSucceededRemoteDataPayload())
+    .toPromise()
+    .then((rd: any) => {
+      const value = rd?.values?.[0]?.trim()?.toLowerCase();
+      return value ? value : DEFAULT_AUTHOR_ORCID_LINK_TARGET;
+    })
+    .catch(() => DEFAULT_AUTHOR_ORCID_LINK_TARGET);
+}
+
+/**
+ * True when the authority string is a recognised ORCID value (bare iD or full URL).
+ * Bare iDs require `orcidDomainUrl` so the link can be built without guessing the domain.
+ */
+export function isOrcidAuthorityValue(authority: string | undefined | null, orcidDomainUrl: string | null): boolean {
+  if (!authority) {
+    return false;
+  }
+  const trimmed = authority.trim();
+  if (ORCID_URL_PATTERN.test(trimmed)) {
+    return true;
+  }
+  return !!orcidDomainUrl && ORCID_ID_PATTERN.test(trimmed);
+}
+
+/**
+ * Build the full ORCID profile URL for the given authority. Returns an empty string when
+ * the authority is not an ORCID value or when the ORCID domain URL is required but missing.
+ */
+export function buildOrcidProfileUrl(authority: string | undefined | null, orcidDomainUrl: string | null): string {
+  if (!authority) {
+    return '';
+  }
+  const trimmed = authority.trim();
+  if (ORCID_URL_PATTERN.test(trimmed)) {
+    return trimmed;
+  }
+  if (orcidDomainUrl && ORCID_ID_PATTERN.test(trimmed)) {
+    const domain = orcidDomainUrl.endsWith('/') ? orcidDomainUrl.slice(0, -1) : orcidDomainUrl;
+    return `${domain}/${trimmed}`;
+  }
+  return '';
+}

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -3423,6 +3423,8 @@
   "item.view.box.author.preview.and": "a",
   // "item.view.box.author.preview.show-everyone": "show everyone:",
   "item.view.box.author.preview.show-everyone": "zobraz všechny autory",
+  // "item.view.box.author.preview.orcid-link.title": "View ORCID profile",
+  "item.view.box.author.preview.orcid-link.title": "Zobrazit ORCID profil",
   // "item.file.description.not.supported.video": "Your browser does not support the video tag.",
   "item.file.description.not.supported.video": "Váš prohlížeč nepodporuje videa.",
   // "item.file.description.name": "Name",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -2868,6 +2868,7 @@
 
   "item.view.box.author.preview.show-everyone": "show everyone",
 
+  "item.view.box.author.preview.orcid-link.title": "View ORCID profile",
 
   "item.file.description.not.supported.video": "Your browser does not support the video tag.",
 


### PR DESCRIPTION
## Problem description
BE PR: https://github.com/dataquest-dev/DSpace/pull/1324
Authors with ORCID have icon next to name (redirect to orcid url). When clicking on author name, you can configure if it will redirect to orcid url or default browse as it was before.

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [x] Requested review from Copilot