### PR TITLE
Enable triggering playwright for jcu

### DIFF
--- a/.github/workflows/trigger-ui-tests.yml
+++ b/.github/workflows/trigger-ui-tests.yml
@@ -24,7 +24,7 @@ jobs:
 
           git fetch --prune origin
           BRANCHES=$(git ls-remote --heads origin | awk -F'/' '{print $3"/"$4}' | grep '^customer/')
-          SKIP_BRANCHES=("customer/jcu" "customer/uk" "customer/mendelu-v7" "customer/palo-docker" "customer/palo-docker-rebase" "customer/palo-docker-typo-fix")
+          SKIP_BRANCHES=("customer/uk" "customer/mendelu-v7" "customer/palo-docker" "customer/palo-docker-rebase" "customer/palo-docker-typo-fix")
           
           for branch in $(echo "$BRANCHES" | sed -e 's/[\[\]"]//g' -e 's/,/\n/g'); do
             if [[ " ${SKIP_BRANCHES[@]} " =~ " ${branch} " ]]; then


### PR DESCRIPTION
## Problem description

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated UI test trigger rules to skip additional customer branches, reducing unnecessary test runs for those branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->