### PR TITLE
JCU/Update dev machine url

### DIFF
--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: test
         working-directory: dspace-ui-tests/scripts
         env:
-          HOME_URL: https://dev-6.pc:8593/
+          HOME_URL: http://dev-6.pc:8593/
           NAME: JCU
         run: |
           ./test.sh


### PR DESCRIPTION
## Problem description
Failing playwright tests due to incorrect url to testing instance

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot