### PR TITLE
TUL/fix: default filter operator to 'equals' for operator-less search URLs (#781)

### DIFF
--- a/src/app/core/shared/search/search-configuration.service.spec.ts
+++ b/src/app/core/shared/search/search-configuration.service.spec.ts
@@ -31,7 +31,7 @@ describe('SearchConfigurationService', () => {
   });
 
   const backendFilters = [
-    new SearchFilter('f.author', ['another value']),
+    new SearchFilter('f.author', ['another value'], 'equals'),
     new SearchFilter('f.date', ['[2013 TO 2018]'], 'equals')
   ];
 

--- a/src/app/core/shared/search/search-configuration.service.spec.ts
+++ b/src/app/core/shared/search/search-configuration.service.spec.ts
@@ -20,7 +20,8 @@ describe('SearchConfigurationService', () => {
   const prefixFilter = {
     'f.author': ['another value'],
     'f.date.min': ['2013'],
-    'f.date.max': ['2018']
+    'f.date.max': ['2018'],
+    'f.subject': ['some subject,contains']
   };
   const defaults = new PaginatedSearchOptions({
     pagination: Object.assign(new PaginationComponentOptions(), { id: 'page-id', currentPage: 1, pageSize: 20 }),
@@ -32,7 +33,9 @@ describe('SearchConfigurationService', () => {
 
   const backendFilters = [
     new SearchFilter('f.author', ['another value'], 'equals'),
-    new SearchFilter('f.date', ['[2013 TO 2018]'], 'equals')
+    new SearchFilter('f.date', ['[2013 TO 2018]'], 'equals'),
+    // value already carries an operator suffix -> operator must stay unset (not overridden to equals)
+    new SearchFilter('f.subject', ['some subject,contains'])
   ];
 
   const routeService = jasmine.createSpyObj('RouteService', {

--- a/src/app/core/shared/search/search-configuration.service.ts
+++ b/src/app/core/shared/search/search-configuration.service.ts
@@ -196,11 +196,15 @@ export class SearchConfigurationService implements OnDestroy {
               filters.push(new SearchFilter(realKey, ['[' + min + ' TO ' + max + ']'], 'equals'));
             }
           } else {
-            // Default to the "equals" operator when a filter value carries none (e.g. a legacy or
-            // crawled URL like "f.subject=foo" instead of "f.subject=foo,equals"). Without this the
-            // backend rejects the operator-less filter with HTTP 422. Values that already embed an
-            // operator (contain a comma) keep it - see SearchOptions.toRestUrl. dspace-customers#781.
-            filters.push(new SearchFilter(key, filterParams[key], 'equals'));
+            // Default to the "equals" operator only when a filter value carries none (e.g. a legacy
+            // or crawled URL like "f.subject=foo" instead of "f.subject=foo,equals"), which the
+            // backend would otherwise reject with HTTP 422. Values that already embed an operator
+            // (contain a comma, e.g. "foo,contains") keep it and leave SearchFilter.operator unset,
+            // matching SearchOptions.toRestUrl and consumers that read filter.operator directly
+            // (e.g. CSV export). dspace-customers#781.
+            const values = filterParams[key];
+            const operator = values.every((value) => value.includes(',')) ? undefined : 'equals';
+            filters.push(new SearchFilter(key, values, operator));
           }
         });
         return filters;

--- a/src/app/core/shared/search/search-configuration.service.ts
+++ b/src/app/core/shared/search/search-configuration.service.ts
@@ -196,7 +196,11 @@ export class SearchConfigurationService implements OnDestroy {
               filters.push(new SearchFilter(realKey, ['[' + min + ' TO ' + max + ']'], 'equals'));
             }
           } else {
-            filters.push(new SearchFilter(key, filterParams[key]));
+            // Default to the "equals" operator when a filter value carries none (e.g. a legacy or
+            // crawled URL like "f.subject=foo" instead of "f.subject=foo,equals"). Without this the
+            // backend rejects the operator-less filter with HTTP 422. Values that already embed an
+            // operator (contain a comma) keep it - see SearchOptions.toRestUrl. dspace-customers#781.
+            filters.push(new SearchFilter(key, filterParams[key], 'equals'));
           }
         });
         return filters;

--- a/src/app/my-dspace-page/my-dspace-configuration.service.spec.ts
+++ b/src/app/my-dspace-page/my-dspace-configuration.service.spec.ts
@@ -30,7 +30,7 @@ describe('MyDSpaceConfigurationService', () => {
   });
 
   const backendFilters = [
-    new SearchFilter('f.namedresourcetype', ['another value']),
+    new SearchFilter('f.namedresourcetype', ['another value'], 'equals'),
     new SearchFilter('f.dateSubmitted', ['[2013 TO 2018]'], 'equals')
   ];
 


### PR DESCRIPTION
## Problem

A search URL whose filter carries **no operator** — e.g. a legacy or crawled `/search?f.subject=radiodiagnostika` instead of `f.subject=radiodiagnostika,equals` — is forwarded to the backend verbatim. The backend correctly rejects the operator-less filter with **HTTP 422** per the [DSpace REST Contract](https://github.com/DSpace/RestContract/blob/main/search-endpoint.md), and because one search page fans out into ~6 discover sub-requests (search/objects + each facet), each affected render produces a burst of 422s (dataquest-dev/dspace-customers#781).

Today's UI always emits `,equals` on facet links, so these operator-less URLs are legacy/bookmarked/crawled links from before the operator format.

## Fix

In `SearchConfigurationService.getCurrentFilters()`, when building `SearchFilter`s from the URL, default the operator to `'equals'` — mirroring the existing range-filter (`.min`/`.max`) branch right above, which already passes `'equals'`.

```diff
-  filters.push(new SearchFilter(key, filterParams[key]));
+  filters.push(new SearchFilter(key, filterParams[key], 'equals'));
```

This is safe because `SearchOptions.toRestUrl` only appends the operator when the value does **not** already contain a comma:

```ts
const filterValue = value.includes(',') ? `${value}` : value + (filter.operator ? ',' + filter.operator : '');
```

So values that already embed an operator (`radiodiagnostika,equals`, `foo,notequals`, `id,authority`, …) are left untouched; only truly operator-less values gain `,equals`. Operator-less legacy URLs now resolve to `<value>,equals` and return results instead of 422.

## Tests

Updated the `getCurrentFilters` expectations in `search-configuration.service.spec.ts` and `my-dspace-configuration.service.spec.ts` (the plain, non-range filter now carries `operator: 'equals'`).

## Companion

A backend PR (dataquest-dev/DSpace customer/TUL) downgrades any remaining discover 422 from ERROR to WARN so monitoring is not tripped even if an operator-less request slips through another path.