### PR TITLE
Fix self-delete tooltip clipped in EPeople table

### DIFF
--- a/src/app/access-control/epeople-registry/epeople-registry.component.html
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.html
@@ -78,7 +78,7 @@
                   </button>
                   <ng-container *ngIf="epersonDto.ableToDelete && currentAuthenticatedUserId">
                     <ng-container *ngIf="isCurrentUser(epersonDto.eperson); else enabledDeleteButton">
-                      <span tabindex="0" [ngbTooltip]="selfDeleteWarningLabel | translate">
+                      <span tabindex="0" [ngbTooltip]="selfDeleteWarningLabel | translate" container="body">
                         <button [dsBtnDisabled]="true"
                                 tabindex="-1"
                                 [attr.aria-label]="selfDeleteWarningLabel | translate"

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.html
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.html
@@ -40,7 +40,8 @@
         <span *ngIf="(canDelete$ | async) && (activeEPerson$ | async) as activeEPerson">
           <span *ngIf="isCurrentUser(activeEPerson); else enabledDeleteButton"
                 tabindex="0"
-                [ngbTooltip]="selfDeleteWarningLabel | translate">
+                [ngbTooltip]="selfDeleteWarningLabel | translate"
+                container="body">
             <button class="btn btn-danger delete-button" [dsBtnDisabled]="true" tabindex="-1" type="button">
               <i class="fas fa-trash"></i> {{'admin.access-control.epeople.actions.delete' | translate}}
             </button>


### PR DESCRIPTION
## Problem

When hovering the disabled delete button on your own row in the EPeople registry, the tooltip explaining why it's disabled ("You cannot delete your own EPerson account.") is visually clipped — only part of the text is visible.

## Root cause

The tooltip (`ngbTooltip`) is rendered inside the table's `.table-responsive` wrapper, which has `overflow-x: auto` (Bootstrap default). Since the delete button sits near the table's right edge, the tooltip popover extends past the wrapper's bounds and gets clipped by that overflow.

## Fix

Add `container="body"` to the `ngbTooltip` directive on both delete entry points (EPeople registry list and the individual EPerson edit form), so the tooltip is appended to `<body>` instead of the clipped ancestor. This is the same convention already used elsewhere in this codebase for the same reason (e.g. `health-status`, `orcid-queue` components).

## Test plan

- [x] `yarn run lint` — passes
- [x] circular dependency check — passes
- [x] `yarn run test:headless` — full suite (5465 tests) passes
- [x] `yarn run build:prod` — succeeds
- [x] Verified visually against a live DSpace stack (Docker) that the full tooltip text is now visible

Fixes dataquest-dev/dspace-customers#800


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the disabled self-delete tooltip display so it renders correctly without being constrained by surrounding elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->