### PR TITLE
[Port to dtq-dev] 117 better control of user deletion in user administration page

### DIFF
--- a/src/app/access-control/access-control.module.ts
+++ b/src/app/access-control/access-control.module.ts
@@ -5,6 +5,7 @@ import { SharedModule } from '../shared/shared.module';
 import { AccessControlRoutingModule } from './access-control-routing.module';
 import { EPeopleRegistryComponent } from './epeople-registry/epeople-registry.component';
 import { EPersonFormComponent } from './epeople-registry/eperson-form/eperson-form.component';
+import { EPersonDeleteGuardService } from './epeople-registry/eperson-delete-guard.service';
 import { GroupFormComponent } from './group-registry/group-form/group-form.component';
 import { MembersListComponent } from './group-registry/group-form/members-list/members-list.component';
 import { SubgroupsListComponent } from './group-registry/group-form/subgroup-list/subgroups-list.component';
@@ -57,6 +58,7 @@ export const ValidateEmailErrorStateMatcher: DynamicErrorMessagesMatcher =
       provide: DYNAMIC_ERROR_MESSAGES_MATCHER,
       useValue: ValidateEmailErrorStateMatcher
     },
+    EPersonDeleteGuardService,
   ]
 })
 /**

--- a/src/app/access-control/epeople-registry/epeople-registry.component.html
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.html
@@ -76,11 +76,26 @@
                           title="{{labelPrefix + 'table.edit.buttons.edit' | translate: { name: dsoNameService.getName(epersonDto.eperson) } }}">
                     <i class="fas fa-edit fa-fw"></i>
                   </button>
-                  <button *ngIf="epersonDto.ableToDelete" (click)="deleteEPerson(epersonDto.eperson)"
-                          class="delete-button btn btn-outline-danger btn-sm access-control-deleteEPersonButton"
-                          title="{{labelPrefix + 'table.edit.buttons.remove' | translate: { name: dsoNameService.getName(epersonDto.eperson) } }}">
-                    <i class="fas fa-trash-alt fa-fw"></i>
-                  </button>
+                  <ng-container *ngIf="epersonDto.ableToDelete && currentAuthenticatedUserId">
+                    <ng-container *ngIf="isCurrentUser(epersonDto.eperson); else enabledDeleteButton">
+                      <span tabindex="0" [ngbTooltip]="selfDeleteWarningLabel | translate">
+                        <button [dsBtnDisabled]="true"
+                                tabindex="-1"
+                                [attr.aria-label]="selfDeleteWarningLabel | translate"
+                                class="delete-button btn btn-outline-danger btn-sm access-control-deleteEPersonButton"
+                                type="button">
+                          <i class="fas fa-trash-alt fa-fw"></i>
+                        </button>
+                      </span>
+                    </ng-container>
+                  </ng-container>
+                  <ng-template #enabledDeleteButton>
+                    <button (click)="deleteEPerson(epersonDto.eperson)"
+                            class="delete-button btn btn-outline-danger btn-sm access-control-deleteEPersonButton"
+                            title="{{labelPrefix + 'table.edit.buttons.remove' | translate: { name: dsoNameService.getName(epersonDto.eperson) } }}">
+                      <i class="fas fa-trash-alt fa-fw"></i>
+                    </button>
+                  </ng-template>
                 </div>
               </td>
             </tr>

--- a/src/app/access-control/epeople-registry/epeople-registry.component.spec.ts
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.spec.ts
@@ -1,7 +1,7 @@
 import { Router } from '@angular/router';
-import { Observable, of as observableOf } from 'rxjs';
+import { Observable, of as observableOf, throwError as observableThrowError } from 'rxjs';
 import { CommonModule } from '@angular/common';
-import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule, By } from '@angular/platform-browser';
@@ -9,25 +9,34 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
 import { buildPaginatedList, PaginatedList } from '../../core/data/paginated-list.model';
 import { RemoteData } from '../../core/data/remote-data';
+import { AuthService } from '../../core/auth/auth.service';
 import { EPersonDataService } from '../../core/eperson/eperson-data.service';
 import { EPerson } from '../../core/eperson/models/eperson.model';
 import { PageInfo } from '../../core/shared/page-info.model';
+import { DSONameService } from '../../core/breadcrumbs/dso-name.service';
 import { FormBuilderService } from '../../shared/form/builder/form-builder.service';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { EPeopleRegistryComponent } from './epeople-registry.component';
 import { EPersonMock, EPersonMock2 } from '../../shared/testing/eperson.mock';
-import { createSuccessfulRemoteDataObject$ } from '../../shared/remote-data.utils';
+import { createFailedRemoteDataObject$, createSuccessfulRemoteDataObject$ } from '../../shared/remote-data.utils';
 import { getMockFormBuilderService } from '../../shared/mocks/form-builder-service.mock';
 import { getMockTranslateService } from '../../shared/mocks/translate.service.mock';
 import { TranslateLoaderMock } from '../../shared/mocks/translate-loader.mock';
 import { NotificationsServiceStub } from '../../shared/testing/notifications-service.stub';
 import { RouterStub } from '../../shared/testing/router.stub';
 import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
+import { FeatureID } from '../../core/data/feature-authorization/feature-id';
+import { EPersonDeleteGuardService } from './eperson-delete-guard.service';
 import { RequestService } from '../../core/data/request.service';
 import { PaginationService } from '../../core/pagination/pagination.service';
 import { PaginationServiceStub } from '../../shared/testing/pagination-service.stub';
+import { WorkspaceitemDataService } from '../../core/submission/workspaceitem-data.service';
+import { WorkflowItemDataService } from '../../core/submission/workflowitem-data.service';
 import { FindListOptions } from '../../core/data/find-list-options.model';
-import {BtnDisabledDirective} from '../../shared/btn-disabled.directive';
+import { SearchService } from '../../core/shared/search/search.service';
+import { DSpaceObject } from '../../core/shared/dspace-object.model';
+import { SearchObjects } from '../../shared/search/models/search-objects.model';
+import { BtnDisabledDirective } from '../../shared/btn-disabled.directive';
 
 describe('EPeopleRegistryComponent', () => {
   let component: EPeopleRegistryComponent;
@@ -38,9 +47,34 @@ describe('EPeopleRegistryComponent', () => {
   let mockEPeople;
   let ePersonDataServiceStub: any;
   let authorizationService: AuthorizationDataService;
+  let authService: jasmine.SpyObj<AuthService>;
+  let workspaceItemDataService: jasmine.SpyObj<WorkspaceitemDataService>;
+  let workflowItemDataService: jasmine.SpyObj<WorkflowItemDataService>;
+  let searchService: jasmine.SpyObj<SearchService>;
+  let notificationsService: NotificationsServiceStub;
   let modalService;
+  let modalRef;
 
   let paginationService;
+
+  const buildRemoteList = <T>(items: T[], totalElements = items.length) => createSuccessfulRemoteDataObject$(
+    buildPaginatedList(new PageInfo({
+      elementsPerPage: items.length || 1,
+      totalElements,
+      totalPages: 1,
+      currentPage: 1
+    }), items)
+  );
+
+  const buildSearchObjects = (totalElements: number) => Object.assign(
+    new SearchObjects<DSpaceObject>(),
+    buildPaginatedList(new PageInfo({
+      elementsPerPage: 1,
+      totalElements,
+      totalPages: 1,
+      currentPage: 1
+    }), [])
+  );
 
   beforeEach(waitForAsync(() => {
     jasmine.getEnv().allowRespy(true);
@@ -119,8 +153,17 @@ describe('EPeopleRegistryComponent', () => {
     authorizationService = jasmine.createSpyObj('authorizationService', {
       isAuthorized: observableOf(true)
     });
+    authService = jasmine.createSpyObj('authService', ['getAuthenticatedUserFromStore']);
+    authService.getAuthenticatedUserFromStore.and.returnValue(observableOf(EPersonMock2));
+    workspaceItemDataService = jasmine.createSpyObj('workspaceItemDataService', ['searchBy']);
+    workspaceItemDataService.searchBy.and.returnValue(buildRemoteList([], 0));
+    workflowItemDataService = jasmine.createSpyObj('workflowItemDataService', ['searchBy']);
+    workflowItemDataService.searchBy.and.returnValue(buildRemoteList([], 0));
+    searchService = jasmine.createSpyObj('searchService', ['search']);
+    searchService.search.and.returnValue(createSuccessfulRemoteDataObject$(buildSearchObjects(0)));
     builderService = getMockFormBuilderService();
     translateService = getMockTranslateService();
+    notificationsService = new NotificationsServiceStub();
 
     paginationService = new PaginationServiceStub();
     TestBed.configureTestingModule({
@@ -135,12 +178,20 @@ describe('EPeopleRegistryComponent', () => {
       declarations: [EPeopleRegistryComponent, BtnDisabledDirective],
       providers: [
         { provide: EPersonDataService, useValue: ePersonDataServiceStub },
-        { provide: NotificationsService, useValue: new NotificationsServiceStub() },
+        { provide: NotificationsService, useValue: notificationsService },
         { provide: AuthorizationDataService, useValue: authorizationService },
+        { provide: AuthService, useValue: authService },
         { provide: FormBuilderService, useValue: builderService },
+        { provide: WorkspaceitemDataService, useValue: workspaceItemDataService },
+        { provide: WorkflowItemDataService, useValue: workflowItemDataService },
+        { provide: SearchService, useValue: searchService },
+        EPersonDeleteGuardService,
         { provide: Router, useValue: new RouterStub() },
         { provide: RequestService, useValue: jasmine.createSpyObj('requestService', ['removeByHrefSubstring']) },
-        { provide: PaginationService, useValue: paginationService }
+        { provide: PaginationService, useValue: paginationService },
+        { provide: DSONameService, useValue: jasmine.createSpyObj('dsoNameService', {
+          getName: (dso: any) => dso?.name ?? dso?.email ?? dso?.id,
+        }) },
       ],
       schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
@@ -150,7 +201,8 @@ describe('EPeopleRegistryComponent', () => {
     fixture = TestBed.createComponent(EPeopleRegistryComponent);
     component = fixture.componentInstance;
     modalService = (component as any).modalService;
-    spyOn(modalService, 'open').and.returnValue(Object.assign({ componentInstance: Object.assign({ response: observableOf(true) }) }));
+    modalRef = Object.assign({ componentInstance: Object.assign({ response: observableOf(true) }) });
+    spyOn(modalService, 'open').and.returnValue(modalRef);
     fixture.detectChanges();
   });
 
@@ -227,6 +279,109 @@ describe('EPeopleRegistryComponent', () => {
         });
       });
     });
+
+    it('should render the self delete button as disabled', () => {
+      const deleteButtons = fixture.debugElement.queryAll(By.css('.access-control-deleteEPersonButton'));
+
+      expect(deleteButtons.length).toBe(2);
+      expect(deleteButtons[0].nativeElement.getAttribute('aria-disabled')).toBeNull();
+      expect(deleteButtons[1].nativeElement.getAttribute('aria-disabled')).toBe('true');
+      expect(deleteButtons[1].nativeElement.classList.contains('disabled')).toBeTrue();
+    });
+
+    it('should call submitter checks and compose the combined warning label', fakeAsync(() => {
+      workspaceItemDataService.searchBy.and.returnValue(buildRemoteList([{} as any], 1));
+      workflowItemDataService.searchBy.and.returnValue(buildRemoteList([], 0));
+      searchService.search.and.returnValue(createSuccessfulRemoteDataObject$(buildSearchObjects(0)));
+      // isAuthorized returns true by default -> the target is treated as an administrator
+      modalRef.componentInstance.response = observableOf(false);
+
+      const deleteButtons = fixture.debugElement.queryAll(By.css('.access-control-deleteEPersonButton'));
+      deleteButtons[0].triggerEventHandler('click', null);
+      tick();
+
+      expect(workspaceItemDataService.searchBy).toHaveBeenCalledWith('findBySubmitter', jasmine.any(FindListOptions));
+      expect(workflowItemDataService.searchBy).toHaveBeenCalledWith('findBySubmitter', jasmine.any(FindListOptions));
+      expect(searchService.search).toHaveBeenCalled();
+      expect(authorizationService.isAuthorized).toHaveBeenCalledWith(FeatureID.AdministratorOf, undefined, EPersonMock.id);
+      expect(modalRef.componentInstance.warningLabel).toBe('admin.access-control.epeople.delete.warning.submitterAndAdmin');
+    }));
+
+    it('should detect administrator via the authorization feature', fakeAsync(() => {
+      workspaceItemDataService.searchBy.and.returnValue(buildRemoteList([], 0));
+      workflowItemDataService.searchBy.and.returnValue(buildRemoteList([], 0));
+      searchService.search.and.returnValue(createSuccessfulRemoteDataObject$(buildSearchObjects(0)));
+      // admin -> true, all submitter probes empty -> admin-only warning
+      (authorizationService.isAuthorized as jasmine.Spy).and.callFake((featureId: FeatureID) => observableOf(featureId === FeatureID.AdministratorOf));
+      modalRef.componentInstance.response = observableOf(false);
+
+      const deleteButtons = fixture.debugElement.queryAll(By.css('.access-control-deleteEPersonButton'));
+      deleteButtons[0].triggerEventHandler('click', null);
+      tick();
+
+      expect(authorizationService.isAuthorized).toHaveBeenCalledWith(FeatureID.AdministratorOf, undefined, EPersonMock.id);
+      expect(modalRef.componentInstance.warningLabel).toBe('admin.access-control.epeople.delete.warning.admin');
+    }));
+
+    it('should still open the delete modal when a submitter probe errors (centralised catchError)', fakeAsync(() => {
+      workspaceItemDataService.searchBy.and.returnValue(observableThrowError(() => new Error('boom')));
+      workflowItemDataService.searchBy.and.returnValue(buildRemoteList([], 0));
+      searchService.search.and.returnValue(createSuccessfulRemoteDataObject$(buildSearchObjects(0)));
+      // CanDelete stays true so the button renders; AdministratorOf false so the only warning could come from submitter probes
+      (authorizationService.isAuthorized as jasmine.Spy).and.callFake((featureId: FeatureID) => observableOf(featureId !== FeatureID.AdministratorOf));
+      modalRef.componentInstance.response = observableOf(false);
+
+      const deleteButtons = fixture.debugElement.queryAll(By.css('.access-control-deleteEPersonButton'));
+      deleteButtons[0].triggerEventHandler('click', null);
+      tick();
+
+      expect(modalService.open).toHaveBeenCalled();
+      expect(modalRef.componentInstance.warningLabel).toBeUndefined();
+    }));
+
+    it('should show a friendly self-delete notification on backend 400 self-delete errors', fakeAsync(() => {
+      modalRef.componentInstance.response = observableOf(true);
+      ePersonDataServiceStub.deleteEPerson = jasmine.createSpy('deleteEPerson').and.returnValue(
+        createFailedRemoteDataObject$('You, as admin user, cannot delete yourself', 400)
+      );
+
+      const deleteButtons = fixture.debugElement.queryAll(By.css('.access-control-deleteEPersonButton'));
+      deleteButtons[0].triggerEventHandler('click', null);
+      tick();
+
+      expect(notificationsService.error).toHaveBeenCalled();
+      let translatedKey: string;
+      notificationsService.error.calls.mostRecent().args[0].subscribe((value) => translatedKey = value);
+      expect(translatedKey).toBe('admin.access-control.epeople.notification.deleted.forbidden.self');
+    }));
+
+    it('should use the deleted.failure key for generic delete failures', fakeAsync(() => {
+      modalRef.componentInstance.response = observableOf(true);
+      ePersonDataServiceStub.deleteEPerson = jasmine.createSpy('deleteEPerson').and.returnValue(
+        createFailedRemoteDataObject$('server error', 500)
+      );
+
+      const deleteButtons = fixture.debugElement.queryAll(By.css('.access-control-deleteEPersonButton'));
+      deleteButtons[0].triggerEventHandler('click', null);
+      tick();
+
+      expect(notificationsService.error).toHaveBeenCalled();
+      let translatedKey: string;
+      notificationsService.error.calls.mostRecent().args[0].subscribe((value) => translatedKey = value);
+      expect(translatedKey).toBe('admin.access-control.epeople.notification.deleted.failure');
+    }));
+
+    it('should not open delete modal before authenticated user id is resolved', fakeAsync(() => {
+      component.currentAuthenticatedUserId = undefined;
+      const deleteSpy = spyOn(ePersonDataServiceStub, 'deleteEPerson').and.callThrough();
+
+      const deleteButtons = fixture.debugElement.queryAll(By.css('.access-control-deleteEPersonButton'));
+      deleteButtons[0].triggerEventHandler('click', null);
+      tick();
+
+      expect(modalService.open).not.toHaveBeenCalled();
+      expect(deleteSpy).not.toHaveBeenCalled();
+    }));
   });
 
   describe('delete EPerson button when the isAuthorized returns false', () => {
@@ -237,12 +392,9 @@ describe('EPeopleRegistryComponent', () => {
       fixture.detectChanges();
     });
 
-    it('should be disabled', () => {
+    it('should be hidden', () => {
       ePeopleDeleteButton = fixture.debugElement.queryAll(By.css('#epeople tr td div button.delete-button'));
-      ePeopleDeleteButton.forEach((deleteButton: DebugElement) => {
-        expect(deleteButton.nativeElement.getAttribute('aria-disabled')).toBe('true');
-        expect(deleteButton.nativeElement.classList.contains('disabled')).toBeTrue();
-      });
+      expect(ePeopleDeleteButton.length).toBe(0);
     });
   });
 });

--- a/src/app/access-control/epeople-registry/epeople-registry.component.ts
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.ts
@@ -2,8 +2,9 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { UntypedFormBuilder } from '@angular/forms';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
-import { BehaviorSubject, combineLatest, Observable, Subscription } from 'rxjs';
+import { BehaviorSubject, combineLatest, Observable, of as observableOf, Subscription } from 'rxjs';
 import { map, switchMap, take } from 'rxjs/operators';
+import { AuthService } from '../../core/auth/auth.service';
 import { buildPaginatedList, PaginatedList } from '../../core/data/paginated-list.model';
 import { RemoteData } from '../../core/data/remote-data';
 import { EPersonDataService } from '../../core/eperson/eperson-data.service';
@@ -23,6 +24,7 @@ import { NoContent } from '../../core/shared/NoContent.model';
 import { PaginationService } from '../../core/pagination/pagination.service';
 import { DSONameService } from '../../core/breadcrumbs/dso-name.service';
 import { getEPersonEditRoute, getEPersonsRoute } from '../access-control-routing-paths';
+import { EPersonDeleteGuardService, SELF_DELETE_WARNING_LABEL } from './eperson-delete-guard.service';
 
 @Component({
   selector: 'ds-epeople-registry',
@@ -35,6 +37,9 @@ import { getEPersonEditRoute, getEPersonsRoute } from '../access-control-routing
 export class EPeopleRegistryComponent implements OnInit, OnDestroy {
 
   labelPrefix = 'admin.access-control.epeople.';
+  selfDeleteWarningLabel = SELF_DELETE_WARNING_LABEL;
+
+  currentAuthenticatedUserId: string;
 
   /**
    * A list of all the current EPeople within the repository or the result of the search
@@ -93,6 +98,8 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
               private translateService: TranslateService,
               private notificationsService: NotificationsService,
               private authorizationService: AuthorizationDataService,
+              private authService: AuthService,
+              private deleteGuard: EPersonDeleteGuardService,
               private formBuilder: UntypedFormBuilder,
               private router: Router,
               private modalService: NgbModal,
@@ -119,6 +126,9 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
     this.searching$.next(true);
     this.search({scope: this.currentSearchScope, query: this.currentSearchQuery});
     this.activeEPerson$ = this.epersonService.getActiveEPerson();
+    this.subs.push(this.authService.getAuthenticatedUserFromStore().subscribe((currentUser: EPerson) => {
+      this.currentAuthenticatedUserId = currentUser?.id;
+    }));
     this.subs.push(this.ePeople$.pipe(
       switchMap((epeople: PaginatedList<EPerson>) => {
         if (epeople.pageInfo.totalElements > 0) {
@@ -135,8 +145,7 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
             return buildPaginatedList(epeople.pageInfo, dtos);
           }));
         } else {
-          // if it's empty, simply forward the empty list
-          return [epeople];
+          return observableOf(buildPaginatedList(epeople.pageInfo, []));
         }
       })).subscribe((value: PaginatedList<EpersonDtoModel>) => {
       this.searching$.next(false);this.ePeopleDto$.next(value);
@@ -191,28 +200,50 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
    */
   deleteEPerson(ePerson: EPerson) {
     if (hasValue(ePerson.id)) {
-      const modalRef = this.modalService.open(ConfirmationModalComponent);
-      modalRef.componentInstance.dso = ePerson;
-      modalRef.componentInstance.headerLabel = 'confirmation-modal.delete-eperson.header';
-      modalRef.componentInstance.infoLabel = 'confirmation-modal.delete-eperson.info';
-      modalRef.componentInstance.cancelLabel = 'confirmation-modal.delete-eperson.cancel';
-      modalRef.componentInstance.confirmLabel = 'confirmation-modal.delete-eperson.confirm';
-      modalRef.componentInstance.brandColor = 'danger';
-      modalRef.componentInstance.confirmIcon = 'fas fa-trash';
-      modalRef.componentInstance.response.pipe(take(1)).subscribe((confirm: boolean) => {
-        if (confirm) {
-          if (hasValue(ePerson.id)) {
+      if (!hasValue(this.currentAuthenticatedUserId)) {
+        return;
+      }
+
+      if (this.isCurrentUser(ePerson)) {
+        this.deleteGuard.showSelfDeleteNotification();
+        return;
+      }
+
+      this.deleteGuard.getDeleteWarningLabel(ePerson).pipe(take(1)).subscribe((warningLabel: string | undefined) => {
+        const modalRef = this.modalService.open(ConfirmationModalComponent);
+        modalRef.componentInstance.dso = ePerson;
+        modalRef.componentInstance.headerLabel = 'confirmation-modal.delete-eperson.header';
+        modalRef.componentInstance.infoLabel = 'confirmation-modal.delete-eperson.info';
+        modalRef.componentInstance.warningLabel = warningLabel;
+        modalRef.componentInstance.cancelLabel = 'confirmation-modal.delete-eperson.cancel';
+        modalRef.componentInstance.confirmLabel = 'confirmation-modal.delete-eperson.confirm';
+        modalRef.componentInstance.brandColor = 'danger';
+        modalRef.componentInstance.confirmIcon = 'fas fa-trash';
+        modalRef.componentInstance.response.pipe(take(1)).subscribe((confirm: boolean) => {
+          if (confirm) {
             this.epersonService.deleteEPerson(ePerson).pipe(getFirstCompletedRemoteData()).subscribe((restResponse: RemoteData<NoContent>) => {
               if (restResponse.hasSucceeded) {
                 this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.deleted.success', {name: this.dsoNameService.getName(ePerson)}));
+              } else if (this.deleteGuard.isSelfDeletionError(restResponse)) {
+                this.deleteGuard.showSelfDeleteNotification();
               } else {
-                this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.deleted.success', { id: ePerson.id, statusCode: restResponse.statusCode, errorMessage: restResponse.errorMessage }));
+                this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.deleted.failure', {
+                  name: this.dsoNameService.getName(ePerson),
+                  id: ePerson.id,
+                  statusCode: restResponse.statusCode,
+                  errorMessage: restResponse.errorMessage,
+                  restResponse,
+                }));
               }
             });
           }
-        }
+        });
       });
     }
+  }
+
+  isCurrentUser(ePerson: EPerson): boolean {
+    return this.deleteGuard.isCurrentUser(ePerson, this.currentAuthenticatedUserId);
   }
 
   /**

--- a/src/app/access-control/epeople-registry/eperson-delete-guard.service.spec.ts
+++ b/src/app/access-control/epeople-registry/eperson-delete-guard.service.spec.ts
@@ -1,0 +1,147 @@
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { of as observableOf, throwError as observableThrowError } from 'rxjs';
+import { TranslateService } from '@ngx-translate/core';
+import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
+import { FeatureID } from '../../core/data/feature-authorization/feature-id';
+import { buildPaginatedList } from '../../core/data/paginated-list.model';
+import { PageInfo } from '../../core/shared/page-info.model';
+import { DSpaceObject } from '../../core/shared/dspace-object.model';
+import { SearchService } from '../../core/shared/search/search.service';
+import { WorkflowItemDataService } from '../../core/submission/workflowitem-data.service';
+import { WorkspaceitemDataService } from '../../core/submission/workspaceitem-data.service';
+import { NotificationsService } from '../../shared/notifications/notifications.service';
+import { createFailedRemoteDataObject$, createSuccessfulRemoteDataObject$ } from '../../shared/remote-data.utils';
+import { SearchObjects } from '../../shared/search/models/search-objects.model';
+import { NotificationsServiceStub } from '../../shared/testing/notifications-service.stub';
+import { EPersonMock } from '../../shared/testing/eperson.mock';
+import { EPersonDeleteGuardService } from './eperson-delete-guard.service';
+
+describe('EPersonDeleteGuardService', () => {
+  let service: EPersonDeleteGuardService;
+  let authorizationService: jasmine.SpyObj<AuthorizationDataService>;
+  let workspaceItemDataService: jasmine.SpyObj<WorkspaceitemDataService>;
+  let workflowItemDataService: jasmine.SpyObj<WorkflowItemDataService>;
+  let searchService: jasmine.SpyObj<SearchService>;
+  let notificationsService: NotificationsServiceStub;
+  let translateService: jasmine.SpyObj<TranslateService>;
+
+  const remoteList = (totalElements: number) => createSuccessfulRemoteDataObject$(
+    buildPaginatedList(new PageInfo({ elementsPerPage: 1, totalElements, totalPages: 1, currentPage: 1 }), [])
+  );
+  const searchObjects = (totalElements: number) => createSuccessfulRemoteDataObject$(Object.assign(
+    new SearchObjects<DSpaceObject>(),
+    buildPaginatedList(new PageInfo({ elementsPerPage: 1, totalElements, totalPages: 1, currentPage: 1 }), [])
+  ));
+
+  beforeEach(() => {
+    authorizationService = jasmine.createSpyObj('authorizationService', ['isAuthorized']);
+    authorizationService.isAuthorized.and.returnValue(observableOf(false));
+    workspaceItemDataService = jasmine.createSpyObj('workspaceItemDataService', ['searchBy']);
+    workspaceItemDataService.searchBy.and.returnValue(remoteList(0));
+    workflowItemDataService = jasmine.createSpyObj('workflowItemDataService', ['searchBy']);
+    workflowItemDataService.searchBy.and.returnValue(remoteList(0));
+    searchService = jasmine.createSpyObj('searchService', ['search']);
+    searchService.search.and.returnValue(searchObjects(0));
+    notificationsService = new NotificationsServiceStub();
+    translateService = jasmine.createSpyObj('translateService', ['get']);
+    translateService.get.and.callFake((key: string) => observableOf(key));
+
+    TestBed.configureTestingModule({
+      providers: [
+        EPersonDeleteGuardService,
+        { provide: AuthorizationDataService, useValue: authorizationService },
+        { provide: WorkspaceitemDataService, useValue: workspaceItemDataService },
+        { provide: WorkflowItemDataService, useValue: workflowItemDataService },
+        { provide: SearchService, useValue: searchService },
+        { provide: NotificationsService, useValue: notificationsService },
+        { provide: TranslateService, useValue: translateService },
+      ],
+    });
+    service = TestBed.inject(EPersonDeleteGuardService);
+  });
+
+  describe('isCurrentUser', () => {
+    it('is true only when the ids match', () => {
+      expect(service.isCurrentUser(EPersonMock, EPersonMock.id)).toBeTrue();
+      expect(service.isCurrentUser(EPersonMock, 'someone-else')).toBeFalse();
+      expect(service.isCurrentUser(undefined, EPersonMock.id)).toBeFalsy();
+    });
+  });
+
+  describe('getDeleteWarningLabel', () => {
+    it('returns undefined when the user is neither a submitter nor an admin', fakeAsync(() => {
+      let label: string | undefined = 'unset';
+      service.getDeleteWarningLabel(EPersonMock).subscribe((value) => label = value);
+      tick();
+      expect(label).toBeUndefined();
+    }));
+
+    it('returns the submitter warning when the user has submitted items', fakeAsync(() => {
+      workspaceItemDataService.searchBy.and.returnValue(remoteList(1));
+      let label: string;
+      service.getDeleteWarningLabel(EPersonMock).subscribe((value) => label = value);
+      tick();
+      expect(label).toBe('admin.access-control.epeople.delete.warning.submitter');
+    }));
+
+    it('returns the admin warning, querying the AdministratorOf feature for the target user', fakeAsync(() => {
+      authorizationService.isAuthorized.and.returnValue(observableOf(true));
+      let label: string;
+      service.getDeleteWarningLabel(EPersonMock).subscribe((value) => label = value);
+      tick();
+      expect(authorizationService.isAuthorized).toHaveBeenCalledWith(FeatureID.AdministratorOf, undefined, EPersonMock.id);
+      expect(label).toBe('admin.access-control.epeople.delete.warning.admin');
+    }));
+
+    it('returns the combined warning when both apply', fakeAsync(() => {
+      workspaceItemDataService.searchBy.and.returnValue(remoteList(1));
+      authorizationService.isAuthorized.and.returnValue(observableOf(true));
+      let label: string;
+      service.getDeleteWarningLabel(EPersonMock).subscribe((value) => label = value);
+      tick();
+      expect(label).toBe('admin.access-control.epeople.delete.warning.submitterAndAdmin');
+    }));
+
+    it('degrades each probe to false on error so a failed lookup never blocks the delete', fakeAsync(() => {
+      workspaceItemDataService.searchBy.and.returnValue(observableThrowError(() => new Error('boom')));
+      searchService.search.and.returnValue(observableThrowError(() => new Error('boom')));
+      authorizationService.isAuthorized.and.returnValue(observableThrowError(() => new Error('boom')));
+      let emitted = false;
+      let label: string | undefined = 'unset';
+      service.getDeleteWarningLabel(EPersonMock).subscribe((value) => {
+        emitted = true;
+        label = value;
+      });
+      tick();
+      expect(emitted).toBeTrue();
+      expect(label).toBeUndefined();
+    }));
+  });
+
+  describe('isSelfDeletionError', () => {
+    it('recognises the backend self-delete rejection', fakeAsync(() => {
+      let rd;
+      createFailedRemoteDataObject$('You, as admin user, cannot delete yourself', 400).subscribe((value) => rd = value);
+      tick();
+      expect(service.isSelfDeletionError(rd)).toBeTrue();
+    }));
+
+    it('ignores other failures', fakeAsync(() => {
+      let rd;
+      createFailedRemoteDataObject$('server error', 500).subscribe((value) => rd = value);
+      tick();
+      expect(service.isSelfDeletionError(rd)).toBeFalsy();
+      expect(service.isSelfDeletionError(null)).toBeFalsy();
+    }));
+  });
+
+  describe('showSelfDeleteNotification', () => {
+    it('emits the self-delete error notification', () => {
+      service.showSelfDeleteNotification();
+      expect(notificationsService.error).toHaveBeenCalled();
+      let translatedKey: string;
+      notificationsService.error.calls.mostRecent().args[0].subscribe((value) => translatedKey = value);
+      expect(translatedKey).toBe('admin.access-control.epeople.notification.deleted.forbidden.self');
+    });
+  });
+});

--- a/src/app/access-control/epeople-registry/eperson-delete-guard.service.ts
+++ b/src/app/access-control/epeople-registry/eperson-delete-guard.service.ts
@@ -105,7 +105,7 @@ export class EPersonDeleteGuardService {
       searchParams: [new RequestParam('uuid', epersonId)],
     });
     const archivedSearchOptions = new PaginatedSearchOptions({
-      query: `submitter_authority:${epersonId}`,
+      query: `submitter_authority:"${epersonId}"`,
       pagination: Object.assign(new PaginationComponentOptions(), {
         currentPage: 1,
         pageSize: 1,

--- a/src/app/access-control/epeople-registry/eperson-delete-guard.service.ts
+++ b/src/app/access-control/epeople-registry/eperson-delete-guard.service.ts
@@ -1,0 +1,145 @@
+import { Injectable } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { combineLatest, Observable, of as observableOf } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { RequestParam } from '../../core/cache/models/request-param.model';
+import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
+import { FeatureID } from '../../core/data/feature-authorization/feature-id';
+import { FindListOptions } from '../../core/data/find-list-options.model';
+import { PaginatedList } from '../../core/data/paginated-list.model';
+import { RemoteData } from '../../core/data/remote-data';
+import { EPerson } from '../../core/eperson/models/eperson.model';
+import { DSpaceObject } from '../../core/shared/dspace-object.model';
+import { NoContent } from '../../core/shared/NoContent.model';
+import { getFirstCompletedRemoteData } from '../../core/shared/operators';
+import { SearchService } from '../../core/shared/search/search.service';
+import { WorkflowItemDataService } from '../../core/submission/workflowitem-data.service';
+import { WorkspaceitemDataService } from '../../core/submission/workspaceitem-data.service';
+import { hasValue } from '../../shared/empty.util';
+import { NotificationsService } from '../../shared/notifications/notifications.service';
+import { PaginationComponentOptions } from '../../shared/pagination/pagination-component-options.model';
+import { PaginatedSearchOptions } from '../../shared/search/models/paginated-search-options.model';
+import { SearchObjects } from '../../shared/search/models/search-objects.model';
+
+/**
+ * Translation key for the notification shown when an admin tries to delete their own account.
+ * Exported so the templates can bind it as the disabled-delete-button tooltip.
+ */
+export const SELF_DELETE_WARNING_LABEL = 'admin.access-control.epeople.notification.deleted.forbidden.self';
+
+const WARNING_LABEL_PREFIX = 'admin.access-control.epeople.delete.warning.';
+
+/**
+ * Shared logic for the EPerson delete flow used by both the EPeople registry and the EPerson form.
+ * Determines a contextual warning for high-impact deletes, recognises the backend self-delete error
+ * and surfaces the self-delete notification. Centralised here so both call sites stay in sync
+ * (the previous per-component copies had already diverged in their error handling).
+ */
+@Injectable()
+export class EPersonDeleteGuardService {
+
+  constructor(
+    private authorizationService: AuthorizationDataService,
+    private workspaceItemDataService: WorkspaceitemDataService,
+    private workflowItemDataService: WorkflowItemDataService,
+    private searchService: SearchService,
+    private notificationsService: NotificationsService,
+    private translateService: TranslateService,
+  ) {
+  }
+
+  /**
+   * Whether the given EPerson is the currently authenticated user.
+   */
+  isCurrentUser(ePerson: EPerson, currentAuthenticatedUserId: string): boolean {
+    return hasValue(ePerson?.id) && ePerson.id === currentAuthenticatedUserId;
+  }
+
+  /**
+   * Resolve the contextual warning translation key for deleting the given EPerson,
+   * or undefined when there is nothing noteworthy to warn about.
+   * Warns when the user has submitted items, is an administrator, or both.
+   */
+  getDeleteWarningLabel(ePerson: EPerson): Observable<string | undefined> {
+    return combineLatest([
+      this.hasSubmittedItems(ePerson.id),
+      this.isAdministrator(ePerson),
+    ]).pipe(
+      map(([hasSubmittedItems, isAdmin]: [boolean, boolean]) => {
+        if (hasSubmittedItems && isAdmin) {
+          return WARNING_LABEL_PREFIX + 'submitterAndAdmin';
+        }
+        if (hasSubmittedItems) {
+          return WARNING_LABEL_PREFIX + 'submitter';
+        }
+        if (isAdmin) {
+          return WARNING_LABEL_PREFIX + 'admin';
+        }
+        return undefined;
+      })
+    );
+  }
+
+  /**
+   * Whether the backend rejected the delete because an admin tried to delete themselves.
+   */
+  isSelfDeletionError(restResponse: RemoteData<NoContent> | null): boolean {
+    return restResponse?.statusCode === 400 && restResponse?.errorMessage?.toLowerCase().includes('cannot delete yourself');
+  }
+
+  /**
+   * Show the "you cannot delete your own account" error notification.
+   */
+  showSelfDeleteNotification(): void {
+    this.notificationsService.error(this.translateService.get(SELF_DELETE_WARNING_LABEL));
+  }
+
+  /**
+   * Whether the EPerson is the submitter of any workspace, workflow or archived item.
+   * Each lookup degrades to `false` on error so a failed probe never blocks the delete.
+   */
+  private hasSubmittedItems(epersonId: string): Observable<boolean> {
+    const submitterSearchOptions = Object.assign(new FindListOptions(), {
+      currentPage: 1,
+      elementsPerPage: 1,
+      searchParams: [new RequestParam('uuid', epersonId)],
+    });
+    const archivedSearchOptions = new PaginatedSearchOptions({
+      query: `submitter_authority:${epersonId}`,
+      pagination: Object.assign(new PaginationComponentOptions(), {
+        currentPage: 1,
+        pageSize: 1,
+      }),
+    });
+
+    return combineLatest([
+      this.workspaceItemDataService.searchBy('findBySubmitter', submitterSearchOptions).pipe(
+        getFirstCompletedRemoteData(),
+        map((rd: RemoteData<PaginatedList<any>>) => rd.hasSucceeded && rd.payload.totalElements > 0),
+        catchError(() => observableOf(false)),
+      ),
+      this.workflowItemDataService.searchBy('findBySubmitter', submitterSearchOptions).pipe(
+        getFirstCompletedRemoteData(),
+        map((rd: RemoteData<PaginatedList<any>>) => rd.hasSucceeded && rd.payload.totalElements > 0),
+        catchError(() => observableOf(false)),
+      ),
+      this.searchService.search<DSpaceObject>(archivedSearchOptions).pipe(
+        getFirstCompletedRemoteData(),
+        map((rd: RemoteData<SearchObjects<DSpaceObject>>) => rd.hasSucceeded && rd.payload.totalElements > 0),
+        catchError(() => observableOf(false)),
+      ),
+    ]).pipe(
+      map((results: boolean[]) => results.some(Boolean)),
+    );
+  }
+
+  /**
+   * Whether the EPerson is a site administrator, via the authorization feature
+   * (catches indirect admin rights and avoids matching on a hard-coded group name).
+   */
+  private isAdministrator(ePerson: EPerson): Observable<boolean> {
+    return this.authorizationService.isAuthorized(FeatureID.AdministratorOf, undefined, ePerson?.id).pipe(
+      catchError(() => observableOf(false)),
+    );
+  }
+}

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.html
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.html
@@ -37,9 +37,20 @@
             <i class="fa fa-user-secret"></i> {{'admin.access-control.epeople.actions.stop-impersonating' | translate}}
           </button>
         </div>
-        <button *ngIf="canDelete$ | async" after class="btn btn-danger delete-button" type="button" (click)="delete()">
-          <i class="fas fa-trash"></i> {{'admin.access-control.epeople.actions.delete' | translate}}
-        </button>
+        <span *ngIf="(canDelete$ | async) && (activeEPerson$ | async) as activeEPerson">
+          <span *ngIf="isCurrentUser(activeEPerson); else enabledDeleteButton"
+                tabindex="0"
+                [ngbTooltip]="selfDeleteWarningLabel | translate">
+            <button class="btn btn-danger delete-button" [dsBtnDisabled]="true" tabindex="-1" type="button">
+              <i class="fas fa-trash"></i> {{'admin.access-control.epeople.actions.delete' | translate}}
+            </button>
+          </span>
+          <ng-template #enabledDeleteButton>
+            <button *ngIf="currentAuthenticatedUserId" class="btn btn-danger delete-button" type="button" (click)="delete()">
+              <i class="fas fa-trash"></i> {{'admin.access-control.epeople.actions.delete' | translate}}
+            </button>
+          </ng-template>
+        </span>
       </ds-form>
 
       <ds-themed-loading [showMessage]="false" *ngIf="!formGroup"></ds-themed-loading>

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
@@ -1,4 +1,6 @@
-import { Observable, of as observableOf } from 'rxjs';
+import { Observable, of as observableOf, throwError as observableThrowError } from 'rxjs';
+import { FeatureID } from '../../../core/data/feature-authorization/feature-id';
+import { EPersonDeleteGuardService } from '../eperson-delete-guard.service';
 import { CommonModule } from '@angular/common';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
@@ -16,7 +18,7 @@ import { NotificationsService } from '../../../shared/notifications/notification
 import { EPeopleRegistryComponent } from '../epeople-registry.component';
 import { EPersonFormComponent } from './eperson-form.component';
 import { EPersonMock, EPersonMock2 } from '../../../shared/testing/eperson.mock';
-import { createSuccessfulRemoteDataObject$ } from '../../../shared/remote-data.utils';
+import { createFailedRemoteDataObject$, createSuccessfulRemoteDataObject$ } from '../../../shared/remote-data.utils';
 import { getMockFormBuilderService } from '../../../shared/mocks/form-builder-service.mock';
 import { NotificationsServiceStub } from '../../../shared/testing/notifications-service.stub';
 import { AuthService } from '../../../core/auth/auth.service';
@@ -35,7 +37,13 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { RouterStub } from '../../../shared/testing/router.stub';
 import { ActivatedRouteStub } from '../../../shared/testing/active-router.stub';
 import { RouterTestingModule } from '@angular/router/testing';
-import {BtnDisabledDirective} from '../../../shared/btn-disabled.directive';
+import { BtnDisabledDirective } from '../../../shared/btn-disabled.directive';
+import { WorkspaceitemDataService } from '../../../core/submission/workspaceitem-data.service';
+import { WorkflowItemDataService } from '../../../core/submission/workflowitem-data.service';
+import { SearchService } from '../../../core/shared/search/search.service';
+import { SearchObjects } from '../../../shared/search/models/search-objects.model';
+import { DSpaceObject } from '../../../core/shared/dspace-object.model';
+import { DSONameService } from '../../../core/breadcrumbs/dso-name.service';
 
 describe('EPersonFormComponent', () => {
   let component: EPersonFormComponent;
@@ -50,12 +58,34 @@ describe('EPersonFormComponent', () => {
   let epersonRegistrationService: EpersonRegistrationService;
   let route: ActivatedRouteStub;
   let router: RouterStub;
+  let notificationsService: NotificationsServiceStub;
+  let workspaceItemDataService: jasmine.SpyObj<WorkspaceitemDataService>;
+  let workflowItemDataService: jasmine.SpyObj<WorkflowItemDataService>;
+  let searchService: jasmine.SpyObj<SearchService>;
 
   let paginationService;
 
 
 
   beforeEach(waitForAsync(() => {
+    const buildRemoteList = <T>(items: T[], totalElements = items.length) => createSuccessfulRemoteDataObject$(
+      buildPaginatedList(new PageInfo({
+        elementsPerPage: items.length || 1,
+        totalElements,
+        totalPages: 1,
+        currentPage: 1,
+      }), items)
+    );
+    const buildSearchObjects = (totalElements: number) => Object.assign(
+      new SearchObjects<DSpaceObject>(),
+      buildPaginatedList(new PageInfo({
+        elementsPerPage: 1,
+        totalElements,
+        totalPages: 1,
+        currentPage: 1,
+      }), [])
+    );
+
     mockEPeople = [EPersonMock, EPersonMock2];
     ePersonDataServiceStub = {
       activeEPerson: null,
@@ -178,7 +208,9 @@ describe('EPersonFormComponent', () => {
         return typeof value === 'object' && value !== null;
       }
     });
-    authService = new AuthServiceStub();
+    authService = Object.assign(new AuthServiceStub(), {
+      getAuthenticatedUserFromStore: () => observableOf(EPersonMock),
+    });
     authorizationService = jasmine.createSpyObj('authorizationService', {
       isAuthorized: observableOf(true),
 
@@ -187,6 +219,13 @@ describe('EPersonFormComponent', () => {
       findListByHref: createSuccessfulRemoteDataObject$(createPaginatedList([])),
       getGroupRegistryRouterLink: ''
     });
+    workspaceItemDataService = jasmine.createSpyObj('workspaceItemDataService', ['searchBy']);
+    workspaceItemDataService.searchBy.and.returnValue(buildRemoteList([], 0));
+    workflowItemDataService = jasmine.createSpyObj('workflowItemDataService', ['searchBy']);
+    workflowItemDataService.searchBy.and.returnValue(buildRemoteList([], 0));
+    searchService = jasmine.createSpyObj('searchService', ['search']);
+    searchService.search.and.returnValue(createSuccessfulRemoteDataObject$(buildSearchObjects(0)));
+    notificationsService = new NotificationsServiceStub();
 
     paginationService = new PaginationServiceStub();
     route = new ActivatedRouteStub();
@@ -201,12 +240,19 @@ describe('EPersonFormComponent', () => {
         { provide: EPersonDataService, useValue: ePersonDataServiceStub },
         { provide: GroupDataService, useValue: groupsDataService },
         { provide: FormBuilderService, useValue: builderService },
-        { provide: NotificationsService, useValue: new NotificationsServiceStub() },
+        { provide: NotificationsService, useValue: notificationsService },
         { provide: AuthService, useValue: authService },
         { provide: AuthorizationDataService, useValue: authorizationService },
         { provide: PaginationService, useValue: paginationService },
+        { provide: WorkspaceitemDataService, useValue: workspaceItemDataService },
+        { provide: WorkflowItemDataService, useValue: workflowItemDataService },
+        { provide: SearchService, useValue: searchService },
+        EPersonDeleteGuardService,
         { provide: RequestService, useValue: jasmine.createSpyObj('requestService', ['removeByHrefSubstring'])},
         { provide: EpersonRegistrationService, useValue: epersonRegistrationService },
+        { provide: DSONameService, useValue: jasmine.createSpyObj('dsoNameService', {
+          getName: (dso: any) => dso?.name ?? dso?.email ?? dso?.id,
+        }) },
         { provide: ActivatedRoute, useValue: route },
         { provide: Router, useValue: router },
         EPeopleRegistryComponent
@@ -448,13 +494,14 @@ describe('EPersonFormComponent', () => {
 
     beforeEach(() => {
       spyOn(authService, 'impersonate').and.callThrough();
-      eperson = EPersonMock;
+      eperson = EPersonMock2;
       component.epersonInitial = eperson;
       component.canDelete$ = observableOf(true);
       spyOn(component.epersonService, 'getActiveEPerson').and.returnValue(observableOf(eperson));
       modalService = (component as any).modalService;
       spyOn(modalService, 'open').and.returnValue(Object.assign({ componentInstance: Object.assign({ response: observableOf(true) }) }));
       component.ngOnInit();
+      component.currentAuthenticatedUserId = 'different-user-id';
       fixture.detectChanges();
     });
 
@@ -487,6 +534,98 @@ describe('EPersonFormComponent', () => {
       deleteButton.triggerEventHandler('click', null);
       fixture.detectChanges();
       expect(component.epersonService.deleteEPerson).toHaveBeenCalledWith(eperson);
+    });
+
+    it('should pass the combined warning label to the delete confirmation modal', () => {
+      workspaceItemDataService.searchBy.and.returnValue(createSuccessfulRemoteDataObject$(buildPaginatedList(new PageInfo({
+        elementsPerPage: 1,
+        totalElements: 1,
+        totalPages: 1,
+        currentPage: 1,
+      }), [{} as any])));
+      // isAuthorized returns true by default -> the target is treated as an administrator
+      fixture.detectChanges();
+
+      const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      deleteButton.triggerEventHandler('click', null);
+
+      expect(authorizationService.isAuthorized).toHaveBeenCalledWith(FeatureID.AdministratorOf, undefined, eperson.id);
+      expect(modalService.open).toHaveBeenCalled();
+      expect(modalService.open.calls.mostRecent().returnValue.componentInstance.warningLabel)
+        .toBe('admin.access-control.epeople.delete.warning.submitterAndAdmin');
+    });
+
+    it('should detect administrator via the authorization feature', () => {
+      // all submitter probes empty (default), administrator feature -> true
+      (authorizationService.isAuthorized as jasmine.Spy).and.callFake((featureId: FeatureID) => observableOf(featureId === FeatureID.AdministratorOf));
+      fixture.detectChanges();
+
+      const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      deleteButton.triggerEventHandler('click', null);
+
+      expect(authorizationService.isAuthorized).toHaveBeenCalledWith(FeatureID.AdministratorOf, undefined, eperson.id);
+      expect(modalService.open.calls.mostRecent().returnValue.componentInstance.warningLabel)
+        .toBe('admin.access-control.epeople.delete.warning.admin');
+    });
+
+    it('should still open the delete modal when a submitter probe errors (centralised catchError)', () => {
+      workspaceItemDataService.searchBy.and.returnValue(observableThrowError(() => new Error('boom')));
+      // workflow/search empty by default; AdministratorOf false so there is no warning to compose
+      (authorizationService.isAuthorized as jasmine.Spy).and.callFake((featureId: FeatureID) => observableOf(featureId !== FeatureID.AdministratorOf));
+      fixture.detectChanges();
+
+      const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      deleteButton.triggerEventHandler('click', null);
+
+      expect(modalService.open).toHaveBeenCalled();
+      expect(modalService.open.calls.mostRecent().returnValue.componentInstance.warningLabel).toBeUndefined();
+    });
+
+    it('should show the friendly self-delete notification when the backend returns the self-delete error', () => {
+      spyOn(component.epersonService, 'deleteEPerson').and.returnValue(createFailedRemoteDataObject$('You, as admin user, cannot delete yourself', 400));
+
+      const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      deleteButton.triggerEventHandler('click', null);
+
+      expect(notificationsService.error).toHaveBeenCalled();
+      let translatedKey: string;
+      notificationsService.error.calls.mostRecent().args[0].subscribe((value) => translatedKey = value);
+      expect(translatedKey).toBe('admin.access-control.epeople.notification.deleted.forbidden.self');
+    });
+
+    it('should hide enabled delete button before authenticated user id is resolved', () => {
+      component.currentAuthenticatedUserId = undefined;
+      fixture.detectChanges();
+
+      const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      expect(deleteButton).toBeNull();
+    });
+
+    it('should not open delete modal before authenticated user id is resolved', () => {
+      component.currentAuthenticatedUserId = undefined;
+      const deleteSpy = spyOn(component.epersonService, 'deleteEPerson').and.callThrough();
+
+      component.delete();
+
+      expect(modalService.open).not.toHaveBeenCalled();
+      expect(deleteSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('self delete button', () => {
+    beforeEach(() => {
+      component.epersonInitial = EPersonMock;
+      component.canDelete$ = observableOf(true);
+      spyOn(component.epersonService, 'getActiveEPerson').and.returnValue(observableOf(EPersonMock));
+      component.ngOnInit();
+      fixture.detectChanges();
+    });
+
+    it('should render the delete button as disabled for the current user', () => {
+      const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      expect(deleteButton).not.toBeNull();
+      expect(deleteButton.nativeElement.getAttribute('aria-disabled')).toBe('true');
+      expect(deleteButton.nativeElement.classList.contains('disabled')).toBeTrue();
     });
   });
 

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -40,6 +40,7 @@ import { TYPE_REQUEST_FORGOT } from '../../../register-email-form/register-email
 import { DSONameService } from '../../../core/breadcrumbs/dso-name.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { getEPersonsRoute } from '../../access-control-routing-paths';
+import { EPersonDeleteGuardService, SELF_DELETE_WARNING_LABEL } from '../eperson-delete-guard.service';
 
 @Component({
   selector: 'ds-eperson-form',
@@ -51,6 +52,9 @@ import { getEPersonsRoute } from '../../access-control-routing-paths';
 export class EPersonFormComponent implements OnInit, OnDestroy {
 
   labelPrefix = 'admin.access-control.epeople.form.';
+  selfDeleteWarningLabel = SELF_DELETE_WARNING_LABEL;
+
+  currentAuthenticatedUserId: string;
 
   /**
    * A unique id used for ds-form
@@ -198,6 +202,7 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
     private authorizationService: AuthorizationDataService,
     private modalService: NgbModal,
     private paginationService: PaginationService,
+    private deleteGuard: EPersonDeleteGuardService,
     public requestService: RequestService,
     private epersonRegistrationService: EpersonRegistrationService,
     public dsoNameService: DSONameService,
@@ -208,6 +213,9 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.activeEPerson$ = this.epersonService.getActiveEPerson();
+    this.subs.push(this.authService.getAuthenticatedUserFromStore().subscribe((currentUser: EPerson) => {
+      this.currentAuthenticatedUserId = currentUser?.id;
+    }));
     this.subs.push(this.activeEPerson$.subscribe((eperson: EPerson) => {
       this.epersonInitial = eperson;
       if (hasValue(eperson)) {
@@ -474,40 +482,76 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
     this.activeEPerson$.pipe(
       take(1),
       switchMap((eperson: EPerson) => {
-        const modalRef = this.modalService.open(ConfirmationModalComponent);
-        modalRef.componentInstance.dso = eperson;
-        modalRef.componentInstance.headerLabel = 'confirmation-modal.delete-eperson.header';
-        modalRef.componentInstance.infoLabel = 'confirmation-modal.delete-eperson.info';
-        modalRef.componentInstance.cancelLabel = 'confirmation-modal.delete-eperson.cancel';
-        modalRef.componentInstance.confirmLabel = 'confirmation-modal.delete-eperson.confirm';
-        modalRef.componentInstance.brandColor = 'danger';
-        modalRef.componentInstance.confirmIcon = 'fas fa-trash';
+        if (!hasValue(eperson?.id)) {
+          return observableOf(null);
+        }
 
-        return modalRef.componentInstance.response.pipe(
+        if (!hasValue(this.currentAuthenticatedUserId)) {
+          return observableOf(null);
+        }
+
+        if (this.isCurrentUser(eperson)) {
+          this.deleteGuard.showSelfDeleteNotification();
+          return observableOf(null);
+        }
+
+        return this.deleteGuard.getDeleteWarningLabel(eperson).pipe(
           take(1),
-          switchMap((confirm: boolean) => {
-            if (confirm && hasValue(eperson.id)) {
-              this.canDelete$ = observableOf(false);
-              return this.epersonService.deleteEPerson(eperson).pipe(
-                getFirstCompletedRemoteData(),
-                map((restResponse: RemoteData<NoContent>) => ({ restResponse, eperson }))
-              );
-            } else {
-              return observableOf(null);
-            }
-          }),
-          finalize(() => this.canDelete$ = observableOf(true))
+          switchMap((warningLabel: string | undefined) => {
+            const modalRef = this.modalService.open(ConfirmationModalComponent);
+            modalRef.componentInstance.dso = eperson;
+            modalRef.componentInstance.headerLabel = 'confirmation-modal.delete-eperson.header';
+            modalRef.componentInstance.infoLabel = 'confirmation-modal.delete-eperson.info';
+            modalRef.componentInstance.warningLabel = warningLabel;
+            modalRef.componentInstance.cancelLabel = 'confirmation-modal.delete-eperson.cancel';
+            modalRef.componentInstance.confirmLabel = 'confirmation-modal.delete-eperson.confirm';
+            modalRef.componentInstance.brandColor = 'danger';
+            modalRef.componentInstance.confirmIcon = 'fas fa-trash';
+
+            return modalRef.componentInstance.response.pipe(
+              take(1),
+              switchMap((confirm: boolean) => {
+                if (confirm) {
+                  this.canDelete$ = observableOf(false);
+                  return this.epersonService.deleteEPerson(eperson).pipe(
+                    getFirstCompletedRemoteData(),
+                    map((restResponse: RemoteData<NoContent>) => ({ restResponse, eperson, attempted: true }))
+                  );
+                }
+
+                return observableOf({ restResponse: null, eperson, attempted: false });
+              }),
+              finalize(() => this.canDelete$ = observableOf(true))
+            );
+          })
         );
       })
-    ).subscribe(({ restResponse, eperson }: { restResponse: RemoteData<NoContent> | null, eperson: EPerson }) => {
+    ).subscribe((result: { restResponse: RemoteData<NoContent> | null, eperson: EPerson, attempted: boolean } | null) => {
+      if (!result?.attempted) {
+        return;
+      }
+
+      const { restResponse, eperson } = result;
       if (restResponse?.hasSucceeded) {
         this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.deleted.success', { name: this.dsoNameService.getName(eperson) }));
         void this.router.navigate([getEPersonsRoute()]);
+      } else if (this.deleteGuard.isSelfDeletionError(restResponse)) {
+        this.deleteGuard.showSelfDeleteNotification();
       } else {
-        this.notificationsService.error(`Error occurred when trying to delete EPerson with id: ${eperson?.id} with code: ${restResponse?.statusCode} and message: ${restResponse?.errorMessage}`);
+        this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.deleted.failure', {
+          name: this.dsoNameService.getName(eperson),
+          id: eperson?.id,
+          statusCode: restResponse?.statusCode,
+          errorMessage: restResponse?.errorMessage,
+          restResponse,
+        }));
       }
       this.cancelForm.emit();
     });
+  }
+
+  isCurrentUser(ePerson: EPerson): boolean {
+    return this.deleteGuard.isCurrentUser(ePerson, this.currentAuthenticatedUserId);
   }
 
   /**

--- a/src/app/shared/confirmation-modal/confirmation-modal.component.html
+++ b/src/app/shared/confirmation-modal/confirmation-modal.component.html
@@ -6,6 +6,7 @@
   </div>
   <div class="modal-body">
     <p>{{ infoLabel | translate:{ dsoName: dsoNameService.getName(dso) } }}</p>
+    <p *ngIf="warningLabel" class="text-warning mb-0">{{ warningLabel | translate:{ dsoName: dsoNameService.getName(dso) } }}</p>
   </div>
   <div class="modal-footer">
     <button type="button" class="cancel btn btn-outline-secondary" (click)="cancelPressed()" aria-label="Cancel">

--- a/src/app/shared/confirmation-modal/confirmation-modal.component.spec.ts
+++ b/src/app/shared/confirmation-modal/confirmation-modal.component.spec.ts
@@ -35,6 +35,19 @@ describe('ConfirmationModalComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should not render a warning message by default', () => {
+    expect(debugElement.query(By.css('.modal-body .text-warning'))).toBeNull();
+  });
+
+  it('should render the warning message when warningLabel is set', () => {
+    component.warningLabel = 'confirmation-modal.warning';
+    fixture.detectChanges();
+
+    const warningMessage = debugElement.query(By.css('.modal-body .text-warning'));
+    expect(warningMessage).not.toBeNull();
+    expect(warningMessage.nativeElement.textContent).toContain('confirmation-modal.warning');
+  });
+
   describe('close', () => {
     beforeEach(() => {
       component.close();

--- a/src/app/shared/confirmation-modal/confirmation-modal.component.ts
+++ b/src/app/shared/confirmation-modal/confirmation-modal.component.ts
@@ -10,6 +10,7 @@ import { DSONameService } from '../../core/breadcrumbs/dso-name.service';
 export class ConfirmationModalComponent {
   @Input() headerLabel: string;
   @Input() infoLabel: string;
+  @Input() warningLabel?: string;
   @Input() cancelLabel: string;
   @Input() confirmLabel: string;
   @Input() confirmIcon: string;

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -551,6 +551,18 @@
   // "admin.access-control.epeople.notification.deleted.success": "Successfully deleted EPerson: \"{{name}}\"",
   "admin.access-control.epeople.notification.deleted.success": "Úspěšně odstraněn uživatel: \"{{name}}\"",
 
+  // "admin.access-control.epeople.notification.deleted.forbidden.self": "You cannot delete your own EPerson account.",
+  "admin.access-control.epeople.notification.deleted.forbidden.self": "Nemůžete smazat svůj vlastní účet uživatele.",
+
+  // "admin.access-control.epeople.delete.warning.submitter": "Warning: this user has submitted items. Deleting this EPerson may affect submission ownership and related repository records.",
+  "admin.access-control.epeople.delete.warning.submitter": "Upozornění: Tento uživatel odeslal položky. Smazání tohoto uživatele může ovlivnit vlastnictví příspěvků a související záznamy v repozitáři.",
+
+  // "admin.access-control.epeople.delete.warning.admin": "Warning: this user has administrator privileges. Deleting this EPerson will remove an administrator account.",
+  "admin.access-control.epeople.delete.warning.admin": "Upozornění: Tento uživatel má oprávnění správce. Smazání tohoto uživatele odebere účet správce.",
+
+  // "admin.access-control.epeople.delete.warning.submitterAndAdmin": "Warning: this user has submitted items and has administrator privileges. Deleting this EPerson may affect submission ownership and remove an administrator account.",
+  "admin.access-control.epeople.delete.warning.submitterAndAdmin": "Upozornění: Tento uživatel odeslal položky a má oprávnění správce. Smazání tohoto uživatele může ovlivnit vlastnictví příspěvků a odebrat účet správce.",
+
   // "admin.access-control.groups.title": "Groups",
   "admin.access-control.groups.title": "Skupiny",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -351,6 +351,14 @@
 
   "admin.access-control.epeople.form.notification.deleted.failure": "Failed to delete EPerson \"{{name}}\"",
 
+  "admin.access-control.epeople.notification.deleted.forbidden.self": "You cannot delete your own EPerson account.",
+
+  "admin.access-control.epeople.delete.warning.submitter": "Warning: this user has submitted items. Deleting this EPerson may affect submission ownership and related repository records.",
+
+  "admin.access-control.epeople.delete.warning.admin": "Warning: this user has administrator privileges. Deleting this EPerson will remove an administrator account.",
+
+  "admin.access-control.epeople.delete.warning.submitterAndAdmin": "Warning: this user has submitted items and has administrator privileges. Deleting this EPerson may affect submission ownership and remove an administrator account.",
+
   "admin.access-control.epeople.form.groupsEPersonIsMemberOf": "Member of these groups:",
 
   "admin.access-control.epeople.form.table.id": "ID",


### PR DESCRIPTION
Port of ufal/dspace-angular#140 by @amadulhaxxani to `dtq-dev`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized self-deletion protection with contextual delete warnings (submitter/admin/both).
  * Delete UI now disables or hides appropriately when the selected account is the current user and while the signed-in user ID is unresolved.
  * Confirmation modal now displays an optional warning paragraph when a warning label is provided.
* **Bug Fixes**
  * Prevented self-deletion from proceeding normally and ensured dedicated notifications for self-delete rejections.
  * Improved deletion flow so it waits for the authenticated user ID before enabling actions.
* **Tests**
  * Expanded unit coverage for delete warnings, self-delete detection, and notification behavior.
* **Documentation**
  * Added new translated messages for delete warnings and self-deletion notices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->