### PR TITLE
ZCU-DATA/Show a per-bitstream embargo-date badge in the CLARIN file listing

### DIFF
--- a/src/app/core/metadata/metadata-bitstream.model.ts
+++ b/src/app/core/metadata/metadata-bitstream.model.ts
@@ -81,6 +81,20 @@ export class MetadataBitstream extends ListableObject implements HALResource {
   canPreview: boolean;
 
   /**
+   * The access status of this bitstream (e.g. "open.access", "embargo", "restricted").
+   * Unlike the standard Bitstream HAL resource, this endpoint embeds the status directly
+   * rather than exposing it via a resolvable accessStatus link.
+   */
+  @autoserialize
+  status: string;
+
+  /**
+   * The date this bitstream's embargo lifts. Only set when status is "embargo".
+   */
+  @autoserialize
+  embargoDate: string;
+
+  /**
    * The {@link HALLink}s for this MetadataField
    */
   @deserialize

--- a/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.html
+++ b/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.html
@@ -9,6 +9,8 @@
       <dt>{{'item.file.description.name' | translate}}</dt>
       <dd title="ud-treebanks-v2.12.tgz">
         {{ fileInput.name }}
+        <span *ngIf="showAccessStatus && fileInput.embargoDate"
+              class="badge badge-secondary access-status-list-element-badge">{{ 'embargo.listelement.badge' | translate: { date: fileInput.embargoDate } }}</span>
       </dd>
       <dt>{{'item.file.description.size' | translate}}</dt>
       <dd>

--- a/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.html
+++ b/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.html
@@ -8,10 +8,13 @@
     <dl class="dl-horizontal">
       <dt>{{'item.file.description.name' | translate}}</dt>
       <dd title="ud-treebanks-v2.12.tgz">
-        <span *ngIf="showAccessStatus && fileInput.status === 'embargo' && fileInput.embargoDate" class="pr-1"><i class="fas fa-lock"></i></span>
-        {{ fileInput.name }}
-        <span *ngIf="showAccessStatus && fileInput.status === 'embargo' && fileInput.embargoDate"
-              class="badge badge-secondary ml-1 access-status-list-element-badge">{{ 'embargo.listelement.badge' | translate: { date: fileInput.embargoDate } }}</span>
+        <ng-container *ngIf="showAccessStatus && fileInput.status === 'embargo' && fileInput.embargoDate; else plainFileName">
+          <a (click)="downloadFile()" class="cursor-pointer">
+            <span class="pr-1"><i class="fas fa-lock"></i></span>{{ fileInput.name }}
+          </a>
+          <span class="badge badge-secondary ml-1 access-status-list-element-badge">{{ 'embargo.listelement.badge' | translate: { date: fileInput.embargoDate } }}</span>
+        </ng-container>
+        <ng-template #plainFileName>{{ fileInput.name }}</ng-template>
       </dd>
       <dt>{{'item.file.description.size' | translate}}</dt>
       <dd>

--- a/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.html
+++ b/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.html
@@ -8,6 +8,7 @@
     <dl class="dl-horizontal">
       <dt>{{'item.file.description.name' | translate}}</dt>
       <dd title="ud-treebanks-v2.12.tgz">
+        <span *ngIf="showAccessStatus && fileInput.status === 'embargo' && fileInput.embargoDate" class="pr-1"><i class="fas fa-lock"></i></span>
         {{ fileInput.name }}
         <span *ngIf="showAccessStatus && fileInput.status === 'embargo' && fileInput.embargoDate"
               class="badge badge-secondary ml-1 access-status-list-element-badge">{{ 'embargo.listelement.badge' | translate: { date: fileInput.embargoDate } }}</span>

--- a/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.html
+++ b/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.html
@@ -9,8 +9,8 @@
       <dt>{{'item.file.description.name' | translate}}</dt>
       <dd title="ud-treebanks-v2.12.tgz">
         {{ fileInput.name }}
-        <span *ngIf="showAccessStatus && fileInput.embargoDate"
-              class="badge badge-secondary access-status-list-element-badge">{{ 'embargo.listelement.badge' | translate: { date: fileInput.embargoDate } }}</span>
+        <span *ngIf="showAccessStatus && fileInput.status === 'embargo' && fileInput.embargoDate"
+              class="badge badge-secondary ml-1 access-status-list-element-badge">{{ 'embargo.listelement.badge' | translate: { date: fileInput.embargoDate } }}</span>
       </dd>
       <dt>{{'item.file.description.size' | translate}}</dt>
       <dd>

--- a/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.spec.ts
+++ b/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.spec.ts
@@ -12,6 +12,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HALEndpointService } from '../../../../../core/shared/hal-endpoint.service';
 import { FileSizePipe } from '../../../../../shared/utils/file-size-pipe';
+import { environment } from '../../../../../../environments/environment';
 
 describe('FileDescriptionComponent', () => {
   let component: FileDescriptionComponent;
@@ -47,11 +48,7 @@ describe('FileDescriptionComponent', () => {
     }).compileComponents();
   });
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(FileDescriptionComponent);
-    component = fixture.componentInstance;
-
-    // Mock the input value
+  function createFileInput(overrides: Partial<MetadataBitstream> = {}): MetadataBitstream {
     const fileInput = new MetadataBitstream();
     fileInput.id = 123;
     fileInput.name = 'testFile';
@@ -66,20 +63,65 @@ describe('FileDescriptionComponent', () => {
       self: { href: '' },
       schema: { href: '' },
     };
+    return Object.assign(fileInput, overrides);
+  }
 
-    component.fileInput = fileInput;
+  describe('by default', () => {
+    beforeEach(() => {
+      fixture = TestBed.createComponent(FileDescriptionComponent);
+      component = fixture.componentInstance;
+      component.fileInput = createFileInput();
+      fixture.detectChanges();
+    });
 
-    fixture.detectChanges();
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should display the file name', () => {
+      const fileNameElement = fixture.debugElement.query(
+        By.css('.file-content dd')
+      ).nativeElement;
+      expect(fileNameElement.textContent).toContain('testFile');
+    });
+
+    it('should not show the embargo badge', () => {
+      const badge = fixture.debugElement.query(By.css('span.badge'));
+      expect(badge).toBeNull();
+    });
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('when the bitstream is embargoed and the feature flag is on', () => {
+    beforeEach(() => {
+      environment.item.bitstream.showAccessStatuses = true;
+      fixture = TestBed.createComponent(FileDescriptionComponent);
+      component = fixture.componentInstance;
+      component.fileInput = createFileInput({ status: 'embargo', embargoDate: '2050-01-01' });
+      fixture.detectChanges();
+    });
+
+    afterEach(() => {
+      environment.item.bitstream.showAccessStatuses = false;
+    });
+
+    it('should show the embargo badge', () => {
+      const badge = fixture.debugElement.query(By.css('span.badge'));
+      expect(badge).not.toBeNull();
+      expect(badge.nativeElement.textContent).toContain('embargo.listelement.badge');
+    });
   });
 
-  it('should display the file name', () => {
-    const fileNameElement = fixture.debugElement.query(
-      By.css('.file-content dd')
-    ).nativeElement;
-    expect(fileNameElement.textContent).toContain('testFile');
+  describe('when the bitstream is embargoed but the feature flag is off', () => {
+    beforeEach(() => {
+      fixture = TestBed.createComponent(FileDescriptionComponent);
+      component = fixture.componentInstance;
+      component.fileInput = createFileInput({ status: 'embargo', embargoDate: '2050-01-01' });
+      fixture.detectChanges();
+    });
+
+    it('should not show the embargo badge', () => {
+      const badge = fixture.debugElement.query(By.css('span.badge'));
+      expect(badge).toBeNull();
+    });
   });
 });

--- a/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.spec.ts
+++ b/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.spec.ts
@@ -119,6 +119,12 @@ describe('FileDescriptionComponent', () => {
       const lockIcon = fixture.debugElement.query(By.css('.file-content dd i.fa-lock'));
       expect(lockIcon).not.toBeNull();
     });
+
+    it('should render the file name as a clickable link, matching the ZCU-PUB pattern', () => {
+      const link = fixture.debugElement.query(By.css('.file-content dd a'));
+      expect(link).not.toBeNull();
+      expect(link.nativeElement.textContent).toContain('testFile');
+    });
   });
 
   describe('when the bitstream is embargoed but the feature flag is off', () => {

--- a/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.spec.ts
+++ b/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.spec.ts
@@ -89,6 +89,11 @@ describe('FileDescriptionComponent', () => {
       const badge = fixture.debugElement.query(By.css('span.badge'));
       expect(badge).toBeNull();
     });
+
+    it('should not show the lock icon', () => {
+      const lockIcon = fixture.debugElement.query(By.css('.file-content dd i.fa-lock'));
+      expect(lockIcon).toBeNull();
+    });
   });
 
   describe('when the bitstream is embargoed and the feature flag is on', () => {
@@ -109,6 +114,11 @@ describe('FileDescriptionComponent', () => {
       expect(badge).not.toBeNull();
       expect(badge.nativeElement.textContent).toContain('embargo.listelement.badge');
     });
+
+    it('should show the lock icon next to the file name', () => {
+      const lockIcon = fixture.debugElement.query(By.css('.file-content dd i.fa-lock'));
+      expect(lockIcon).not.toBeNull();
+    });
   });
 
   describe('when the bitstream is embargoed but the feature flag is off', () => {
@@ -122,6 +132,11 @@ describe('FileDescriptionComponent', () => {
     it('should not show the embargo badge', () => {
       const badge = fixture.debugElement.query(By.css('span.badge'));
       expect(badge).toBeNull();
+    });
+
+    it('should not show the lock icon', () => {
+      const lockIcon = fixture.debugElement.query(By.css('.file-content dd i.fa-lock'));
+      expect(lockIcon).toBeNull();
     });
   });
 });

--- a/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.ts
+++ b/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.ts
@@ -18,7 +18,9 @@ export class FileDescriptionComponent {
    * Whether to show the embargo-date badge for a restricted bitstream. Same feature flag as
    * the standard file-download-link/AccessStatusBadgeComponent path on other customer instances.
    */
-  showAccessStatus = environment.item.bitstream.showAccessStatuses;
+  get showAccessStatus(): boolean {
+    return environment.item.bitstream.showAccessStatuses;
+  }
 
   @Input()
   fileInput: MetadataBitstream;

--- a/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.ts
+++ b/src/app/item-page/simple/field-components/preview-section/file-description/file-description.component.ts
@@ -2,6 +2,7 @@ import { Component, Input } from '@angular/core';
 import { MetadataBitstream } from 'src/app/core/metadata/metadata-bitstream.model';
 import { HALEndpointService } from '../../../../../core/shared/hal-endpoint.service';
 import {Router} from '@angular/router';
+import { environment } from 'src/environments/environment';
 
 const allowedPreviewFormats = ['text/plain', 'text/html', 'application/zip'];
 @Component({
@@ -12,6 +13,12 @@ const allowedPreviewFormats = ['text/plain', 'text/html', 'application/zip'];
 export class FileDescriptionComponent {
   MIME_TYPE_IMAGES_PATH = '/assets/images/mime/';
   MIME_TYPE_DEFAULT_IMAGE_NAME = 'application-octet-stream.png';
+
+  /**
+   * Whether to show the embargo-date badge for a restricted bitstream. Same feature flag as
+   * the standard file-download-link/AccessStatusBadgeComponent path on other customer instances.
+   */
+  showAccessStatus = environment.item.bitstream.showAccessStatuses;
 
   @Input()
   fileInput: MetadataBitstream;

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -8397,4 +8397,6 @@
   // "item.page.cc.license.disclaimer": "Except where otherwised noted, this item's license is described as",
   // TODO New key - Add a translation
   "item.page.cc.license.disclaimer": "Except where otherwised noted, this item's license is described as",
+  // "embargo.listelement.badge": "Embargo until {{ date }}",
+  "embargo.listelement.badge": "Embargo do {{ date }}",
 }

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5930,4 +5930,6 @@
   "navbar.about.service-integrations": "Service integrations",
 
   "navbar.about.project-partnership": "Project partnerships",
+
+  "embargo.listelement.badge": "Embargo until {{ date }}",
 }

--- a/src/config/default-app-config.ts
+++ b/src/config/default-app-config.ts
@@ -285,7 +285,10 @@ export class DefaultAppConfig implements AppConfig {
       // Number of entries in the bitstream list in the item view page.
       // Rounded to the nearest size in the list of selectable sizes on the
       // settings menu.  See pageSizeOptions in 'pagination-component-options.model.ts'.
-      pageSize: 5
+      pageSize: 5,
+      // Show the bitstream embargo-date badge.
+      // Keep this false until the backend accessStatus support (DSpace#1380) is deployed.
+      showAccessStatuses: false
     }
   };
 

--- a/src/config/item-config.interface.ts
+++ b/src/config/item-config.interface.ts
@@ -12,5 +12,7 @@ export interface ItemConfig extends Config {
     // Rounded to the nearest size in the list of selectable sizes on the
     // settings menu.  See pageSizeOptions in 'pagination-component-options.model.ts'.
     pageSize: number;
+    // Show the bitstream embargo-date badge
+    showAccessStatuses: boolean;
   }
 }

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -254,7 +254,9 @@ export const environment: BuildConfig = {
       // Number of entries in the bitstream list in the item view page.
       // Rounded to the nearest size in the list of selectable sizes on the
       // settings menu.  See pageSizeOptions in 'pagination-component-options.model.ts'.
-      pageSize: 5
+      pageSize: 5,
+      // Show the bitstream embargo-date badge
+      showAccessStatuses: false
     }
   },
   collection: {


### PR DESCRIPTION
## Problem
The bitstream download in the ZCU-DATA Item View gives no indication when a restricted file's embargo lifts. Fixes dataquest-dev/dspace-customers#823 (ZCU-DATA frontend portion).

## Root cause / why this isn't a port of #1378
ZCU-DATA's Item View doesn't use the standard `file-download-link`/`AccessStatusBadgeComponent` path at all - the whole `ds-clarin-files-item-field` block is commented out in both `publication.component.html` and `untyped-item.component.html`. Instead, every item page unconditionally renders `<ds-clarin-files-section>` (wired directly into `simple/item-page.component.html`), which goes through a completely separate, CLARIN-specific component chain: `clarin-files-section` → `preview-section` → `file-description`, backed by its own REST endpoint (`metadatabitstreams/search/byHandle` → `MetadataBitstreamWrapperRest`) that returns a flat DTO per file rather than a HAL resource with resolvable links. This needed real new implementation, not a cherry-pick.

## Change set
- `MetadataBitstream` model gains `status`/`embargoDate` fields, matching what the backend companion PR (dataquest-dev/DSpace#1380) now embeds directly in the endpoint's response - no separate link-resolution step needed here, unlike the HAL-link approach on ZCU-PUB.
- `file-description.component.html` renders the same visual badge (`badge badge-secondary`, `embargo.listelement.badge` i18n key) already used on ZCU-PUB (#1378), next to the file name, for a consistent look across both customer instances.
- New `item.bitstream.showAccessStatuses` config flag, defaulting to `false` - same reasoning as #1378: flip it only once the backend PR is deployed.
- i18n copy matches ZCU-PUB/vanilla exactly: `"Embargo until {{ date }}"` (en) / `"Embargo do {{ date }}"` (cs).

## Backend dependency
Needs dataquest-dev/DSpace#1380 (which also fixes a real pre-existing bug found while testing this: the CLARIN file listing 500'd entirely for any item with an embargoed bitstream, anonymously, independent of this change - see that PR for details). With the flag at its default `false`, this frontend PR has no runtime effect either way.

## Test evidence
```
npx ng lint --quiet                       -> All files pass linting.
npx ng build --configuration production   -> build succeeded, no budget warnings
npx ng test (file-description.component.spec.ts)
                                           -> 5/5 SUCCESS
```
Covers: badge hidden by default (no embargo), badge shown when embargoed + flag on, badge hidden when embargoed but flag off (fail-safe default).

## Risk & rollback
Low risk: two new optional fields on an existing DTO, one new conditional badge in one template, feature-flagged off by default. Revert is a straight `git revert`.

## Notes / assumptions
- Companion backend PR: dataquest-dev/DSpace#1380.
- Companion PRs for ZCU-PUB (same feature, different implementation path): dataquest-dev/dspace-angular#1378 (badge) + #1390 (accessibility fix, unrelated but adjacent).
