### PR TITLE
fix(deploy): make jcu GA deploy support ERASE_DB and import

### DIFF
--- a/.github/actions/erase-db/action.yml
+++ b/.github/actions/erase-db/action.yml
@@ -1,0 +1,31 @@
+name: 'Erase dspace db'
+description: 'CI/CD Erase db'
+
+inputs:
+  INSTANCE:
+    description: 'port suffix'
+    required: true
+    type: string
+  NAME:
+    description: 'docker compose project name'
+    required: true
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: stop and remove containers
+      shell: bash
+      env:
+        INSTANCE: ${{ inputs.INSTANCE }}
+      run: |
+        docker stop dspacesolr$INSTANCE dspacedb$INSTANCE dspace$INSTANCE dspace-angular$INSTANCE || true
+        docker rm   dspacesolr$INSTANCE dspacedb$INSTANCE dspace$INSTANCE dspace-angular$INSTANCE || true
+
+    - name: remove volumes
+      shell: bash
+      env:
+        NAME: ${{ inputs.NAME }}
+      run: |
+          docker volume rm $(docker volume ls --filter name="${NAME}_" -q) || true

--- a/.github/actions/erase-db/action.yml
+++ b/.github/actions/erase-db/action.yml
@@ -5,10 +5,12 @@ inputs:
   INSTANCE:
     description: 'port suffix'
     required: true
+    default: '8593'
     type: string
   NAME:
     description: 'docker compose project name'
     required: true
+    default: 'dspace-8593'
     type: string
 
 runs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -148,7 +148,7 @@ jobs:
         run: |
           export DNAME=dspace${{inputs.INSTANCE}}
           echo "Creating DSpace administrator..."
-          docker exec $DNAME /bin/bash -c "cd /dspace/bin && ./dspace create-administrator -e dspace.admin.dev@dataquest.sk -f admin -l user -p \"${ADMIN_PASSWORD}\" -c en -o dataquest"
+          docker exec $DNAME /bin/bash -c "cd /dspace/bin && ./dspace create-administrator -e dspace.admin.dev@dataquest.sk -f admin -l user -p \"${ADMIN_PASSWORD}\" -c en"
 
       - name: rebuild discovery index and run oai import
         run: |


### PR DESCRIPTION
## Goal
Make the `customer/jcu` GA deploy work with **ERASE_DB** and **import**.

## Included in this PR
- **Add `.github/actions/erase-db/action.yml`** (same as `customer/vsb-tuo`). `deploy.yml` already `uses: ./.github/actions/erase-db`, but the branch had no `.github/actions/` dir, so `ERASE_DB=true` failed with:
  ```
  Can't find 'action.yml' … under '.github/actions/erase-db'
  ```

## Still needed in `deploy.yml` (NOT in this PR — the pushing token lacks the `workflow` scope)
Two edits in the `import-3` job, needed for the import to finish:
1. **Drop `-o dataquest`** from `create-administrator`. The `customer-jcu` image is stock DSpace and rejects the dataquest-only `-o` flag (`Unrecognized option: -o`).
2. **Fix the admin-password secret**: `import-3` reads `secrets.ADMIN_PASSWORD`, but `deploy-3` uses `secrets.DSPACE_ADMIN_PASSWORD` → the import admin password is empty. Align both on `DSPACE_ADMIN_PASSWORD`.

Apply these two via the GitHub web editor (or a push from a token with `workflow` scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)