### PR TITLE
fix(docker): publish UI on a per-instance port so dev instances coexist

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -34,10 +34,13 @@ services:
     networks:
     - dspacenet
     ports:
-    - published: 4000
+    # Publish the UI on a per-instance loopback port so multiple customer
+    # instances can coexist on the same dev host. DSPACE_FE_PORT comes from the
+    # instance .env (e.g. 4593 for 8593); nginx proxies :<INSTANCE> -> this port.
+    # A fixed 0.0.0.0:4000 let only one deployed instance exist per host.
+    - published: ${DSPACE_FE_PORT:-4000}
       target: 4000
-    - published: 9876
-      target: 9876
+      host_ip: 127.0.0.1
     volumes:
     # Mount the local 'src' directory to the '/app' directory on the container.
     # Allows the UI to "watch" this directory for changes and reload/rebuild when changes are detected.


### PR DESCRIPTION
## Problem
The dev deploy (`.github/workflows/deploy.yml` -> `build-scripts/run/start.sh`) brings the stack up from `docker/docker-compose.yml`, which publishes the Angular UI on fixed `0.0.0.0:4000` and `0.0.0.0:9876`. Because those ports are hardcoded on all interfaces, only **one** customer instance can run per dev host. Deploying JCU (`8593`) to `dev-6`, where `customer-mendelu` (`8573`) already publishes `0.0.0.0:4000`, failed:

```
Error response from daemon: failed to set up container networking:
Bind for 0.0.0.0:4000 failed: port is already allocated
```

## Fix
Publish the UI on a per-instance loopback port driven by `DSPACE_FE_PORT` (already defined in each instance `.env`, e.g. `4593` for `8593`), bound to `127.0.0.1`. This matches the pyinfra/nginx convention (nginx proxies `:<instance>` -> this port) so instances coexist. The `9876` Karma unit-test port is dropped: a deployed instance does not serve it and it would collide across instances too.

## Testing
Deploy `8593` to `dev-6` alongside the existing `8573`/`8583` instances; the UI binds `127.0.0.1:4593` with no port conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)