### PR TITLE
ZCU-DATA/Make Solr heap tunable via SOLR_HEAP (backport #1309)

### DIFF
--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -161,7 +161,7 @@ services:
       cp -r -u /opt/solr/server/solr/configsets/dspace/search/* search
       precreate-core statistics /opt/solr/server/solr/configsets/dspace/statistics
       cp -r -u /opt/solr/server/solr/configsets/dspace/statistics/* statistics
-      exec solr -p 898${INSTANCE} -f -m 4g
+      exec solr -p 898${INSTANCE} -f -m "${SOLR_HEAP:-4g}"
 volumes:
   assetstore:
   pgdata:


### PR DESCRIPTION
## Problem

The Solr heap in `docker/docker-compose-rest.yml` is hardcoded to `-m 4g`. With
`-XX:+AlwaysPreTouch` the container commits the full 4 GB on start — wasteful on shared dev
hosts running several DSpace stacks, and not lowerable without editing a tracked file.

Backport of dataquest-dev/dspace-angular#1309 to `customer/zcu-data`.
Tracking issue: dataquest-dev/dspace-customers#746

## Change set

Single-line change to the `dspacesolr` entrypoint in `docker/docker-compose-rest.yml`:

```diff
-      exec solr -p 898${INSTANCE} -f -m 4g
+      exec solr -p 898${INSTANCE} -f -m "${SOLR_HEAP:-4g}"
```

**Translated, not cherry-picked** (per the FE backport model). On this branch (7.6.1 family) the Solr launch uses `-p 898${INSTANCE}`,
so only the `-m 4g` argument changed; the port and every other line are untouched. The value
is quoted to survive word-splitting, matching the source PR follow-up.

Out of scope: the default heap value (stays `4g`), other services, ports, Solr image/version,
and `AlwaysPreTouch`.

## Test evidence

- Post-change marker present (line 164): `-m "${SOLR_HEAP:-4g}"`
- Pre-change marker `-m 4g` no longer present (grep count 0)
- Compose YAML re-parses cleanly (`yaml.safe_load`); edit sits inside the entrypoint scalar
- Default/override: `SOLR_HEAP` unset -> 4g, `SOLR_HEAP=1g` -> 1g
