### PR TITLE
Fix misleading notification when admin self-delete is rejected

### DIFF
--- a/src/app/access-control/epeople-registry/epeople-registry.component.spec.ts
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.spec.ts
@@ -1,5 +1,5 @@
 import { Router } from '@angular/router';
-import { Observable, of as observableOf, throwError as observableThrowError } from 'rxjs';
+import { defer, Observable, of as observableOf, throwError as observableThrowError } from 'rxjs';
 import { CommonModule } from '@angular/common';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
@@ -381,6 +381,27 @@ describe('EPeopleRegistryComponent', () => {
 
       expect(modalService.open).not.toHaveBeenCalled();
       expect(deleteSpy).not.toHaveBeenCalled();
+    }));
+
+    it('should still show the friendly self-delete notification if the authenticated user id resolves late and the backend rejection carries no usable message', fakeAsync(() => {
+      // Simulates the authenticated-user subscription resolving after the click (so the
+      // pre-flight self-delete check is bypassed) combined with a backend response whose error
+      // message can't be pattern-matched (e.g. Spring Boot's default message suppression).
+      // The self-delete notification must still win over the generic failure one.
+      modalRef.componentInstance.response = observableOf(true);
+      component.currentAuthenticatedUserId = EPersonMock.id;
+      ePersonDataServiceStub.deleteEPerson = jasmine.createSpy('deleteEPerson').and.returnValue(defer(() => {
+        component.currentAuthenticatedUserId = EPersonMock2.id;
+        return createFailedRemoteDataObject$(undefined, 400);
+      }));
+
+      component.deleteEPerson(EPersonMock2);
+      tick();
+
+      expect(notificationsService.error).toHaveBeenCalled();
+      let translatedKey: string;
+      notificationsService.error.calls.mostRecent().args[0].subscribe((value) => translatedKey = value);
+      expect(translatedKey).toBe('admin.access-control.epeople.notification.deleted.forbidden.self');
     }));
   });
 

--- a/src/app/access-control/epeople-registry/epeople-registry.component.spec.ts
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.spec.ts
@@ -384,10 +384,6 @@ describe('EPeopleRegistryComponent', () => {
     }));
 
     it('should still show the friendly self-delete notification if the authenticated user id resolves late and the backend rejection carries no usable message', fakeAsync(() => {
-      // Simulates the authenticated-user subscription resolving after the click (so the
-      // pre-flight self-delete check is bypassed) combined with a backend response whose error
-      // message can't be pattern-matched (e.g. Spring Boot's default message suppression).
-      // The self-delete notification must still win over the generic failure one.
       modalRef.componentInstance.response = observableOf(true);
       component.currentAuthenticatedUserId = EPersonMock.id;
       ePersonDataServiceStub.deleteEPerson = jasmine.createSpy('deleteEPerson').and.returnValue(defer(() => {

--- a/src/app/access-control/epeople-registry/epeople-registry.component.ts
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.ts
@@ -224,7 +224,7 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
             this.epersonService.deleteEPerson(ePerson).pipe(getFirstCompletedRemoteData()).subscribe((restResponse: RemoteData<NoContent>) => {
               if (restResponse.hasSucceeded) {
                 this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.deleted.success', {name: this.dsoNameService.getName(ePerson)}));
-              } else if (this.deleteGuard.isSelfDeletionError(restResponse)) {
+              } else if (this.isCurrentUser(ePerson) || this.deleteGuard.isSelfDeletionError(restResponse)) {
                 this.deleteGuard.showSelfDeleteNotification();
               } else {
                 this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.deleted.failure', {

--- a/src/app/access-control/epeople-registry/eperson-delete-guard.service.ts
+++ b/src/app/access-control/epeople-registry/eperson-delete-guard.service.ts
@@ -82,6 +82,9 @@ export class EPersonDeleteGuardService {
 
   /**
    * Whether the backend rejected the delete because an admin tried to delete themselves.
+   * Best-effort only: Spring Boot omits the exception message from the response body by
+   * default, so callers should treat this as a fallback alongside a client-side identity
+   * check rather than the sole signal.
    */
   isSelfDeletionError(restResponse: RemoteData<NoContent> | null): boolean {
     return restResponse?.statusCode === 400 && restResponse?.errorMessage?.toLowerCase().includes('cannot delete yourself');

--- a/src/app/access-control/epeople-registry/eperson-delete-guard.service.ts
+++ b/src/app/access-control/epeople-registry/eperson-delete-guard.service.ts
@@ -82,9 +82,6 @@ export class EPersonDeleteGuardService {
 
   /**
    * Whether the backend rejected the delete because an admin tried to delete themselves.
-   * Best-effort only: Spring Boot omits the exception message from the response body by
-   * default, so callers should treat this as a fallback alongside a client-side identity
-   * check rather than the sole signal.
    */
   isSelfDeletionError(restResponse: RemoteData<NoContent> | null): boolean {
     return restResponse?.statusCode === 400 && restResponse?.errorMessage?.toLowerCase().includes('cannot delete yourself');

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
@@ -612,10 +612,6 @@ describe('EPersonFormComponent', () => {
     });
 
     it('should still show the friendly self-delete notification if the authenticated user id resolves late and the backend rejection carries no usable message', () => {
-      // Simulates the authenticated-user subscription resolving after the modal was confirmed
-      // (so the pre-flight self-delete check was bypassed) combined with a backend response
-      // whose error message can't be pattern-matched (e.g. Spring Boot's default message
-      // suppression). The self-delete notification must still win over the generic failure one.
       spyOn(component.epersonService, 'deleteEPerson').and.returnValue(defer(() => {
         component.currentAuthenticatedUserId = eperson.id;
         return createFailedRemoteDataObject$(undefined, 400);

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
@@ -1,4 +1,4 @@
-import { Observable, of as observableOf, throwError as observableThrowError } from 'rxjs';
+import { defer, Observable, of as observableOf, throwError as observableThrowError } from 'rxjs';
 import { FeatureID } from '../../../core/data/feature-authorization/feature-id';
 import { EPersonDeleteGuardService } from '../eperson-delete-guard.service';
 import { CommonModule } from '@angular/common';
@@ -609,6 +609,25 @@ describe('EPersonFormComponent', () => {
 
       expect(modalService.open).not.toHaveBeenCalled();
       expect(deleteSpy).not.toHaveBeenCalled();
+    });
+
+    it('should still show the friendly self-delete notification if the authenticated user id resolves late and the backend rejection carries no usable message', () => {
+      // Simulates the authenticated-user subscription resolving after the modal was confirmed
+      // (so the pre-flight self-delete check was bypassed) combined with a backend response
+      // whose error message can't be pattern-matched (e.g. Spring Boot's default message
+      // suppression). The self-delete notification must still win over the generic failure one.
+      spyOn(component.epersonService, 'deleteEPerson').and.returnValue(defer(() => {
+        component.currentAuthenticatedUserId = eperson.id;
+        return createFailedRemoteDataObject$(undefined, 400);
+      }));
+
+      const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+      deleteButton.triggerEventHandler('click', null);
+
+      expect(notificationsService.error).toHaveBeenCalled();
+      let translatedKey: string;
+      notificationsService.error.calls.mostRecent().args[0].subscribe((value) => translatedKey = value);
+      expect(translatedKey).toBe('admin.access-control.epeople.notification.deleted.forbidden.self');
     });
   });
 

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -535,7 +535,7 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
       if (restResponse?.hasSucceeded) {
         this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.deleted.success', { name: this.dsoNameService.getName(eperson) }));
         void this.router.navigate([getEPersonsRoute()]);
-      } else if (this.deleteGuard.isSelfDeletionError(restResponse)) {
+      } else if (this.isCurrentUser(eperson) || this.deleteGuard.isSelfDeletionError(restResponse)) {
         this.deleteGuard.showSelfDeleteNotification();
       } else {
         this.notificationsService.error(this.translateService.get(this.labelPrefix + 'notification.deleted.failure', {


### PR DESCRIPTION
## Problem

When an admin's own-account delete request is rejected by the backend, the frontend was supposed to show a friendly "you cannot delete your own account" message. It sometimes didn't, and fell through to the generic, technical failure notification instead.

## Root cause

`EPersonDeleteGuardService.isSelfDeletionError()` detects the backend rejection by pattern-matching the response's error text against `"cannot delete yourself"`. That text is not reliably present:

- Spring Boot omits exception `message` fields from error response bodies by default (`server.error.include-message` defaults to `never`).
- `DSpaceBadRequestException` / `IllegalStateException` have no dedicated `@ExceptionHandler` that builds a structured JSON body with the message.

So a legitimate self-delete rejection can arrive with no usable message text, the pattern match silently fails, and the UI falls through to the generic "delete failed" notification instead of the friendly self-delete one.

## Fix

Add a deterministic client-side identity check (`isCurrentUser`) as an OR-fallback alongside the text match, in both delete entry points (EPeople registry list and the individual EPerson edit form). This doesn't depend on what the backend's error body contains — if we already know the target is the current user, we show the friendly message regardless.

## Test plan

- [x] `yarn run lint` — passes
- [x] circular dependency check — passes
- [x] `yarn run test:headless` — full suite (5465 tests) passes, including 2 new regression tests simulating a race where the auth-subscription resolves late and the backend rejection carries no matchable message
- [x] `yarn run build:prod` — succeeds
- [x] Verified against a live DSpace stack (Docker) that the backend's actual self-delete rejection format is reproduced by the new tests

Fixes dataquest-dev/dspace-customers#782


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delete error handling so self-delete attempts now consistently show the friendly “you can’t delete yourself” message, even when the backend response doesn’t include a usable error message.
  * Applied this behavior in both the registry and form flows.
* **Tests**
  * Added coverage for delayed user identity resolution to ensure the self-delete notification still appears instead of a generic failure message.
* **Documentation**
  * Clarified the guidance for detecting self-delete errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->