### PR TITLE
ci: build & push Docker images from dtq-dev-9-base

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,179 +1,60 @@
 # DSpace Docker image build for hub.docker.com
 name: Docker images
 
-# Run this Build for all pushes to 'main' or maintenance branches, or tagged releases.
-# Also run for PRs to ensure PR doesn't break Docker build process
-# NOTE: uses "reusable-docker-build.yml" in DSpace/DSpace to actually build each of the Docker images
-# https://github.com/DSpace/DSpace/blob/main/.github/workflows/reusable-docker-build.yml
-# 
+# Run this Build for all pushes to 'dtq-dev-9-base' (the CLARIN/DSpace 9 base branch).
+# Also run for PRs to ensure PR doesn't break Docker build process (PRs build, but do not push).
+# NOTE: uses "reusable-docker-build.yml" from the 'dtq-dev' branch of dataquest-dev/DSpace to actually
+# build each of the Docker images. That is the same reusable workflow which builds our 'dtq-dev' and
+# 'customer/*' images, and it pushes straight to hub.docker.com/u/dataquest.
+# https://github.com/dataquest-dev/DSpace/blob/dtq-dev/.github/workflows/reusable-docker-build.yml
 on:
   push:
     branches:
-      - main
-      - 'dspace-**'
-    tags:
-      - 'dspace-**'
+      - dtq-dev-9-base
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read  # to fetch code (actions/checkout)
-  packages: write # to write images to GitHub Container Registry (GHCR)
 
 jobs:
   #############################################################
-  # Build/Push the 'dspace/dspace-angular' image
+  # Build/Push the 'dataquest/dspace-angular' image ('-dev' tag)
   #############################################################
   dspace-angular:
-    # Ensure this job never runs on forked repos. It's only executed for 'dspace/dspace-angular'
+    # Ensure this job never runs on forked repos. It's only executed for 'dataquest-dev/dspace-angular'
     if: github.repository == 'dataquest-dev/dspace-angular'
-    # Use the reusable-docker-build.yml script from DSpace/DSpace repo to build our Docker image
-    uses: dataquest-dev/DSpace/.github/workflows/reusable-docker-build.yml@ufal/clarin-dspace-upgrade-v9
+    # Use the reusable-docker-build.yml script from dataquest-dev/DSpace repo to build our Docker image
+    uses: dataquest-dev/DSpace/.github/workflows/reusable-docker-build.yml@dtq-dev
     with:
       build_id: dspace-angular-dev
       image_name: dataquest/dspace-angular
       dockerfile_path: ./Dockerfile
+      # As this is a development image, its tags are all suffixed with "-dev". Otherwise, it uses the same
+      # tagging logic as the primary 'dataquest/dspace-angular' image below.
+      tags_flavor: suffix=-dev
+      run_python_version_script: true
+      python_version_script_dest: src/static-files/VERSION_D.html
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
   #############################################################
-  # Build/Push the 'dspace/dspace-angular' image ('-dist' tag)
+  # Build/Push the 'dataquest/dspace-angular' image.
+  # This is the production ("dist") build and, matching 'dtq-dev',
+  # it is the one published under the plain (un-suffixed) tag.
   #############################################################
   dspace-angular-dist:
-    # Ensure this job never runs on forked repos. It's only executed for 'dspace/dspace-angular'
+    # Ensure this job never runs on forked repos. It's only executed for 'dataquest-dev/dspace-angular'
     if: github.repository == 'dataquest-dev/dspace-angular'
-    # Use the reusable-docker-build.yml script from DSpace/DSpace repo to build our Docker image
-    uses: dataquest-dev/DSpace/.github/workflows/reusable-docker-build.yml@ufal/clarin-dspace-upgrade-v9
+    # Use the reusable-docker-build.yml script from dataquest-dev/DSpace repo to build our Docker image
+    uses: dataquest-dev/DSpace/.github/workflows/reusable-docker-build.yml@dtq-dev
     with:
-      build_id: dspace-angular-dist
+      build_id: dspace-angular
       image_name: dataquest/dspace-angular
       dockerfile_path: ./Dockerfile.dist
-      # As this is a "dist" image, its tags are all suffixed with "-dist". Otherwise, it uses the same
-      # tagging logic as the primary 'dspace/dspace-angular' image above.
-      tags_flavor: suffix=-dist
+      run_python_version_script: true
+      python_version_script_dest: src/static-files/VERSION_D.html
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-      # Enable redeploy of sandbox & demo if the branch for this image matches the deployment branch of
-      # these sites as specified in reusable-docker-build.xml
-      REDEPLOY_SANDBOX_URL:  ${{ secrets.REDEPLOY_SANDBOX_URL }}
-      REDEPLOY_DEMO_URL:  ${{ secrets.REDEPLOY_DEMO_URL }}
-
-  #################################################################################
-  # Test Deployment via Docker to ensure newly built images are working properly
-  #################################################################################
-  docker-deploy:
-    # Ensure this job never runs on forked repos. It's only executed for 'dspace/dspace-angular'
-    if: github.repository == 'dataquest-dev/dspace-angular' && github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-        # Must run after all major images are built
-    needs: [dspace-angular, dspace-angular-dist]
-    env:
-      # Override default dspace.server.url & REST 'host' because backend starts at http://127.0.0.1:8080
-      dspace__P__server__P__url: http://127.0.0.1:8080/server
-      DSPACE_REST_HOST: 127.0.0.1
-      # Override default dspace.ui.url to also use 127.0.0.1.
-      dspace__P__ui__P__url: http://127.0.0.1:4000
-      # Override default ui.baseUrl to also use 127.0.0.1. This must match 'dspace.ui.url' for SSR to be enabled.
-      DSPACE_UI_BASEURL: http://127.0.0.1:4000
-    steps:
-      # Checkout our codebase (to get access to Docker Compose scripts)
-      - name: Checkout codebase
-        uses: actions/checkout@v6
-      # Download Docker image artifacts (which were just built by reusable-docker-build.yml)
-      - name: Download Docker image artifacts
-        uses: actions/download-artifact@v8
-        with:
-          # Download all amd64 Docker images (TAR files) into the /tmp/docker directory
-          pattern: docker-image-*-linux-amd64
-          path: /tmp/docker
-          merge-multiple: true
-      # Load each of the images into Docker by calling "docker image load" for each.
-      # This ensures we are using the images just built & not any prior versions on DockerHub
-      - name: Load all downloaded Docker images
-        run: |
-          find /tmp/docker -type f -name "*.tar" -exec docker image load --input "{}" \;
-          docker image ls -a
-      # Start backend using our compose script in the codebase.
-      - name: Start backend in Docker
-        # MUST use docker.io as we don't have a copy of this backend image in our GitHub Action,
-        # and docker.io is the only public image. If we ever hit aggressive rate limits at DockerHub,
-        # we may need to consider making the 'ghcr.io' images public & switch this to 'ghcr.io'
-        env:
-          DOCKER_REGISTRY: docker.io
-        run: |
-          docker compose -f docker/docker-compose-rest.yml up -d
-          sleep 10
-          docker container ls
-      # Create a test admin account. Load test data from a simple set of AIPs as defined in cli.ingest.yml
-      # NOTE: Before creating test data, we wait for the backend to become responsive by requesting it every 10 sec.
-      # Timeout after 5 minutes. This is done to ensure the backend is fully initialized before we create test data.
-      - name: Load test data into Backend
-        run: |
-          timeout 5m wget --retry-connrefused -t 0 --waitretry=10 http://127.0.0.1:8080/server/api
-          docker compose -f docker/cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en
-          docker compose -f docker/cli.yml -f docker/cli.ingest.yml run --rm dspace-cli
-      # Verify backend started successfully.
-      # 1. Make sure root endpoint is responding (check for dspace.name defined in docker-compose.yml)
-      # 2. Also check /collections endpoint to ensure the test data loaded properly (check for a collection name in AIPs)
-      - name: Verify backend is responding properly
-        run: |
-          result=$(wget -O- -q http://127.0.0.1:8080/server/api)
-          echo "$result"
-          echo "$result" |  grep -oE "\"DSpace Started with Docker Compose\""
-          result=$(wget -O- -q http://127.0.0.1:8080/server/api/core/collections)
-          echo "$result"
-          echo "$result" |  grep -oE "\"Dog in Yard\""
-      # Start production frontend using our compose script in the codebase.
-      - name: Start production frontend in Docker
-        # Specify the GHCR copy of the production frontend, so that we use the newly built image
-        env:
-          DOCKER_REGISTRY: ghcr.io
-        run: |
-          docker compose -f docker/docker-compose-dist.yml up -d
-          sleep 10
-          docker container ls
-      # Verify production frontend started successfully.
-      # 1. Make sure /home path has "DSpace software" (this is in the footer of the page)
-      # 2. Also check /community-list page lists one of the test Communities in the loaded test data
-      - name: Verify production frontend is responding properly
-        run: |
-          result=$(wget -O- -q http://127.0.0.1:4000/home)
-          echo "$result"
-          echo "$result" |  grep -oE "\"DSpace software\""
-      - name: Error logs of production frontend (if error in startup)
-        if: ${{ failure() }}
-        run: |
-          docker compose -f docker/docker-compose-dist.yml logs
-      # Now shutdown the production frontend image and startup the development frontend image
-      - name: Shutdown production frontend
-        run: |
-          docker compose -f docker/docker-compose-dist.yml down
-          sleep 10
-          docker container ls
-      - name: Startup development frontend
-        # Specify the GHCR copy of the development frontend, so that we use the newly built image
-        env:
-          DOCKER_REGISTRY: ghcr.io
-        run: |
-          docker compose -f docker/docker-compose.yml up -d
-          sleep 10
-          docker container ls
-      # Verify development frontend started successfully.
-      # 1. First, keep requesting the frontend every 10 seconds to wait until its up. Timeout after 10 minutes.
-      # 2. Once it's responding, check to see if the word "DSpace" appears.
-      #    We cannot check for anything more specific because development mode doesn't have SSR.
-      - name: Verify development frontend is responding properly
-        run: |
-          timeout 10m wget --retry-connrefused -t 0 --waitretry=10 http://127.0.0.1:4000
-          result=$(wget -O- -q http://127.0.0.1:4000)
-          echo "$result"
-          echo "$result" |  grep -oE "DSpace"
-      - name: Error logs of development frontend (if error in startup)
-        if: ${{ failure() }}
-        run: |
-          docker compose -f docker/docker-compose.yml logs
-      # Shutdown our containers
-      - name: Shutdown running Docker containers
-        run: |
-          docker compose -f docker/docker-compose.yml -f docker/docker-compose-rest.yml down

--- a/scripts/sourceversion.py
+++ b/scripts/sourceversion.py
@@ -1,0 +1,38 @@
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+# when next editing this script, please introduce argparse.
+# do not forget, it is called in BE by .github\workflows\reusable-docker-build.yml
+# argparse must be introduced there.
+# that action also calls BE version of this script, which is different (BE: scripts/sourceversion.py).
+# It must also cooperate with argparse
+
+# the idea is, that this will be different on each branch, but could be possibly passed by argv/argparse
+RELEASE_TAG_BASE='none'
+
+def get_time_in_timezone(zone: str = "Europe/Bratislava"):
+    try:
+        from zoneinfo import ZoneInfo
+        my_tz = ZoneInfo(zone)
+    except Exception as e:
+        my_tz = timezone.utc
+    return datetime.now(my_tz)
+
+
+if __name__ == '__main__':
+    ts = get_time_in_timezone()
+    # we have html tags, since this script ends up creating VERSION_D.html
+    print(f"<h4>This info was generated on: <br> <strong> {ts.strftime('%Y-%m-%d %H:%M:%S %Z%z')} </strong> </h4>")
+
+    cmd = 'git log -1 --pretty=format:"<h4>Git hash: <br><strong> %H </strong> <br> Date of commit: <br> <strong> %ai </strong></h4>"'
+    subprocess.check_call(cmd, shell=True)
+
+    # when adding argparse, this should be a bit more obvious
+    link = sys.argv[1] + sys.argv[2]
+    print('<br> <h4>Build run: </h4> <a href="' + link + '"> ' + link + '</a> ')
+
+    link = "https://github.com/dataquest-dev/dspace-angular/releases/tag/" \
+        + RELEASE_TAG_BASE + "-" + datetime.now().strftime('%Y.%m.') + sys.argv[2]
+
+    print('<br> <br> <h4>Release link: </h4><a href="' + link + '"> ' + link + '</a> (if it does not work, then this is not an official release instance) ')


### PR DESCRIPTION
## Why

After the CLARIN-DSpace v9 merge, `dtq-dev-9-base` produces **no images** in hub.docker.com/u/dataquest, so there is nothing to deploy from it.

1. **The workflow never triggers.** The `docker.yml` on this branch is still vanilla DSpace's — it only fires on pushes to `main` / `dspace-**`.
2. **It points at a reusable workflow that cannot push.** `reusable-docker-build.yml@ufal/clarin-dspace-upgrade-v9` builds via `ghcr.io/${image_name}` → `ghcr.io/dataquest/*`. Our GitHub org is `dataquest-dev`; `dataquest` is an **unrelated GitHub user account**, so `GITHUB_TOKEN` cannot push there (`ghcr.io/dataquest/dspace` → HTTP 403).

   The green Docker runs on `ufal/clarin-dspace-upgrade-v9` are misleading: they are `pull_request` events, so `docker-build_manifest` and `docker-copy_to_dockerhub` were **skipped** (e.g. run 29243711968). The GHCR push and the DockerHub copy have never actually executed.

## What this does

Trigger on pushes to `dtq-dev-9-base` (plus PRs and `workflow_dispatch`), and pin the reusable workflow to `dataquest-dev/DSpace/.github/workflows/reusable-docker-build.yml@dtq-dev` — the same one that builds our `customer/*` frontend images today, which pushes straight to DockerHub.

### Tag flavours swapped to match dtq-dev — please look at this bit

On `dtq-dev` (and every `customer/*` branch) the **production/SSR** build (`Dockerfile.dist`) takes the **plain** tag, and the **dev** build (`Dockerfile`) is suffixed `-dev`. This branch had it inverted: the dev build took the plain tag and dist was suffixed `-dist`.

Left as-is, `dataquest/dspace-angular:dtq-dev-9-base` would have been a **non-SSR dev image** — it would pull and run, but it would be the wrong thing to deploy. Now it's the production image, consistent with `customer-lindat`, `dspace-7_x`, etc.

(There has never been a `-dist` tag in the `dataquest` namespace — every tag is either plain or `-dev` paired.)

### Other

- **Ported `scripts/sourceversion.py` from `dtq-dev`** — it doesn't exist on this branch — and enabled `run_python_version_script`, so `/VERSION_D.html` reports the built commit like it does on `dtq-dev`.
- **Dropped the vanilla `docker-deploy` job.** It consumes `docker-image-*-linux-amd64` artifacts the dtq-dev reusable never uploads, and it's gated on `workflow_dispatch`, which this PR now enables — so it would have started running and failing.
- Deliberately **not** adding dtq-dev's `deploy` job: that would redeploy the shared dev instance with v9 images.

## Resulting images (tag `dtq-dev-9-base`, linux/amd64)

| Image | Tags |
|---|---|
| `dataquest/dspace-angular` (prod/SSR, `Dockerfile.dist`) | `dtq-dev-9-base`, `<sha>` |
| `dataquest/dspace-angular` (dev, `Dockerfile`) | `dtq-dev-9-base-dev`, `<sha>-dev` |

`dspace-7_x` / `latest` are not at risk — those only emit when `github.ref_name == default_branch`, and the default branch is `dtq-dev`.

Backend counterpart: dataquest-dev/DSpace#1367

## Verification

Reviewed by a fan-out of adversarial agents across six lenses (Actions semantics, tag computation, Docker build chain, removal fallout, version script, secrets/push). Every `with:`/`secrets:` key was cross-checked against the `@dtq-dev` reusable's declared `workflow_call` signature; the ported script is byte-identical to dtq-dev's; `src/static-files/` exists and isn't excluded by `.dockerignore`; tag derivation confirmed against live DockerHub data. 6 candidate findings were raised and all 6 were refuted on precedent or evidence. No must-fix items.

Unlike the backend, the v9 frontend Docker build itself is already proven green (as a PR build) — only the push path was broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)