### PR TITLE
test: fix flaky DSDynamicTypeBindRelationService spec (double spyOn)

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-type-bind-relation.service.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-type-bind-relation.service.spec.ts
@@ -27,8 +27,8 @@ describe('DSDynamicTypeBindRelationService test suite', () => {
 
   beforeEach(() => {
     // Return the promise so the module (and its fresh getMockFormBuilderService() spy mock) is fully set up
-    // before each spec runs; the previous dangling .then() did not await, allowing async setup slop between
-    // specs.
+    // before each spec runs; the previous dangling .then() did not await, letting asynchronous module setup
+    // leak between specs.
     return TestBed.configureTestingModule({
       imports: [ReactiveFormsModule],
       providers: [

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-type-bind-relation.service.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-type-bind-relation.service.spec.ts
@@ -86,7 +86,7 @@ describe('DSDynamicTypeBindRelationService test suite', () => {
     it('Should not push undefined bind models', () => {
       const testModel = mockInputWithTypeBindModel;
       testModel.typeBindRelations = getTypeBindRelations(['boundType']);
-      spyOn((service as any).formBuilderService, 'getTypeBindModel').and.returnValue(undefined);
+      ((service as any).formBuilderService.getTypeBindModel as jasmine.Spy).and.returnValue(undefined);
 
       const relatedModels = service.getRelatedFormModel(testModel);
 
@@ -143,7 +143,7 @@ describe('DSDynamicTypeBindRelationService test suite', () => {
         opposingMatch: HIDDEN_MATCHER.match,
         onChange: jasmine.createSpy('onChange')
       };
-      spyOn((service as any).formBuilderService, 'getTypeBindModel').and.returnValue(undefined);
+      ((service as any).formBuilderService.getTypeBindModel as jasmine.Spy).and.returnValue(undefined);
 
       const hasMatch = service.matchesCondition(relation, visibleMatcher);
 
@@ -159,7 +159,7 @@ describe('DSDynamicTypeBindRelationService test suite', () => {
         opposingMatch: MATCH_VISIBLE,
         onChange: jasmine.createSpy('onChange')
       };
-      spyOn((service as any).formBuilderService, 'getTypeBindModel').and.returnValue(undefined);
+      ((service as any).formBuilderService.getTypeBindModel as jasmine.Spy).and.returnValue(undefined);
 
       const hasMatch = service.matchesCondition(relation, hiddenMatcher);
 
@@ -185,8 +185,8 @@ describe('DSDynamicTypeBindRelationService test suite', () => {
         onChange: jasmine.createSpy('onChange')
       };
       (service as any).dynamicMatchers = [visibleMatcher];
-      spyOn((service as any).formBuilderService, 'getTypeBindModel').and.callFake(() => bindModelAvailable ? bindModel : undefined);
-      spyOn((service as any).formBuilderService, 'getTypeBindModelUpdates').and.returnValue(bindModelUpdates$.asObservable());
+      ((service as any).formBuilderService.getTypeBindModel as jasmine.Spy).and.callFake(() => bindModelAvailable ? bindModel : undefined);
+      ((service as any).formBuilderService.getTypeBindModelUpdates as jasmine.Spy).and.returnValue(bindModelUpdates$.asObservable());
 
       const subscriptions = service.subscribeRelations(testModel, dcTypeControl);
       expect(subscriptions.length).toBe(1);
@@ -220,8 +220,8 @@ describe('DSDynamicTypeBindRelationService test suite', () => {
         onChange: jasmine.createSpy('onChange')
       };
       (service as any).dynamicMatchers = [hiddenMatcher];
-      spyOn((service as any).formBuilderService, 'getTypeBindModel').and.callFake(() => bindModelAvailable ? bindModel : undefined);
-      spyOn((service as any).formBuilderService, 'getTypeBindModelUpdates').and.returnValue(bindModelUpdates$.asObservable());
+      ((service as any).formBuilderService.getTypeBindModel as jasmine.Spy).and.callFake(() => bindModelAvailable ? bindModel : undefined);
+      ((service as any).formBuilderService.getTypeBindModelUpdates as jasmine.Spy).and.returnValue(bindModelUpdates$.asObservable());
 
       const subscriptions = service.subscribeRelations(testModel, dcTypeControl);
       expect(subscriptions.length).toBe(1);
@@ -254,8 +254,8 @@ describe('DSDynamicTypeBindRelationService test suite', () => {
         onChange: jasmine.createSpy('onChange')
       };
       (service as any).dynamicMatchers = [visibleMatcher];
-      spyOn((service as any).formBuilderService, 'getTypeBindModel').and.callFake(() => bindModelAvailable ? bindModel : undefined);
-      spyOn((service as any).formBuilderService, 'getTypeBindModelUpdates').and.returnValue(bindModelUpdates$.asObservable());
+      ((service as any).formBuilderService.getTypeBindModel as jasmine.Spy).and.callFake(() => bindModelAvailable ? bindModel : undefined);
+      ((service as any).formBuilderService.getTypeBindModelUpdates as jasmine.Spy).and.returnValue(bindModelUpdates$.asObservable());
 
       const subscriptions = service.subscribeRelations(testModel, dcTypeControl);
       expect(visibleMatcher.onChange).toHaveBeenCalledWith(false, testModel, dcTypeControl, jasmine.anything());

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-type-bind-relation.service.spec.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-type-bind-relation.service.spec.ts
@@ -26,7 +26,10 @@ describe('DSDynamicTypeBindRelationService test suite', () => {
   let injector: Injector;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
+    // Return the promise so the module (and its fresh getMockFormBuilderService() spy mock) is fully set up
+    // before each spec runs; the previous dangling .then() did not await, allowing async setup slop between
+    // specs.
+    return TestBed.configureTestingModule({
       imports: [ReactiveFormsModule],
       providers: [
         { provide: FormBuilderService, useValue: getMockFormBuilderService() },
@@ -34,7 +37,7 @@ describe('DSDynamicTypeBindRelationService test suite', () => {
         { provide: DynamicFormRelationService },
         DISABLED_MATCHER_PROVIDER, HIDDEN_MATCHER_PROVIDER, REQUIRED_MATCHER_PROVIDER
       ]
-    }).compileComponents().then();
+    }).compileComponents();
   });
 
   beforeEach(inject([DsDynamicTypeBindRelationService, DynamicFormRelationService],


### PR DESCRIPTION
## Why

The frontend `dtq-dev` build is intermittently red on the `DSDynamicTypeBindRelationService` suite. It's a
genuine flake: the **same commit `fecfa07e` passes some runs and fails others** — e.g. one scheduled run
reports `TOTAL: 5417 SUCCESS`, another fails with 36×:

```
DSDynamicTypeBindRelationService test suite ... FAILED
	Error: <spyOn> : getTypeBindModel has already been spied upon
```

## Root cause

The suite's `FormBuilderService` mock is built with `jasmine.createSpyObj(...)`
(`src/app/shared/mocks/form-builder-service.mock.ts`), so `getTypeBindModel` and `getTypeBindModelUpdates`
are **already jasmine spies**. Several specs in `ds-dynamic-type-bind-relation.service.spec.ts` then call
`spyOn((service as any).formBuilderService, 'getTypeBindModel')` **on top of the existing spy**. Calling
`spyOn` on a method that is already a spy is illegal in Jasmine and throws
`"<spyOn> : … has already been spied upon"`. Because Karma/Jasmine runs specs in **randomized order**, this
surfaces intermittently rather than on every run — hence the flaky pipeline.

## Fix (test-only)

Reconfigure the **existing** spies instead of re-spying them — the standard Jasmine idiom for a
`createSpyObj` mock:

```diff
- spyOn((service as any).formBuilderService, 'getTypeBindModel').and.returnValue(undefined);
+ ((service as any).formBuilderService.getTypeBindModel as jasmine.Spy).and.returnValue(undefined);
```

Applied to all 9 call sites (`getTypeBindModel` ×6 with `returnValue`/`callFake`, `getTypeBindModelUpdates`
×3). The spy behaviour set for each test is identical to before (`.and.returnValue(...)` /
`.and.callFake(...)`), so every assertion is unchanged — only the illegal double-`spyOn` is removed, which
makes `"already been spied upon"` impossible in any spec order. No production code changed; no test behaviour
or coverage changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the unit test initialization to ensure module compilation completes before each spec runs.
  * Standardized how service methods are mocked, improving consistency across tests for missing vs. available bind model data.
  * Enhanced scenarios that verify the UI reacts when bind model values become available later and when they change after registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->