### PR TITLE
JCU/Fix untranslated number-picker label on Czech locale

### DIFF
--- a/src/app/shared/form/number-picker/number-picker.component.html
+++ b/src/app/shared/form/number-picker/number-picker.component.html
@@ -1,5 +1,5 @@
 <div class="d-flex flex-column align-items-center">
-  <label class="ml-n3" [for]="id">{{'form.number-picker.label.' + placeholder | translate }}</label>
+  <label class="ml-n3" [for]="id">{{ placeholder }}</label>
   <div class="d-flex flex-column align-items-stretch justify-content-around position-relative">
     <button id="increment-{{id}}"
             class="btn btn-link-focus btn-date ml-2"
@@ -26,7 +26,7 @@
         [readonly]="disabled"
         [disabled]="disabled"
         [ngClass]="{'is-invalid': invalid}"
-        title="{{'form.number-picker.label.' + placeholder | translate}}"
+        title="{{ placeholder }}"
         [attr.aria-labelledby]="id + ' increment-' + id + ' decrement-' + id"
     >
 

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -3162,16 +3162,16 @@
   "form.number-picker.increment": "Zvýšit {{field}}",
 
   // "form.number-picker.label.Year": "Year",
-  // TODO New key - Add a translation
-  "form.number-picker.label.Year": "Year",
+  // Keyed on the translated placeholder text (see form.date-picker.placeholder.year = "Rok"),
+  // not the English default, since number-picker.component.html looks the key up as
+  // 'form.number-picker.label.' + placeholder.
+  "form.number-picker.label.Rok": "Rok",
 
   // "form.number-picker.label.Month": "Month",
-  // TODO New key - Add a translation
-  "form.number-picker.label.Month": "Month",
+  "form.number-picker.label.Měsíc": "Měsíc",
 
   // "form.number-picker.label.Day": "Day",
-  // TODO New key - Add a translation
-  "form.number-picker.label.Day": "Day",
+  "form.number-picker.label.Den": "Den",
 
   // "form.repeatable.sort.tip": "Drop the item in the new position",
   "form.repeatable.sort.tip": "Přetáhněte záznam na novou pozici",

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -3162,9 +3162,6 @@
   "form.number-picker.increment": "Zvýšit {{field}}",
 
   // "form.number-picker.label.Year": "Year",
-  // Keyed on the translated placeholder text (see form.date-picker.placeholder.year = "Rok"),
-  // not the English default, since number-picker.component.html looks the key up as
-  // 'form.number-picker.label.' + placeholder.
   "form.number-picker.label.Rok": "Rok",
 
   // "form.number-picker.label.Month": "Month",

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -3161,15 +3161,6 @@
   // "form.number-picker.increment": "Increment {{field}}",
   "form.number-picker.increment": "Zvýšit {{field}}",
 
-  // "form.number-picker.label.Year": "Year",
-  "form.number-picker.label.Rok": "Rok",
-
-  // "form.number-picker.label.Month": "Month",
-  "form.number-picker.label.Měsíc": "Měsíc",
-
-  // "form.number-picker.label.Day": "Day",
-  "form.number-picker.label.Den": "Den",
-
   // "form.repeatable.sort.tip": "Drop the item in the new position",
   "form.repeatable.sort.tip": "Přetáhněte záznam na novou pozici",
 
@@ -10960,6 +10951,5 @@
   // "item.preview.organization.alternateName": "Alternative name",
   // TODO New key - Add a translation
   "item.preview.organization.alternateName": "Alternative name",
-
 
 }

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -2103,12 +2103,6 @@
 
   "form.number-picker.increment": "Increment {{field}}",
 
-  "form.number-picker.label.Year": "Year",
-
-  "form.number-picker.label.Month": "Month",
-
-  "form.number-picker.label.Day": "Day",
-
   "form.repeatable.sort.tip": "Drop the item in the new position",
 
   "grant-deny-request-copy.deny": "Deny access request",


### PR DESCRIPTION
## Pull request overview

This PR fixes an i18n issue where the number-picker label could render an unresolved translation key (notably in Czech) by removing the composite translation-key construction and instead displaying the already-translated placeholder text.

**Changes:**
- Render `NumberPickerComponent`’s visible label and input `title` directly from the `placeholder` input.
- Remove now-unused `form.number-picker.label.*` entries from `en.json5` and `cs.json5`.

### Reviewed changes

Copilot reviewed 3 out of 3 changed files in this pull request and generated 2 comments.

| File | Description |
| ---- | ----------- |
| `src/app/shared/form/number-picker/number-picker.component.html` | Stops composing `form.number-picker.label.<placeholder>` keys; uses `placeholder` directly for label/title. |
| `src/assets/i18n/en.json5` | Removes unused `form.number-picker.label.Year/Month/Day` keys. |
| `src/assets/i18n/cs.json5` | Removes unused `form.number-picker.label.Year/Month/Day` keys and cleans up file ending. |







---

💡 <a href="/dataquest-dev/dspace-angular/new/customer/jcu?filename=.github/instructions/*.instructions.md" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Add Copilot custom instructions</a> for smarter, more guided reviews. <a href="https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Learn how to get started</a>.