### PR TITLE
VSB-TUO/Backport: align eager-themes with the other flicker backports

### DIFF
--- a/src/themes/eager-themes.module.ts
+++ b/src/themes/eager-themes.module.ts
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
 import { EagerThemeModule as DSpaceEagerThemeModule } from './dspace/eager-theme.module';
-import { EagerThemeModule } from './dspace/eager-theme.module';
 import { EagerThemeModule as CustomEagerThemeModule } from './custom/eager-theme.module';
 
 /**
@@ -18,10 +17,6 @@ import { EagerThemeModule as CustomEagerThemeModule } from './custom/eager-theme
 @NgModule({
   imports: [
     DSpaceEagerThemeModule,
-    // Uncomment this because the `untyped-item` theming is not working when it is commented out.
-    // Issue: https://github.com/DSpace/dspace-angular/issues/1897
-    // Useful info in PR: https://github.com/DSpace/dspace-angular/pull/2262#issuecomment-1557146081
-    EagerThemeModule,
     CustomEagerThemeModule,
   ],
 })


### PR DESCRIPTION
## What this is

Follow-up on `customer/vsb-tuo`, kept in sync with the customer flicker-backport family (#1310 / #1311 / #1312 / #1314).

All the SSR anti-flicker overlay work for VSB-TUO already landed on this base:
- #1288 (original), #1317 (content-visible gate), **#1318 + #1321** (final DOM-settle mechanism — overlay kept until the routed `<ds-app>` DOM settles; purely-visual mask so the live app stays interactive; closes dspace-customers#725), #1333 (admin-sidebar gutter).

So the overlay fixes are already in the base. This PR carries the one remaining piece needed to match the other customers:

- **Align `eager-themes.module.ts`** — drop the duplicate dspace eager-theme import (it was imported once as `DSpaceEagerThemeModule` and again, unaliased, as `EagerThemeModule`, with both in `imports[]`). Result matches the canonical form now shared by TUL/SAV/ZCU-DATA/ZCU-PUB: dspace eager theme once + custom eager theme once.

### Dropped from this branch's earlier revision
The blank-page guard previously here is no longer needed: #1321 removed the `ds-app { visibility:hidden }` rule (the overlay is now a purely visual mask), so the early-return can no longer leave the app hidden — and the other customers adopted #1321's `index.html` verbatim. Re-adding a guard only here would re-diverge `index.html`.

## Related
- Final overlay mechanism (already in base): #1318, #1321
- Original VSB-TUO backport: #1288