### PR TITLE
[Port to dtq-dev] fix(bitstream): restore item UUID in edit redirect

### DIFF
--- a/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.spec.ts
+++ b/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.spec.ts
@@ -414,6 +414,19 @@ describe('EditBitstreamPageComponent', () => {
         comp.navigateToItemEditBitstreams();
         expect(router.navigate).toHaveBeenCalledWith([getEntityEditRoute(null, 'some-uuid1'), 'bitstreams']);
       });
+
+      it('should resolve itemId from bundle.item when query param is missing', () => {
+        const mockItem = new Item();
+        mockItem.uuid = 'resolved-uuid-456';
+        const mockBundle = {
+          item: createSuccessfulRemoteDataObject$(mockItem)
+        };
+        (comp as any).bundle = mockBundle;
+        comp.itemId = undefined;
+        comp.navigateToItemEditBitstreams();
+        fixture.detectChanges();
+        expect(router.navigate).toHaveBeenCalledWith([getEntityEditRoute(null, 'resolved-uuid-456'), 'bitstreams']);
+      });
     });
   });
 

--- a/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.ts
+++ b/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.ts
@@ -745,7 +745,33 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
    * otherwise retrieve the item ID based on the owning bundle's link
    */
   navigateToItemEditBitstreams() {
-    this.router.navigate([getEntityEditRoute(this.entityType, this.itemId), 'bitstreams']);
+    const navigate = () => this.router.navigate([getEntityEditRoute(this.entityType, this.itemId), 'bitstreams']);
+
+    if (hasValue(this.itemId)) {
+      navigate();
+      return;
+    }
+
+    if (hasValue(this.bundle) && hasValue(this.bundle.item)) {
+      this.subs.push(
+        this.bundle.item.pipe(
+          getFirstCompletedRemoteData(),
+        ).subscribe((itemRd: RemoteData<Item>) => {
+          if (itemRd.hasSucceeded && hasValue(itemRd.payload)) {
+            this.itemId = itemRd.payload.uuid;
+            if (!hasValue(this.entityType)) {
+              this.entityType = itemRd.payload.firstMetadataValue('dspace.entity.type');
+            }
+            navigate();
+          } else {
+            this.location.back();
+          }
+        }),
+      );
+      return;
+    }
+
+    this.location.back();
   }
 
   /**

--- a/src/app/item-page/edit-item-page/item-bitstreams/item-edit-bitstream-bundle/item-edit-bitstream-bundle.component.html
+++ b/src/app/item-page/edit-item-page/item-bitstreams/item-edit-bitstream-bundle/item-edit-bitstream-bundle.component.html
@@ -112,7 +112,9 @@
                      [attr.data-test]="'download-button' | dsBrowserOnly">
                     <i class="fas fa-download fa-fw"></i>
                   </a>
-                  <button [routerLink]="['/bitstreams/', entry.id, 'edit']" class="btn btn-outline-primary btn-sm"
+                  <button [routerLink]="['/bitstreams/', entry.id, 'edit']"
+                          [queryParams]="{ itemId: item.uuid, entityType: item.firstMetadataValue('dspace.entity.type') }"
+                          class="btn btn-outline-primary btn-sm"
                           [attr.aria-label]="'item.edit.bitstreams.edit.buttons.edit' | translate"
                           title="{{'item.edit.bitstreams.edit.buttons.edit' | translate}}">
                     <i class="fas fa-edit fa-fw"></i>


### PR DESCRIPTION
Port of ufal/dspace-angular#154 by @amadulhaxxani to `dtq-dev`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced bitstream editing page navigation to handle cases where the item ID is unavailable by deriving it from available item data when possible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->