### PR TITLE
CLARIN-DSpace v9/Port #1372 remainder + #1309 Solr heap knob to the v9 base

### DIFF
--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -21,6 +21,7 @@ jobs:
         env:
           HOME_URL: http://dev-6.pc:8603/repository/
           NAME: LINDAT-9
+          PASSWORD_ADMIN: ${{ secrets.DSPACE_ADMIN_PASSWORD }}
         run: |
           ./test.sh
 

--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -92,6 +92,10 @@ services:
   dspacesolr:
     container_name: dspacesolr
     image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-solr:${DSPACE_VER:-dspace-9_x}"
+    # Solr JVM heap is tunable per deployment via SOLR_HEAP (default 4g);
+    # solr-foreground honors this env var, runuser (without -l) preserves it
+    environment:
+      SOLR_HEAP: "${SOLR_HEAP:-4g}"
     networks:
       - dspacenet
     ports:


### PR DESCRIPTION
## Tranža FE-1 (Vlna 1) — post-snapshot sync dtq-dev → dtq-dev-9-base

Per [CLARIN_V9_POST_SNAPSHOT_SYNC_PLAN.md](../blob/dtq-dev-9-base/CLARIN_V9_POST_SNAPSHOT_SYNC_PLAN.md) §4 Vlna 1 / FE-1.

### `d8c5d54598` (fork PR #1309) — SOLR_HEAP knob — ADAPT
Fork hunk edited the 7.6 compose entrypoint (`exec solr -p 8983 -f -m 4g`) which no longer exists on the vanilla 9_x entrypoint. Re-applied as an `environment:` entry `SOLR_HEAP: "${SOLR_HEAP:-4g}"` on `dspacesolr` (solr-foreground honors SOLR_HEAP; runuser without `-l` preserves env; quotes kept per the fork squash). Verified locally: `docker compose config` renders `4g` default and `2g` with `SOLR_HEAP=2g`; heap line is the only diff vs pre-change render.

### `af0c70f74e` (fork PR #1372) — Playwright config-copy removal — partially SUPERSEDED, remainder ported
**Target-branch drift note:** the newer v9-side commit `c22bfa0956` (#1386) already removed the broken 'Copy customer config' step (the functional core of #1372) and retargeted the pipeline to dev-6:8603 with `NAME: LINDAT-9` (profile exists in dspace-ui-tests). Those newer choices are kept — this PR does **not** clobber them with the fork's `NAME: DEFAULT`.
The only fork delta still missing was **`PASSWORD_ADMIN`**: `dspace-ui-tests/scripts/test.sh` forwards it into the test container, so it is added here from the existing `DSPACE_ADMIN_PASSWORD` repo secret (verified present via `gh secret list`).
AC deviation recorded: plan AC2 (byte-parity with fork head) is obsolete due to #1386–#1388 drift; disposition PORT → ADAPT/partially-superseded.

### AC status (acceptance doc §5, FE-1)
- `d8c5d54598` AC1–4 ✅ local; AC5–7 (runtime heap proof, 6 cores, deploy-path) → covered by the Vlna 1 dev-6 live check; AC8 lint = CI; AC9 CI-green pending this PR's checks.
- `af0c70f74e` AC1 partially (no copy step ✓, no lindat config ref ✓; NAME deliberately LINDAT-9), AC2 obsolete (drift), AC3 ✓, AC5 YAML ✓, AC6 secret ✓, AC7 lindat-9 profile ✓, AC8 → live check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)