### PR TITLE
JCU/Fix ports in erase db

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,7 +94,7 @@ jobs:
       INSTANCE: ${{inputs.INSTANCE}}
       CONFIG_PATH: /opt/dspace-envs/
       FNAME: old_dump.sql
-      ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
+      ADMIN_PASSWORD: ${{ secrets.DSPACE_ADMIN_PASSWORD }}
     steps:
       - name: vanilla import
         run: |
@@ -112,9 +112,9 @@ jobs:
 
           # Create database, import dumpand extensions, then cleanup
           docker exec $DDBNAME /bin/bash -c "
-          dropdb -U dspace -p 10593 dspace || true &&
-          createdb -U dspace -p 10593 --owner=dspace --encoding=UNICODE dspace &&
-          psql -p 10593 -U dspace -d dspace -f /tmp/$FNAME
+          dropdb -U dspace dspace || true &&
+          createdb -U dspace --owner=dspace --encoding=UNICODE dspace &&
+          psql -U dspace -d dspace -f /tmp/$FNAME
           "
           echo "====="
           docker start $DNAME


### PR DESCRIPTION
## Problem description
Error:
```
Run export DATADIR=$CONFIG_PATH/8593/dump/$FNAME
dspace8593
=====
Copying script for setup db roles to container...
dropdb: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.10593" failed: No such file or directory
	Is the server running locally and accepting connections on that socket?
createdb: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.10593" failed: No such file or directory
	Is the server running locally and accepting connections on that socket?
Error: Process completed with exit code 1.
```

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot