### PR TITLE
UFAL/Namespace-correct SSR proxy pathRewrite and epic-handle fallback link

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -181,7 +181,8 @@ export function app() {
    */
   router.use('/sitemap**', createProxyMiddleware({
     target: `${REST_BASE_URL}/sitemaps`,
-    pathRewrite: path => path.replace(environment.ui.nameSpace, '/'),
+    // strip the UI namespace prefix; collapse any leading double slash it may leave (e.g. nameSpace '/repository')
+    pathRewrite: path => path.replace(environment.ui.nameSpace, '/').replace(/^\/{2,}/, '/'),
     changeOrigin: true
   }));
 
@@ -190,7 +191,8 @@ export function app() {
    */
   router.use('/signposting**', createProxyMiddleware({
     target: `${REST_BASE_URL}`,
-    pathRewrite: path => path.replace(environment.ui.nameSpace, '/'),
+    // strip the UI namespace prefix; collapse any leading double slash it may leave (e.g. nameSpace '/repository')
+    pathRewrite: path => path.replace(environment.ui.nameSpace, '/').replace(/^\/{2,}/, '/'),
     changeOrigin: true
   }));
 

--- a/src/app/core/data/epic-handle-data.service.spec.ts
+++ b/src/app/core/data/epic-handle-data.service.spec.ts
@@ -109,4 +109,32 @@ describe('EpicHandleDataService',()=>{
         searchReq.flush(mockPaginationResponse);
       });
     });
+
+    describe('findByPrefixAndSuffix', () => {
+      it('builds a namespace-aware fallback self link when _links is missing', (done) => {
+        service.findByPrefixAndSuffix(mockPrefix, mockSuffix).subscribe(handle => {
+          expect(handle.id).toBe(mockHandleId);
+          expect(handle.url).toBe('http://example.com');
+          // fallback is derived from the resolved endpoint, not a hardcoded /server/api path
+          expect(handle._links.self.href).toBe(`${mockBaseUrl}/${mockHandleId}`);
+          done();
+        });
+
+        const req = httpMock.expectOne(`${mockBaseUrl}/${mockPrefix}/${mockSuffix}`);
+        expect(req.request.method).toBe('GET');
+        req.flush({ id: mockHandleId, url: 'http://example.com' });
+      });
+
+      it('keeps the _links returned by the backend when present', (done) => {
+        const links = { self: { href: `${mockBaseUrl}/${mockHandleId}` } };
+
+        service.findByPrefixAndSuffix(mockPrefix, mockSuffix).subscribe(handle => {
+          expect(handle._links).toEqual(links);
+          done();
+        });
+
+        httpMock.expectOne(`${mockBaseUrl}/${mockPrefix}/${mockSuffix}`)
+          .flush({ id: mockHandleId, url: 'http://example.com', _links: links });
+      });
+    });
 });

--- a/src/app/core/data/epic-handle-data.service.ts
+++ b/src/app/core/data/epic-handle-data.service.ts
@@ -187,17 +187,18 @@ export class EpicHandleDataService {
   findByPrefixAndSuffix(prefix: string, suffix: string): Observable<EpicHandle> {
     // we search for the handle using the prefix and suffix
     return this.halService.getEndpoint('epichandles').pipe(
-      map(baseUrl => `${baseUrl}/${prefix}/${suffix}`),
-      mergeMap(url => this.http.get<{id: string; url: string; _links?: any}>(url)),
-      map(response => {
-        const handle = new EpicHandle();
-        handle.id = response.id;
-        handle.url = response.url;
-        handle._links = response._links || {
-          self: { href: `/server/api/epichandles/${response.id}`}
-        };
-        return handle;
-      }),
+      mergeMap(baseUrl => this.http.get<{id: string; url: string; _links?: any}>(`${baseUrl}/${prefix}/${suffix}`).pipe(
+        map(response => {
+          const handle = new EpicHandle();
+          handle.id = response.id;
+          handle.url = response.url;
+          // Fall back to the resolved REST endpoint (namespace-aware) rather than a hardcoded /server path
+          handle._links = response._links || {
+            self: { href: `${baseUrl}/${response.id}` },
+          };
+          return handle;
+        }),
+      )),
       catchError(error => {
         return throwError(() => error);
       })


### PR DESCRIPTION
## References
* Frontend namespace-correctness fixes for deployments served under a non-root UI namespace (e.g. `/repository`, as used on dev-5). FE subset of the same fixes prepared for the v9 branch in dataquest-dev/dspace-angular#1391.

## Description
Two small SSR/service fixes so the app behaves correctly when the UI runs under a non-root namespace: a proxy `pathRewrite` double-slash guard, and a namespace-aware fallback link in the epic-handle service.

## Instructions for Reviewers

List of changes in this PR:
* **`server.ts`** — guard the `/sitemap**` and `/signposting**` proxy `pathRewrite` against a leading double slash left after stripping `ui.nameSpace` when it is non-root (e.g. `/repository`). No-op for the default `nameSpace: /`.
* **`src/app/core/data/epic-handle-data.service.ts`** — in `findByPrefixAndSuffix`, build the fallback `self` link from the resolved REST endpoint (`getEndpoint('epichandles')`) instead of a hardcoded `/server/api/...` path, so it is namespace-aware. Pure restructure of the existing pipe (`map`+`mergeMap` → `mergeMap(... .pipe(map()))`); behaviour is otherwise unchanged.

**How to test / reasoning:**
* `pathRewrite` guard: with `ui.nameSpace: /` (default) the transform is byte-identical to before; with `/repository`, an input like `/repository/sitemap_index.xml` no longer yields `//sitemap_index.xml`. The extra `.replace(/^\/{2,}/, '/')` only ever collapses an accidental leading double slash, which is never a valid proxied path — so it cannot regress the working default.
* epic-handle fallback: the `_links.self.href` fallback only applies when the REST response omits `_links`, and no consumer currently reads it (`handle.url` is used everywhere), so this is a correctness/consistency fix rather than a behavioural one; the built link now matches the absolute, namespaced form of the real backend `_links`.

## Checklist
- [x] PR is created against **`dtq-dev`** (fork branch), not `main`.
- [x] PR is **small** (~16 lines across 2 files).
- [ ] **ESLint** — could not run in the local workspace (`.eslintrc.json` references `@smarttools/eslint-plugin-rxjs`, which is not installed here); CI lint will validate. The epic-handle change is a standard higher-order `mergeMap(... .pipe(map()))`, not a nested subscribe.
- [x] **No circular dependencies** introduced (no import-graph changes).
- [x] **TypeDoc / comments** — no new public API; explanatory inline comment added to each change.
- [ ] **Specs/tests** — no new tests; changes verified by reasoning above (default path unchanged; fallback link is inert).
- [x] **Accessibility** — no UI changes.
- [x] **i18n** — no user-facing text.
- [x] **How to test** — provided above.
- [x] **No new libraries/dependencies.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy path rewriting for sitemap and signposting requests to prevent malformed URLs caused by duplicate leading slashes.
  * Fixed generated Epic Handle “self” links to be namespace-aware and based on the resolved service URL and returned handle id (while preserving backend-provided links when available).
* **Tests**
  * Added unit coverage for Epic Handle lookups, including link fallback and request URL formation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->