### PR TITLE
[Backport dtq-dev] 141 lost license in workflow edit (ufal#144)

### DIFF
--- a/src/app/submission/sections/clarin-license-resource/section-license.component.spec.ts
+++ b/src/app/submission/sections/clarin-license-resource/section-license.component.spec.ts
@@ -200,16 +200,18 @@ describe('ClarinSubmissionSectionLicenseComponent test suite', () => {
         (app as any).pathCombiner = new JsonPatchOperationPathCombiner('sections', 'clarin-license');
 
         const wsiId = 42;
-        const baseHref = 'http://localhost/api/submission/workspaceitems';
+        const selfHref = 'http://localhost/api/submission/workspaceitems/' + wsiId;
 
-        spyOn(app as any, 'getActualWorkspaceItem').and.returnValue(
-          Promise.resolve({ payload: { id: wsiId } })
+        // The component now resolves the current submission object and PATCHes its
+        // self link directly, so stub getActualSubmissionItem with a succeeded
+        // RemoteData exposing _links.self.href.
+        spyOn(app as any, 'getActualSubmissionItem').and.returnValue(
+          Promise.resolve({ hasSucceeded: true, payload: { _links: { self: { href: selfHref } } } })
         );
         spyOn(app as any, 'updateSectionStatus').and.callFake(() => undefined);
 
         mockRequestService.generateRequestId.and.returnValue('req-id-1');
         mockRequestService.send.calls.reset();
-        mockHalService.getEndpoint.and.returnValue(of(baseHref));
         mockRdbService.buildFromRequestUUID.and.returnValue(of({ payload: { sections: {}, errors: [] } } as any));
 
         // Act
@@ -217,7 +219,7 @@ describe('ClarinSubmissionSectionLicenseComponent test suite', () => {
           // Assert
           expect(mockRequestService.send).toHaveBeenCalledTimes(1);
           const sentRequest = mockRequestService.send.calls.mostRecent().args[0] as PatchRequest;
-          expect(sentRequest.href).toBe(baseHref + '/' + wsiId);
+          expect(sentRequest.href).toBe(selfHref);
           const body: any[] = (sentRequest as any).body;
           expect(body.length).toBe(1);
           expect(body[0].op).toBe('replace');

--- a/src/app/submission/sections/clarin-license-resource/section-license.component.ts
+++ b/src/app/submission/sections/clarin-license-resource/section-license.component.ts
@@ -16,10 +16,9 @@ import { Operation } from 'fast-json-patch';
 import { ClarinLicenseDataService } from '../../../core/data/clarin/clarin-license-data.service';
 import { ClarinLicense } from '../../../core/shared/clarin/clarin-license.model';
 import { getFirstCompletedRemoteData, getFirstSucceededRemoteListPayload } from '../../../core/shared/operators';
-import { distinctUntilChanged, filter, find } from 'rxjs/operators';
-import { HALEndpointService } from '../../../core/shared/hal-endpoint.service';
+import { distinctUntilChanged, filter } from 'rxjs/operators';
 import { RemoteDataBuildService } from '../../../core/cache/builders/remote-data-build.service';
-import { WorkspaceitemDataService } from '../../../core/submission/workspaceitem-data.service';
+import { SubmissionService } from '../../submission.service';
 import { RemoteData } from '../../../core/data/remote-data';
 import parseSectionErrors from '../../utils/parseSectionErrors';
 import { normalizeSectionData } from '../../../core/submission/submission-response-parsing.service';
@@ -27,7 +26,7 @@ import { License4Selector } from './license-4-selector.model';
 import { ConfigurationProperty } from '../../../core/shared/configuration-property.model';
 import { HELP_DESK_PROPERTY } from '../../../item-page/tombstone/tombstone.component';
 import { ConfigurationDataService } from '../../../core/data/configuration-data.service';
-import { WorkspaceItem } from '../../../core/submission/models/workspaceitem.model';
+import { SubmissionObject } from '../../../core/submission/models/submission-object.model';
 import { PaginatedList } from '../../../core/data/paginated-list.model';
 import { ItemDataService } from '../../../core/data/item-data.service';
 import { Item } from '../../../core/shared/item.model';
@@ -135,8 +134,7 @@ export class SubmissionSectionClarinLicenseComponent extends SectionModelCompone
    * @param clarinLicenseService
    * @param translateService
    * @param itemService
-   * @param workspaceItemService
-   * @param halService
+   * @param submissionService
    * @param rdbService
    * @param configurationDataService
    * @param requestService
@@ -151,8 +149,7 @@ export class SubmissionSectionClarinLicenseComponent extends SectionModelCompone
               protected clarinLicenseService: ClarinLicenseDataService,
               protected translateService: TranslateService,
               protected itemService: ItemDataService,
-              protected workspaceItemService: WorkspaceitemDataService,
-              protected halService: HALEndpointService,
+              protected submissionService: SubmissionService,
               protected rdbService: RemoteDataBuildService,
               private configurationDataService: ConfigurationDataService,
               protected requestService: RequestService,
@@ -196,11 +193,17 @@ export class SubmissionSectionClarinLicenseComponent extends SectionModelCompone
     this.formId = this.formService.getUniqueId(this.sectionData.id);
 
     // Load the accepted license of the item
-    this.getActualWorkspaceItem()
-      .then((workspaceItemRD: RemoteData<WorkspaceItem>) => {
-        this.itemService.findByHref(workspaceItemRD.payload._links.item.href)
+    this.getActualSubmissionItem()
+      .then((submissionItemRD: RemoteData<SubmissionObject>) => {
+        if (!submissionItemRD?.hasSucceeded || !submissionItemRD.payload?._links?.item?.href) {
+          return;
+        }
+        this.itemService.findByHref(submissionItemRD.payload._links.item.href)
           .pipe(getFirstCompletedRemoteData())
           .subscribe((itemRD: RemoteData<Item>) => {
+            if (!itemRD?.hasSucceeded || !itemRD.payload) {
+              return;
+            }
             // Load the metadata where is store clarin license name (`dc.rights`).
             const item = itemRD.payload;
             const dcRightsMetadata = item.metadata['dc.rights'];
@@ -273,29 +276,25 @@ export class SubmissionSectionClarinLicenseComponent extends SectionModelCompone
     }
 
     this.updateSectionStatus();
-    await this.getActualWorkspaceItem()
-      .then(workspaceItemRD => {
+    await this.getActualSubmissionItem()
+      .then(submissionItemRD => {
+        if (!submissionItemRD?.hasSucceeded || !submissionItemRD.payload?._links?.self?.href) {
+          return;
+        }
         const requestId = this.requestService.generateRequestId();
-        const hrefObs = this.halService.getEndpoint(this.workspaceItemService.getLinkPath());
-
         // Route the PATCH through the `clarin-license` submission step so it
         // works for workflow items too and keeps `sections.license` (CC) and
         // `sections.clarin-license` payloads separate on subsequent GETs.
         const patchOperation2 = {
           op: 'replace', path: this.pathCombiner.getPath('select').path, value: licenseNameRest
         } as Operation;
-
-        hrefObs.pipe(
-          find((href: string) => hasValue(href)),
-        ).subscribe((href: string) => {
-          const request = new PatchRequest(requestId, href + '/' + workspaceItemRD.payload.id, [patchOperation2]);
-          this.requestService.send(request);
-        });
+        const request = new PatchRequest(requestId, submissionItemRD.payload._links.self.href, [patchOperation2]);
+        this.requestService.send(request);
 
         // process the response
         this.rdbService.buildFromRequestUUID(requestId)
           .pipe(getFirstCompletedRemoteData())
-          .subscribe((response: RemoteData<WorkspaceItem>) => {
+          .subscribe((response: RemoteData<SubmissionObject>) => {
 
             // show validation errors in every section
             const workspaceitem = response.payload;
@@ -465,10 +464,11 @@ export class SubmissionSectionClarinLicenseComponent extends SectionModelCompone
   }
 
   /**
-   * Get the current workspace item by the submissionId.
+   * Get the current submission item (workspace or workflow) by the submissionId.
+   * This method is route-aware and retrieves from the appropriate endpoint based on the current URL.
    */
-  private async getActualWorkspaceItem(): Promise<RemoteData<WorkspaceItem>> {
-    return this.workspaceItemService.findById(this.submissionId)
+  private async getActualSubmissionItem(): Promise<RemoteData<SubmissionObject>> {
+    return this.submissionService.retrieveSubmission(this.submissionId)
       .pipe(getFirstCompletedRemoteData()).toPromise();
   }
 


### PR DESCRIPTION
Backport of ufal/dspace-angular#144 to `dtq-dev`. The automated port-pr cherry-pick of `fb97ec9f16` failed; resolved manually.

**What #144 brings:** makes the CLARIN-license section route-aware so it loads/saves the license on **workflow** edit pages too (previously it only handled workspace items), by replacing the workspace-only `getActualWorkspaceItem()` (via `WorkspaceitemDataService` + `HALEndpointService`) with `getActualSubmissionItem()` (via `SubmissionService.retrieveSubmission`), and PATCHing directly to the submission object's `self` href.

**Conflict resolution vs `dtq-dev`:** `dtq-dev` had independently changed the PATCH **path** to the section-scoped `pathCombiner.getPath('select').path` (instead of upstream's top-level `/license`) and carried an explanatory comment + a now-obsolete `hrefObs` line. The merge keeps `dtq-dev`'s section path and comment, takes #144's route-aware retrieval and direct-`self`-href PATCH, and drops the orphaned `hrefObs` line (and with it the unused `halService`/`workspaceItemService` deps, per #144). Net diff is the same 26/26 single-file scope as the original.

Head branch is on my fork (`kosarko/dspace-angular`) since I don't have push access to `dataquest-dev`.

Build/lint not run locally (no toolchain in this env) — CI validates this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * License selection now loads and saves via the unified submission item flow, improving reliability when opening submissions.
  * Validation errors from license updates are properly propagated across submission sections for clearer feedback.

* **Tests**
  * Unit tests updated to reflect the new submission-item behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->