### PR TITLE
Fix broken/untranslated accessible names in admin sidebar, pagination, and bitstream format registry

### DIFF
--- a/src/app/admin/admin-registries/bitstream-formats/bitstream-formats.component.html
+++ b/src/app/admin/admin-registries/bitstream-formats/bitstream-formats.component.html
@@ -35,7 +35,6 @@
                           [checked]="(selectedBitstreamFormatIDs$ | async)?.includes(bitstreamFormat.id)"
                           (change)="selectBitStreamFormat(bitstreamFormat, $event)"
                           >
-                        <span class="sr-only">{{'admin.registries.bitstream-formats.select' | translate}}&#125;</span>
                       </label>
                     </td>
                     <td><a [routerLink]="['/admin/registries/bitstream-formats', bitstreamFormat.id, 'edit']">{{bitstreamFormat.id}}</a></td>

--- a/src/app/admin/admin-sidebar/admin-sidebar-section/admin-sidebar-section.component.ts
+++ b/src/app/admin/admin-sidebar/admin-sidebar-section/admin-sidebar-section.component.ts
@@ -71,12 +71,19 @@ export class AdminSidebarSectionComponent extends AbstractMenuSectionComponent i
   }
 
   adminMenuSectionId(section: MenuSection) {
-    const accessibilityHandle = section.accessibilityHandle ?? section.id;
-    return `admin-menu-section-${accessibilityHandle}`;
+    return `admin-menu-section-${this.getAccessibilityHandle(section)}`;
   }
 
   adminMenuSectionTitleAccessibilityHandle(section: MenuSection) {
-    const accessibilityHandle = section.accessibilityHandle ?? section.id;
-    return `admin-menu-section-${accessibilityHandle}-title`;
+    return `admin-menu-section-${this.getAccessibilityHandle(section)}-title`;
+  }
+
+  /**
+   * Returns the identifier to use when building translation keys and DOM ids for a menu section.
+   * Falls back to the (often auto-generated, non-translatable) section id when no explicit
+   * accessibilityHandle was provided by the section's menu provider.
+   */
+  getAccessibilityHandle(section: MenuSection): string {
+    return section.accessibilityHandle ?? section.id;
   }
 }

--- a/src/app/admin/admin-sidebar/expandable-admin-sidebar-section/expandable-admin-sidebar-section.component.html
+++ b/src/app/admin/admin-sidebar/expandable-admin-sidebar-section/expandable-admin-sidebar-section.component.html
@@ -10,7 +10,7 @@
       aria-haspopup="menu"
       [attr.aria-controls]="adminMenuSectionId(section)"
       [attr.aria-expanded]="isExpanded$ | async"
-      [attr.aria-label]="('menu.section.toggle.' + section.id) | translate"
+      [attr.aria-label]="('menu.section.toggle.' + getAccessibilityHandle(section)) | translate"
       [class.disabled]="section.model?.disabled"
       (click)="toggleSection($event)"
       (keyup.space)="toggleSection($event)"
@@ -36,7 +36,7 @@
         <div class="sidebar-fixed-element-wrapper"></div>
         <div class="sidebar-collapsible-element-outer-wrapper">
           <div class="sidebar-collapsible-element-inner-wrapper">
-            <div class="sidebar-sub-level-item-list" role="menu" [id]="adminMenuSectionId(section)" [attr.aria-label]="('menu.section.' + section.id) | translate">
+            <div class="sidebar-sub-level-item-list" role="menu" [id]="adminMenuSectionId(section)" [attr.aria-label]="('menu.section.' + getAccessibilityHandle(section)) | translate">
               @for (subSection of (subSections$ | async); track subSection) {
                 <div class="sidebar-item">
                   <ng-container

--- a/src/app/shared/menu/providers/access-control.menu.spec.ts
+++ b/src/app/shared/menu/providers/access-control.menu.spec.ts
@@ -20,6 +20,7 @@ import { AccessControlMenuProvider } from './access-control.menu';
 
 describe('AccessControlMenuProvider', () => {
   const expectedTopSection: PartialMenuSection = {
+    accessibilityHandle: 'access_control',
     visible: true,
     model: {
       type: MenuItemType.TEXT,

--- a/src/app/shared/menu/providers/access-control.menu.ts
+++ b/src/app/shared/menu/providers/access-control.menu.ts
@@ -38,6 +38,7 @@ export class AccessControlMenuProvider extends AbstractExpandableMenuProvider {
 
   public getTopSection(): Observable<PartialMenuSection> {
     return of({
+      accessibilityHandle: 'access_control',
       model: {
         type: MenuItemType.TEXT,
         text: 'menu.section.access_control',

--- a/src/app/shared/menu/providers/coar-notify.menu.spec.ts
+++ b/src/app/shared/menu/providers/coar-notify.menu.spec.ts
@@ -19,6 +19,7 @@ import { CoarNotifyMenuProvider } from './coar-notify.menu';
 
 describe('CoarNotifyMenuProvider', () => {
   const expectedTopSection: PartialMenuSection = {
+    accessibilityHandle: 'coar_notify',
     visible: true,
     model: {
       type: MenuItemType.TEXT,

--- a/src/app/shared/menu/providers/coar-notify.menu.ts
+++ b/src/app/shared/menu/providers/coar-notify.menu.ts
@@ -65,6 +65,7 @@ export class CoarNotifyMenuProvider extends AbstractExpandableMenuProvider {
     ]).pipe(
       map(([isCoarNotifyEnabled, isSiteAdmin]: [boolean, boolean]) => {
         return {
+          accessibilityHandle: 'coar_notify',
           visible: isSiteAdmin && isCoarNotifyEnabled,
           model: {
             type: MenuItemType.TEXT,

--- a/src/app/shared/menu/providers/create-report.menu.spec.ts
+++ b/src/app/shared/menu/providers/create-report.menu.spec.ts
@@ -24,6 +24,7 @@ import { CreateReportMenuProvider } from './create-report.menu';
 
 describe('CreateReportMenuProvider', () => {
   const expectedTopSection: PartialMenuSection = {
+    accessibilityHandle: 'reports',
     visible: true,
     model: {
       type: MenuItemType.TEXT,

--- a/src/app/shared/menu/providers/create-report.menu.ts
+++ b/src/app/shared/menu/providers/create-report.menu.ts
@@ -81,6 +81,7 @@ export class CreateReportMenuProvider extends AbstractExpandableMenuProvider {
     ]).pipe(
       map(([reportEnabled, isSiteAdmin]: [boolean, boolean]) => {
         return {
+          accessibilityHandle: 'reports',
           visible: isSiteAdmin && reportEnabled,
           model: {
             type: MenuItemType.TEXT,

--- a/src/app/shared/menu/providers/import.menu.spec.ts
+++ b/src/app/shared/menu/providers/import.menu.spec.ts
@@ -19,6 +19,7 @@ import { ImportMenuProvider } from './import.menu';
 
 describe('ImportMenuProvider', () => {
   const expectedTopSection: PartialMenuSection = {
+    accessibilityHandle: 'import',
     visible: true,
     model: {
       type: MenuItemType.TEXT,

--- a/src/app/shared/menu/providers/import.menu.ts
+++ b/src/app/shared/menu/providers/import.menu.ts
@@ -41,6 +41,7 @@ export class ImportMenuProvider extends AbstractExpandableMenuProvider {
   public getTopSection(): Observable<PartialMenuSection> {
     return of(
       {
+        accessibilityHandle: 'import',
         model: {
           type: MenuItemType.TEXT,
           text: 'menu.section.import',

--- a/src/app/shared/menu/providers/notifications.menu.spec.ts
+++ b/src/app/shared/menu/providers/notifications.menu.spec.ts
@@ -21,6 +21,7 @@ import { NotificationsMenuProvider } from './notifications.menu';
 
 describe('NotificationsMenuProvider', () => {
   const expectedTopSection: PartialMenuSection = {
+    accessibilityHandle: 'notifications',
     visible: true,
     model: {
       type: MenuItemType.TEXT,

--- a/src/app/shared/menu/providers/notifications.menu.ts
+++ b/src/app/shared/menu/providers/notifications.menu.ts
@@ -67,6 +67,7 @@ export class NotificationsMenuProvider extends AbstractExpandableMenuProvider {
     ]).pipe(
       map(([canSeeQa, isSiteAdmin]: [boolean, boolean]) => {
         return {
+          accessibilityHandle: 'notifications',
           visible: canSeeQa || isSiteAdmin,
           model: {
             type: MenuItemType.TEXT,

--- a/src/app/shared/menu/providers/registries.menu.spec.ts
+++ b/src/app/shared/menu/providers/registries.menu.spec.ts
@@ -20,6 +20,7 @@ import { RegistriesMenuProvider } from './registries.menu';
 describe('RegistriesMenuProvider', () => {
 
   const expectedTopSection: PartialMenuSection = {
+    accessibilityHandle: 'registries',
     visible: true,
     model: {
       type: MenuItemType.TEXT,

--- a/src/app/shared/menu/providers/registries.menu.ts
+++ b/src/app/shared/menu/providers/registries.menu.ts
@@ -38,6 +38,7 @@ export class RegistriesMenuProvider extends AbstractExpandableMenuProvider {
   public getTopSection(): Observable<PartialMenuSection> {
     return of(
       {
+        accessibilityHandle: 'registries',
         model: {
           type: MenuItemType.TEXT,
           text: 'menu.section.registries',

--- a/src/app/shared/pagination/pagination.component.html
+++ b/src/app/shared/pagination/pagination.component.html
@@ -55,7 +55,7 @@
       <div>
         @if (showPaginator) {
           <div class="pagination justify-content-center clearfix bottom">
-            <ngb-pagination [attr.aria-label]="('pagination-control.page-number-bar' | translate) + paginationOptions.id"
+            <ngb-pagination [attr.aria-label]="('pagination.page-number-bar' | translate) + paginationOptions.id"
               [boundaryLinks]="paginationOptions.boundaryLinks"
               [collectionSize]="collectionSize"
               [disabled]="paginationOptions.disabled"

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -5425,6 +5425,9 @@
   // "menu.section.toggle.access_control": "Toggle Access Control section",
   "menu.section.toggle.access_control": "Přepnout sekci Řízení přístupu",
 
+  // "menu.section.toggle.coar_notify": "Toggle COAR Notify section",
+  "menu.section.toggle.coar_notify": "Přepnout sekci COAR Notify",
+
   // "menu.section.toggle.reports": "Toggle Reports section",
   "menu.section.toggle.reports": "Přepnout sekci Zprávy",
 
@@ -5448,6 +5451,9 @@
 
   // "menu.section.toggle.new": "Toggle New section",
   "menu.section.toggle.new": "Přepnout sekci Nová",
+
+  // "menu.section.toggle.notifications": "Toggle Notifications section",
+  "menu.section.toggle.notifications": "Přepnout sekci Oznámení",
 
   // "menu.section.toggle.registries": "Toggle Registries section",
   "menu.section.toggle.registries": "Přepnout sekci Registry",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3599,6 +3599,8 @@
 
   "menu.section.toggle.access_control": "Toggle Access Control section",
 
+  "menu.section.toggle.coar_notify": "Toggle COAR Notify section",
+
   "menu.section.toggle.reports": "Toggle Reports section",
 
   "menu.section.toggle.control_panel": "Toggle Control Panel section",
@@ -3614,6 +3616,8 @@
   "menu.section.toggle.import": "Toggle Import section",
 
   "menu.section.toggle.new": "Toggle New section",
+
+  "menu.section.toggle.notifications": "Toggle Notifications section",
 
   "menu.section.toggle.registries": "Toggle Registries section",
 


### PR DESCRIPTION
## Summary

Found during accessibility-focused QA testing of the JCU (Jihočeská univerzita) instance (DSpace 9.3.0, dev-6.pc:8593). Three related bugs where UI elements announce a raw/broken i18n key instead of a real translated accessible name. Confirmed these bugs come from vanilla upstream `DSpace/dspace-angular` (still present on `main`), not from any JCU-specific customization — a separate PR with the same fix was also opened upstream: DSpace/dspace-angular#5953.

### 1. Admin sidebar expandable sections use raw `section.id` instead of `section.accessibilityHandle`
`ExpandableAdminSidebarSectionComponent`'s aria-label bindings built translation keys from `section.id` — often an auto-generated, non-human id like `admin-sidebar_0_0` — instead of the semantic `section.accessibilityHandle` (e.g. `'edit'`) that `AdminSidebarSectionComponent.adminMenuSectionId()` already falls back to correctly. Screen readers announced literal keys like `menu.section.toggle.admin-sidebar_0_0` for every top-level sidebar section.

Fix:
- Extracted the existing `section.accessibilityHandle ?? section.id` fallback into a shared `getAccessibilityHandle()` method, reused everywhere it was previously duplicated or bypassed.
- Added the missing `accessibilityHandle` to the 6 menu providers that didn't set one: Import, Notifications, Access Control, Registries, Reports, COAR Notify.
- Added the 2 missing translation keys this exposed: `menu.section.toggle.notifications` and `menu.section.toggle.coar_notify`.
- Updated the corresponding provider spec fixtures to include the new field (Jasmine `toEqual` is a strict structural match).

### 2. Pagination control aria-label references a nonexistent, typo'd i18n key
Used `'pagination-control.page-number-bar' | translate` (hyphen) which doesn't exist in `en.json5`, always rendering as the literal key + concatenated id. The correct key `pagination.page-number-bar` (period) already exists and is designed for exactly this concatenation. Fixed the typo.

### 3. Broken accessible name on bitstream format registry checkboxes
Removed a redundant `<span class="sr-only">` duplicating the checkbox's own `aria-label`, with a stray literal `}` appended, producing accessible name `"Select Select}"`.

## Test plan
- [x] Confirmed all 3 bug patterns are present verbatim on `customer/jcu` (this branch), matching what was observed live on the JCU instance
- [x] Confirmed `accessibilityHandle` is a pre-existing field on `MenuSection`, not new API
- [x] Confirmed all `accessibilityHandle` values match existing `menu.section.toggle.*` keys (or added the 2 missing ones)
- [x] Confirmed `pagination.page-number-bar` exists with a value designed for direct id concatenation
- [x] Confirmed the checkbox's `aria-label` binding is untouched after removing the redundant span
- [x] Updated existing provider spec fixtures that would otherwise fail due to the new field
- [x] Independently reviewed by 2 separate critic passes (code correctness + blast-radius/missed-cases) before opening
- [ ] Not run against a live build/e2e suite in this environment — please have CI confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)
