### PR TITLE
UFAL/Configurable REST context-path for /repository namespace

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,8 +150,8 @@ jobs:
           echo "===== dspace version"
           docker exec dspace$INSTANCE /bin/bash -c "cd /dspace/bin && ./dspace version" 2>&1 | head -5 || echo "dspace version failed"
           echo "===== REST API on the instance"
-          curl -s -o /dev/null -w "  server/api -> HTTP %{http_code}\n" "http://localhost:${DSPACE_DOCKER_REST_PORT:-6603}/server/api" || true
-          curl -s "http://localhost:${DSPACE_DOCKER_REST_PORT:-6603}/server/api/core/items?size=1" 2>/dev/null | head -c 300 || true
+          curl -s -o /dev/null -w "  repository/server/api -> HTTP %{http_code}\n" "http://localhost:${DSPACE_DOCKER_REST_PORT:-6603}/repository/server/api" || true
+          curl -s "http://localhost:${DSPACE_DOCKER_REST_PORT:-6603}/repository/server/api/core/items?size=1" 2>/dev/null | head -c 300 || true
           echo ""
 
   deploy-8603:

--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -34,6 +34,10 @@ services:
       # dspace__P__dir: /dspace
       # dspace__P__server__P__url: http://localhost:8080/server
       # dspace__P__ui__P__url: http://localhost:4000
+      # server.servlet.context-path: base path the Spring Boot REST webapp is served under (default /server).
+      # Override per-instance via the .env passed to `docker compose --env-file`, e.g.
+      # server__P__servlet__P__context__D__path=/repository/server when running behind a namespaced proxy.
+      server__P__servlet__P__context__D__path: ${SERVER_SERVLET_CONTEXT_PATH:-/server}
       # Set SSR URL to the Docker container name so that UI can contact container directly in Production mode.
       # (This is necessary for docker-compose-dist.yml)
       dspace__P__server__P__ssr__P__url: ${dspace__P__server__P__ssr__P__url:-http://dspace:8080/server}

--- a/server.ts
+++ b/server.ts
@@ -164,7 +164,8 @@ export function app() {
    */
   router.use('/sitemap**', createProxyMiddleware({
     target: `${REST_BASE_URL}/sitemaps`,
-    pathRewrite: path => path.replace(environment.ui.nameSpace, '/'),
+    // strip the UI namespace prefix; collapse any leading double slash it may leave (e.g. nameSpace '/repository')
+    pathRewrite: path => path.replace(environment.ui.nameSpace, '/').replace(/^\/{2,}/, '/'),
     changeOrigin: true,
   }));
 
@@ -173,7 +174,8 @@ export function app() {
    */
   router.use('/signposting**', createProxyMiddleware({
     target: `${REST_BASE_URL}`,
-    pathRewrite: path => path.replace(environment.ui.nameSpace, '/'),
+    // strip the UI namespace prefix; collapse any leading double slash it may leave (e.g. nameSpace '/repository')
+    pathRewrite: path => path.replace(environment.ui.nameSpace, '/').replace(/^\/{2,}/, '/'),
     changeOrigin: true,
   }));
 

--- a/src/app/core/data/epic-handle-data.service.ts
+++ b/src/app/core/data/epic-handle-data.service.ts
@@ -202,17 +202,18 @@ export class EpicHandleDataService {
   findByPrefixAndSuffix(prefix: string, suffix: string): Observable<EpicHandle> {
     // we search for the handle using the prefix and suffix
     return this.halService.getEndpoint('epichandles').pipe(
-      map(baseUrl => `${baseUrl}/${prefix}/${suffix}`),
-      mergeMap(url => this.http.get<{id: string; url: string; _links?: any}>(url)),
-      map(response => {
-        const handle = new EpicHandle();
-        handle.id = response.id;
-        handle.url = response.url;
-        handle._links = response._links || {
-          self: { href: `/server/api/epichandles/${response.id}` },
-        };
-        return handle;
-      }),
+      mergeMap(baseUrl => this.http.get<{id: string; url: string; _links?: any}>(`${baseUrl}/${prefix}/${suffix}`).pipe(
+        map(response => {
+          const handle = new EpicHandle();
+          handle.id = response.id;
+          handle.url = response.url;
+          // Fall back to the resolved REST endpoint (namespace-aware) rather than a hardcoded /server path
+          handle._links = response._links || {
+            self: { href: `${baseUrl}/${response.id}` },
+          };
+          return handle;
+        }),
+      )),
       catchError((error: unknown) => {
         return throwError(() => error);
       }),


### PR DESCRIPTION
## References
* Follows #1387 and #1388, which added the `/repository` prefix to the Playwright `HOME_URL` and the `deploy.yml` dispatch URLs. Part of the CLARIN-DSpace v9 `/repository` namespace work for instance **8603** on dev-6.

## Description
Serve the Spring Boot backend under a **configurable context-path** so instance 8603 can run behind the `/repository/server` namespace without a Java change or image rebuild, plus the FE/CI follow-ups that path implies. **Config/FE-only** — no backend source changes.

## Instructions for Reviewers

List of changes in this PR:
* **`docker/docker-compose-rest.yml`** — add a parameterized `server.servlet.context-path` knob: `server__P__servlet__P__context__D__path: ${SERVER_SERVLET_CONTEXT_PATH:-/server}`. Default `/server` keeps local dev, CI and every other instance unchanged; a deployment sets the value per-instance via the `.env` passed to `docker compose --env-file`. DSpace registers this property source before the embedded Tomcat starts, so it overrides the built-in `/server` default with no code change.
* **`server.ts`** — guard the `/sitemap**` and `/signposting**` proxy `pathRewrite` against a leading double slash when `ui.nameSpace` is non-root (e.g. `/repository`). No-op for the default `nameSpace: /`.
* **`src/app/core/data/epic-handle-data.service.ts`** — build the fallback `self` link from the resolved REST endpoint (`getEndpoint('epichandles')`) instead of a hardcoded `/server/api` path, so it is namespace-aware.
* **`.github/workflows/deploy.yml`** — point the instance REST smoke probe at `/repository/server/api` (matches the dispatch URLs already changed in #1388).

**How to test:**
* Default is unchanged: `docker compose -f docker/docker-compose-rest.yml config` → `server__P__servlet__P__context__D__path: /server`.
* Override works: `SERVER_SERVLET_CONTEXT_PATH=/repository/server docker compose -f docker/docker-compose-rest.yml config` → `/repository/server`.
* On dev-6 (instance 8603): add `SERVER_SERVLET_CONTEXT_PATH=/repository/server` to `/opt/dspace-envs/8603/.env`, recreate the `dspace` service (`up -d --no-build --force-recreate dspace`), then on the box: `curl localhost:$PORT/repository/server/api` → **200**, `curl localhost:$PORT/server/api` → **404**, and the `DSPACE-XSRF-COOKIE` is set with `Path=/repository/server`.

**Out of scope (separate follow-ups):** removing the nginx `/repository/server → /server` path-rewrite on the dev-6 deployment, and patching the JWT external-login cookie `.path` hardcode (`/server/api/authn`) that affects Shibboleth/OIDC/ORCID/SAML logins. Password login is unaffected.

## Checklist
- [x] PR is created against **`dtq-dev-9-base`** (fork branch), not `main` — this is a deployment/namespace fix specific to the CLARIN v9 branch.
- [x] PR is **small** (~22 lines across 4 files).
- [ ] **ESLint** — could not run in the local workspace (`.eslintrc.json` references `@smarttools/eslint-plugin-rxjs`, which is not installed here). Changes are minimal and type-clean per the IDE TypeScript diagnostics; CI lint will validate.
- [x] **No circular dependencies** introduced (no import-graph changes).
- [x] **TypeDoc / comments** — no new public API; explanatory inline comments added to the compose knob and the `pathRewrite` guard.
- [ ] **Specs/tests** — no new tests; behavioural changes verified manually (compose `config` for default+override, and a runtime proof of the `pathRewrite` regex). The epic-handle fallback path is inert (no consumer reads `_links.self.href`).
- [x] **Accessibility** — no UI changes.
- [x] **i18n** — no user-facing text.
- [x] **How to test** — provided above.
- [x] **No new libraries/dependencies.**
- [x] **Technical documentation** — the new knob is documented inline in `docker-compose-rest.yml` and in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
