### PR TITLE
ZCU-PUB/Make Solr heap tunable via SOLR_HEAP (backport #1309)

### DIFF
--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -161,7 +161,7 @@ services:
       cp -r -u /opt/solr/server/solr/configsets/dspace/search/* search
       precreate-core statistics /opt/solr/server/solr/configsets/dspace/statistics
       cp -r -u /opt/solr/server/solr/configsets/dspace/statistics/* statistics
-      exec solr -p 898${INSTANCE} -f -m 4g
+      exec solr -p 898${INSTANCE} -f -m "${SOLR_HEAP:-4g}"
 volumes:
   assetstore:
   pgdata:


### PR DESCRIPTION
## Problem

The Solr heap in `docker/docker-compose-rest.yml` is hardcoded to `-m 4g`. Combined with
`-XX:+AlwaysPreTouch`, the container commits the full 4 GB on start, which is wasteful on
shared dev hosts running several DSpace stacks. Operators cannot lower the heap without
editing a tracked file.

Backport of dataquest-dev/dspace-angular#1309 to `customer/zcu-pub`.
Tracking issue: dataquest-dev/dspace-customers#746

## Root cause

The Solr launch command was written with a literal heap argument (`-m 4g`) instead of an
environment-driven one, so there is no runtime knob and `AlwaysPreTouch` forces the full
allocation up front.

## Change set

Single-line change to the `dspacesolr` entrypoint in `docker/docker-compose-rest.yml`:

```diff
-      exec solr -p 898${INSTANCE} -f -m 4g
+      exec solr -p 898${INSTANCE} -f -m "${SOLR_HEAP:-4g}"
```

**Translated, not cherry-picked** (per the FE backport model). On this branch (7.6.1 family)
the Solr launch uses `-p 898${INSTANCE}`, not the source PR's `-p 8983`, so only the `-m 4g`
argument was changed; the port and every other line are untouched. The value is quoted
(`"${SOLR_HEAP:-4g}"`) to survive word-splitting, matching the source PR's follow-up fix.

Intentionally out of scope: the default heap value (stays `4g`), other services, ports,
Solr image/version, and `AlwaysPreTouch`.

## Test evidence

Static fingerprints:

```
$ grep -n 'm "${SOLR_HEAP:-4g}"' docker/docker-compose-rest.yml
164:      exec solr -p 898${INSTANCE} -f -m "${SOLR_HEAP:-4g}"

$ grep -n 'm 4g' docker/docker-compose-rest.yml
(no matches — hardcoded value gone)

$ git diff --stat
 docker/docker-compose-rest.yml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

Compose render (Docker Compose interpolates `${SOLR_HEAP:-4g}`, demonstrating both paths;
`INSTANCE=0` set only to silence unset-var noise):

```
# Default path — SOLR_HEAP unset:
$ docker compose -f docker/docker-compose-rest.yml config | grep 'exec solr'
      exec solr -p 8980 -f -m "4g"

# Override path — SOLR_HEAP=1g:
$ SOLR_HEAP=1g docker compose -f docker/docker-compose-rest.yml config | grep 'exec solr'
      exec solr -p 8980 -f -m "1g"

# Valid render:
$ docker compose -f docker/docker-compose-rest.yml config --quiet ; echo $?
0
```

Default preserved (4g), override honored (1g), YAML/interpolation valid.

## Risk & rollback

- **Risk:** Very low — single-line, default-preserving config change. Main failure mode would
  be an unquoted/typo'd interpolation; mitigated by the quoting and the compose-render check above.
- **Backward compatible:** Full. Unset `SOLR_HEAP` reproduces the prior 4 GB behavior exactly;
  existing `.env`/compose overrides that don't set `SOLR_HEAP` keep working.
- **Rollback:** Revert this one-line change (or the PR). No state, migration, or data implications.

## Notes / assumptions

- Source PR: dataquest-dev/dspace-angular#1309 (commits `27253a3` env var, `0d652dc` quoting).
- Sibling target `customer/mendelu` from the tracking issue is **not** included: that branch
  (DSpace 9.1) launches Solr via `solr-foreground` and has no hardcoded `-m 4g` line to
  translate, so the backport does not apply there. Reported separately on the tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
