### PR TITLE
feat(docker): tunable Solr heap via SOLR_HEAP (jcu, 9.3)

### DIFF
--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -129,7 +129,7 @@ services:
       precreate-core suggestion /opt/solr/server/solr/configsets/suggestion
       cp -r /opt/solr/server/solr/configsets/suggestion/* suggestion
       chown -R solr:solr /var/solr
-      runuser -u solr -- solr-foreground
+      runuser -u solr -- env SOLR_HEAP="${SOLR_HEAP:-4g}" solr-foreground
 volumes:
   assetstore:
   pgdata:


### PR DESCRIPTION
## Problem
On DSpace 9.x (`customer/jcu`, 9.3) the Solr container has **no heap knob**. It launches via
`runuser -u solr -- solr-foreground` with no `-m` flag, so Solr falls back to the image default
heap (**512m**) and operators can't tune it without editing this tracked compose file. The whole
7.x customer fleet runs **4g** (source PR dataquest-dev/dspace-angular#1309); 9.x had no equivalent.

Carved out of dataquest-dev/dspace-customers#746, which marked the 9.x branches **N/A** for the
`-m 4g` backport (no anchor to translate) and flagged a tunable heap as a **separate feature**.

## Root cause
The 9.x Solr entrypoint never passed a heap argument, and `solr-foreground` runs under a `runuser`
user switch, so no `SOLR_HEAP` reached Solr's start scripts.

## Change set
One line in `docker/docker-compose-rest.yml`, the Solr entrypoint's final command:

```diff
-      runuser -u solr -- solr-foreground
+      runuser -u solr -- env SOLR_HEAP="${SOLR_HEAP:-4g}" solr-foreground
```

- `env SOLR_HEAP=…` forwards the value explicitly through `runuser` into the `solr` user's
  environment, where `solr-foreground` honours it natively — no dependence on runuser env passing.
- Compose interpolates `${SOLR_HEAP:-4g}` from the host/`.env` at parse time; quoted to survive
  word-splitting.
- **Default decision:** 4g when unset — aligns 9.x with the 7.x fleet and #1309. This is a
  **deliberate behavior change** on 9.x (image default 512m → 4g). Override with `SOLR_HEAP=1g`
  in `.env`. No other line changed.

## Test evidence
`docker compose config` renders the interpolated entrypoint correctly:

```
# unset  -> default 4g
$ SOLR_HEAP= docker compose -f docker/docker-compose.yml -f docker/docker-compose-rest.yml config | grep solr-foreground
        runuser -u solr -- env SOLR_HEAP="4g" solr-foreground

# override
$ SOLR_HEAP=1g docker compose ... config | grep solr-foreground
        runuser -u solr -- env SOLR_HEAP="1g" solr-foreground
```

## Risk & rollback
Low. Infra-only, single line. Default heap rises 512m → 4g on 9.x (intended; matches fleet). If a
host lacks 4g, set `SOLR_HEAP` lower in `.env`. Rollback = revert this commit.

## Notes / assumptions
- Sibling PR opens the identical change on `customer/mendelu` (9.1).
- Out of scope: 7.x branches (#746), other services/ports, the Solr image/version.
- No standalone tracking issue created (per request this is delivered as PRs); source context is
  #1309 + dataquest-dev/dspace-customers#746.
