### PR TITLE
Clarin9/Restore DiscoJuice auto-popup on login page (#834)

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -100,8 +100,13 @@ Cypress.Commands.add('login', login);
  * @param password password to login as
  */
 function loginViaForm(email: string, password: string): void {
+  // The CLARIN/LINDAT DiscoJuice federated-login popup auto-opens on /login and covers the local
+  // password form, so close it first (if present) before filling in the local-account credentials.
+  cy.wait(500);
+  cy.get('.discojuice_close').should('exist').click();
+
   // Enter email
-  cy.get('[data-test="email"]').type(email);
+  cy.get('[data-test="email"]').should('be.visible').type(email);
   // Enter password
   cy.get('[data-test="password"]').type(password);
   // Click login button

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -108,7 +108,7 @@ function loginViaForm(email: string, password: string): void {
   // Enter email
   cy.get('[data-test="email"]').should('be.visible').type(email);
   // Enter password
-  cy.get('[data-test="password"]').type(password);
+  cy.get('[data-test="password"]').should('be.visible').type(password);
   // Click login button
   cy.get('[data-test="login-button"]').click();
 }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -101,9 +101,9 @@ Cypress.Commands.add('login', login);
  */
 function loginViaForm(email: string, password: string): void {
   // The CLARIN/LINDAT DiscoJuice federated-login popup auto-opens on /login and covers the local
-  // password form, so close it first (if present) before filling in the local-account credentials.
-  cy.wait(500);
-  cy.get('.discojuice_close').should('exist').click();
+  // password form. It opens only once the AAI scripts have loaded and DiscoJuice has bound, so wait
+  // until it is actually visible, then close it before filling in the local-account credentials.
+  cy.get('.discojuice_close', { timeout: 20000 }).should('be.visible').click();
 
   // Enter email
   cy.get('[data-test="email"]').should('be.visible').type(email);

--- a/src/app/shared/log-in/container/log-in-container.component.spec.ts
+++ b/src/app/shared/log-in/container/log-in-container.component.spec.ts
@@ -21,7 +21,9 @@ import { AuthService } from '../../../core/auth/auth.service';
 import { AuthMethod } from '../../../core/auth/models/auth.method';
 import { AuthMethodType } from '../../../core/auth/models/auth.method-type';
 import { AuthorizationDataService } from '../../../core/data/feature-authorization/authorization-data.service';
+import { CookieService } from '../../../core/services/cookie.service';
 import { HardRedirectService } from '../../../core/services/hard-redirect.service';
+import { CookieServiceMock } from '../../mocks/cookie.service.mock';
 import { AuthServiceStub } from '../../testing/auth-service.stub';
 import { AuthorizationDataServiceStub } from '../../testing/authorization-service.stub';
 import { createTestComponent } from '../../testing/utils.test';
@@ -55,6 +57,7 @@ describe('LogInContainerComponent', () => {
         { provide: AuthService, useClass: AuthServiceStub },
         { provide: AuthorizationDataService, useClass: AuthorizationDataServiceStub },
         { provide: HardRedirectService, useValue: hardRedirectService },
+        { provide: CookieService, useValue: new CookieServiceMock() },
         LogInContainerComponent,
       ],
       schemas: [

--- a/src/app/shared/log-in/log-in.component.spec.ts
+++ b/src/app/shared/log-in/log-in.component.spec.ts
@@ -23,8 +23,10 @@ import { of } from 'rxjs';
 import { authReducer } from '../../core/auth/auth.reducer';
 import { AuthService } from '../../core/auth/auth.service';
 import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
+import { CookieService } from '../../core/services/cookie.service';
 import { HardRedirectService } from '../../core/services/hard-redirect.service';
 import { NativeWindowService } from '../../core/services/window.service';
+import { CookieServiceMock } from '../mocks/cookie.service.mock';
 import { NativeWindowMockFactory } from '../mocks/mock-native-window-ref';
 import { getMockThemeService } from '../mocks/theme-service.mock';
 import { ActivatedRouteStub } from '../testing/active-router.stub';
@@ -85,6 +87,7 @@ describe('LogInComponent', () => {
         { provide: ActivatedRoute, useValue: new ActivatedRouteStub() },
         { provide: HardRedirectService, useValue: hardRedirectService },
         { provide: AuthorizationDataService, useValue: authorizationService },
+        { provide: CookieService, useValue: new CookieServiceMock() },
         provideMockStore({ initialState }),
         { provide: ThemeService, useValue: getMockThemeService() },
         LogInComponent,

--- a/src/app/shared/log-in/methods/password/log-in-password.component.spec.ts
+++ b/src/app/shared/log-in/methods/password/log-in-password.component.spec.ts
@@ -32,7 +32,10 @@ import { ActivatedRouteStub } from '../../../testing/active-router.stub';
 import { AuthServiceStub } from '../../../testing/auth-service.stub';
 import { AuthorizationDataServiceStub } from '../../../testing/authorization-service.stub';
 import { ThemeService } from '../../../theme-support/theme.service';
-import { LogInPasswordComponent } from './log-in-password.component';
+import {
+  LogInPasswordComponent,
+  SHOW_DISCOJUICE_POPUP_CACHE_NAME,
+} from './log-in-password.component';
 
 describe('LogInPasswordComponent', () => {
 
@@ -122,6 +125,37 @@ describe('LogInPasswordComponent', () => {
 
     // verify Store.dispatch() is invoked
     expect(page.navigateSpy.calls.any()).toBe(true, 'Store.dispatch not invoked');
+  });
+
+  describe('DiscoJuice auto-popup (SHOW_DISCOJUICE_POPUP cookie)', () => {
+    let storage: any; // CookieServiceMock — typed as any so get() can return the stored boolean
+    let popUpSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      storage = TestBed.inject(CookieService) as unknown as CookieServiceMock;
+      // Spy so we assert the trigger *decision* without scheduling the real timer/DOM popup.
+      popUpSpy = spyOn(component as any, 'popUpDiscoJuiceLogin');
+    });
+
+    it('seeds the cookie to true on the first visit (cookie unset)', () => {
+      storage.remove(SHOW_DISCOJUICE_POPUP_CACHE_NAME);
+      (component as any).initializeDiscoJuiceCache();
+      expect(storage.get(SHOW_DISCOJUICE_POPUP_CACHE_NAME)).toBe(true);
+    });
+
+    it('opens the popup when the cookie is true and keeps it true for the next visit', () => {
+      storage.set(SHOW_DISCOJUICE_POPUP_CACHE_NAME, true);
+      (component as any).toggleDiscojuiceLogin();
+      expect(popUpSpy).toHaveBeenCalledTimes(1);
+      expect(storage.get(SHOW_DISCOJUICE_POPUP_CACHE_NAME)).toBe(true);
+    });
+
+    it('suppresses the popup once when the cookie is false (user chose local login), then resets it to true', () => {
+      storage.set(SHOW_DISCOJUICE_POPUP_CACHE_NAME, false);
+      (component as any).toggleDiscojuiceLogin();
+      expect(popUpSpy).not.toHaveBeenCalled();
+      expect(storage.get(SHOW_DISCOJUICE_POPUP_CACHE_NAME)).toBe(true);
+    });
   });
 
 });

--- a/src/app/shared/log-in/methods/password/log-in-password.component.spec.ts
+++ b/src/app/shared/log-in/methods/password/log-in-password.component.spec.ts
@@ -25,6 +25,7 @@ import { AuthMethod } from '../../../../core/auth/models/auth.method';
 import { AuthMethodType } from '../../../../core/auth/models/auth.method-type';
 import { AuthorizationDataService } from '../../../../core/data/feature-authorization/authorization-data.service';
 import { CookieService } from '../../../../core/services/cookie.service';
+import { HardRedirectService } from '../../../../core/services/hard-redirect.service';
 import { CookieServiceMock } from '../../../mocks/cookie.service.mock';
 import { getMockThemeService } from '../../../mocks/theme-service.mock';
 import { ActivatedRouteStub } from '../../../testing/active-router.stub';

--- a/src/app/shared/log-in/methods/password/log-in-password.component.spec.ts
+++ b/src/app/shared/log-in/methods/password/log-in-password.component.spec.ts
@@ -24,7 +24,8 @@ import { AuthService } from '../../../../core/auth/auth.service';
 import { AuthMethod } from '../../../../core/auth/models/auth.method';
 import { AuthMethodType } from '../../../../core/auth/models/auth.method-type';
 import { AuthorizationDataService } from '../../../../core/data/feature-authorization/authorization-data.service';
-import { HardRedirectService } from '../../../../core/services/hard-redirect.service';
+import { CookieService } from '../../../../core/services/cookie.service';
+import { CookieServiceMock } from '../../../mocks/cookie.service.mock';
 import { getMockThemeService } from '../../../mocks/theme-service.mock';
 import { ActivatedRouteStub } from '../../../testing/active-router.stub';
 import { AuthServiceStub } from '../../../testing/auth-service.stub';
@@ -75,6 +76,7 @@ describe('LogInPasswordComponent', () => {
         { provide: 'authMethodProvider', useValue: new AuthMethod(AuthMethodType.Password, 0) },
         { provide: 'isStandalonePage', useValue: true },
         { provide: HardRedirectService, useValue: hardRedirectService },
+        { provide: CookieService, useValue: new CookieServiceMock() },
         { provide: ActivatedRoute, useValue: new ActivatedRouteStub() },
         { provide: ThemeService, useValue: themeService },
         provideMockStore({ initialState }),

--- a/src/app/shared/log-in/methods/password/log-in-password.component.ts
+++ b/src/app/shared/log-in/methods/password/log-in-password.component.ts
@@ -58,12 +58,6 @@ import {
 } from '../../../empty.util';
 import { BrowserOnlyPipe } from '../../../utils/browser-only.pipe';
 
-/**
- * Cookie name that controls whether the CLARIN/LINDAT DiscoJuice federated-login popup is shown on
- * the login page. It is set to `false` from `aai.js` when the user chooses the `local` account
- * option inside the DiscoJuice box, so that landing back on /login shows the password form instead
- * of immediately re-opening the popup.
- */
 export const SHOW_DISCOJUICE_POPUP_CACHE_NAME = 'SHOW_DISCOJUICE_POPUP';
 
 /**
@@ -158,9 +152,6 @@ export class LogInPasswordComponent implements OnInit {
    * @method ngOnInit
    */
   public ngOnInit() {
-    // Auto-open the CLARIN/LINDAT DiscoJuice federated-login popup when the user lands on /login,
-    // unless they just chose local authentication (see SHOW_DISCOJUICE_POPUP_CACHE_NAME). This is
-    // browser-only: it clicks a DOM element and relies on a cookie set client-side by aai.js.
     if (isPlatformBrowser(this.platformId)) {
       this.initializeDiscoJuiceCache();
       this.toggleDiscojuiceLogin();
@@ -251,9 +242,8 @@ export class LogInPasswordComponent implements OnInit {
   }
 
   /**
-   * Show the DiscoJuice popup on every visit to the login page, except right after the user clicked
-   * the `local` button inside the DiscoJuice box (which sets the cookie to `false` from `aai.js`).
-   * The flag is then reset to `true` so the popup shows again on the next visit.
+   * Toggle Discojuice login. Show it every time except the case when the user click
+   * on the `local` button in the discojuice box.
    * @private
    */
   private toggleDiscojuiceLogin() {
@@ -264,13 +254,8 @@ export class LogInPasswordComponent implements OnInit {
   }
 
   /**
-   * Trigger the DiscoJuice popup by programmatically clicking the sign-on link that the AAI script
-   * binds DiscoJuice to (rendered in the CLARIN top navbar). The timeout defers the click until
-   * after Angular has finished rendering this component, otherwise DiscoJuice would not show up.
-   *
-   * A programmatic `click()` bypasses the sign-on link's `pointer-events: none` guard (that guard
-   * only blocks real pointer input), so the popup opens even while the link is still visually
-   * disabled for the mouse.
+   * Show DiscoJuice login modal using javascript functions. The timeout must be set because of angular component
+   * lifecycle. Discojuice won't be showed up without timeout.
    * @private
    */
   private popUpDiscoJuiceLogin() {
@@ -280,7 +265,8 @@ export class LogInPasswordComponent implements OnInit {
   }
 
   /**
-   * Initialise the DiscoJuice popup flag to `true` on first load so the popup is shown by default.
+   * Set SHOW_DISCOJUICE_POPUP_CACHE_NAME to true because the discojuice login must be popped up on init
+   * if it is loaded for the first time.
    * @private
    */
   private initializeDiscoJuiceCache() {

--- a/src/app/shared/log-in/methods/password/log-in-password.component.ts
+++ b/src/app/shared/log-in/methods/password/log-in-password.component.ts
@@ -262,24 +262,13 @@ export class LogInPasswordComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Trigger the DiscoJuice popup by programmatically clicking the sign-on link that the AAI script
-   * binds DiscoJuice to (rendered in the CLARIN top navbar).
-   *
-   * The AAI/DiscoJuice scripts are loaded asynchronously (and in parallel) by the navbar component,
-   * so on a cold load DiscoJuice may not have bound its click handler by the time this component
-   * initialises. Clicking too early is a silent no-op and the popup never opens. We therefore poll
-   * (bounded) until DiscoJuice has created its popup markup (`div.discojuice`, built when it binds
-   * to the sign-on link) and only then click, which reliably opens the popup regardless of how long
-   * the scripts take to load.
-   *
-   * The polling runs OUTSIDE the Angular zone so it never keeps the application unstable (which
-   * would stall SSR rendering and `fixture.whenStable()` in tests). A programmatic `click()` also
-   * bypasses the sign-on link's `pointer-events: none` guard (that guard only blocks real pointer
-   * input), so the popup opens even while the link is still visually disabled for the mouse.
+   * Show DiscoJuice login modal using javascript functions. The timeout must be set because of angular component
+   * lifecycle. Discojuice won't be showed up without timeout. Introducing a timer to check
+   * if the DiscoJuice login is loaded and then pop it up. The timer will be cleared on destroy.
    * @private
    */
   private popUpDiscoJuiceLogin() {
-    const maxAttempts = 40; // ~10s at 250ms intervals — well beyond a normal script load
+    const maxAttempts = 40; // ~10s at 250ms intervals
     let attempts = 0;
     this.zone.runOutsideAngular(() => {
       const tryOpen = () => {

--- a/src/app/shared/log-in/methods/password/log-in-password.component.ts
+++ b/src/app/shared/log-in/methods/password/log-in-password.component.ts
@@ -1,8 +1,12 @@
-import { AsyncPipe } from '@angular/common';
+import {
+  AsyncPipe,
+  isPlatformBrowser,
+} from '@angular/common';
 import {
   Component,
   Inject,
   OnInit,
+  PLATFORM_ID,
 } from '@angular/core';
 import {
   FormsModule,
@@ -44,11 +48,23 @@ import {
 import { CoreState } from '../../../../core/core-state.model';
 import { AuthorizationDataService } from '../../../../core/data/feature-authorization/authorization-data.service';
 import { FeatureID } from '../../../../core/data/feature-authorization/feature-id';
+import { CookieService } from '../../../../core/services/cookie.service';
 import { HardRedirectService } from '../../../../core/services/hard-redirect.service';
 import { fadeOut } from '../../../animations/fade';
 import { BtnDisabledDirective } from '../../../btn-disabled.directive';
-import { isNotEmpty } from '../../../empty.util';
+import {
+  isEmpty,
+  isNotEmpty,
+} from '../../../empty.util';
 import { BrowserOnlyPipe } from '../../../utils/browser-only.pipe';
+
+/**
+ * Cookie name that controls whether the CLARIN/LINDAT DiscoJuice federated-login popup is shown on
+ * the login page. It is set to `false` from `aai.js` when the user chooses the `local` account
+ * option inside the DiscoJuice box, so that landing back on /login shows the password form instead
+ * of immediately re-opening the popup.
+ */
+export const SHOW_DISCOJUICE_POPUP_CACHE_NAME = 'SHOW_DISCOJUICE_POPUP';
 
 /**
  * /users/sign-in
@@ -131,6 +147,8 @@ export class LogInPasswordComponent implements OnInit {
     private formBuilder: UntypedFormBuilder,
     protected store: Store<CoreState>,
     protected authorizationService: AuthorizationDataService,
+    @Inject(PLATFORM_ID) protected platformId: object,
+    protected storage: CookieService,
   ) {
     this.authMethod = injectedAuthMethodModel;
   }
@@ -140,6 +158,13 @@ export class LogInPasswordComponent implements OnInit {
    * @method ngOnInit
    */
   public ngOnInit() {
+    // Auto-open the CLARIN/LINDAT DiscoJuice federated-login popup when the user lands on /login,
+    // unless they just chose local authentication (see SHOW_DISCOJUICE_POPUP_CACHE_NAME). This is
+    // browser-only: it clicks a DOM element and relies on a cookie set client-side by aai.js.
+    if (isPlatformBrowser(this.platformId)) {
+      this.initializeDiscoJuiceCache();
+      this.toggleDiscojuiceLogin();
+    }
 
     // set formGroup
     this.form = this.formBuilder.group({
@@ -223,6 +248,45 @@ export class LogInPasswordComponent implements OnInit {
 
     // clear form
     this.form.reset();
+  }
+
+  /**
+   * Show the DiscoJuice popup on every visit to the login page, except right after the user clicked
+   * the `local` button inside the DiscoJuice box (which sets the cookie to `false` from `aai.js`).
+   * The flag is then reset to `true` so the popup shows again on the next visit.
+   * @private
+   */
+  private toggleDiscojuiceLogin() {
+    if (this.storage.get(SHOW_DISCOJUICE_POPUP_CACHE_NAME) === true) {
+      this.popUpDiscoJuiceLogin();
+    }
+    this.storage.set(SHOW_DISCOJUICE_POPUP_CACHE_NAME, true);
+  }
+
+  /**
+   * Trigger the DiscoJuice popup by programmatically clicking the sign-on link that the AAI script
+   * binds DiscoJuice to (rendered in the CLARIN top navbar). The timeout defers the click until
+   * after Angular has finished rendering this component, otherwise DiscoJuice would not show up.
+   *
+   * A programmatic `click()` bypasses the sign-on link's `pointer-events: none` guard (that guard
+   * only blocks real pointer input), so the popup opens even while the link is still visually
+   * disabled for the mouse.
+   * @private
+   */
+  private popUpDiscoJuiceLogin() {
+    setTimeout(() => {
+      document?.getElementById('clarin-signon-discojuice')?.click();
+    }, 250);
+  }
+
+  /**
+   * Initialise the DiscoJuice popup flag to `true` on first load so the popup is shown by default.
+   * @private
+   */
+  private initializeDiscoJuiceCache() {
+    if (isEmpty(this.storage.get(SHOW_DISCOJUICE_POPUP_CACHE_NAME))) {
+      this.storage.set(SHOW_DISCOJUICE_POPUP_CACHE_NAME, true);
+    }
   }
 
 }

--- a/src/app/shared/log-in/methods/password/log-in-password.component.ts
+++ b/src/app/shared/log-in/methods/password/log-in-password.component.ts
@@ -5,6 +5,8 @@ import {
 import {
   Component,
   Inject,
+  NgZone,
+  OnDestroy,
   OnInit,
   PLATFORM_ID,
 } from '@angular/core';
@@ -79,7 +81,12 @@ export const SHOW_DISCOJUICE_POPUP_CACHE_NAME = 'SHOW_DISCOJUICE_POPUP';
     TranslateModule,
   ],
 })
-export class LogInPasswordComponent implements OnInit {
+export class LogInPasswordComponent implements OnInit, OnDestroy {
+
+  /**
+   * Handle of the pending DiscoJuice popup-open timer so it can be cancelled on destroy.
+   */
+  private discoJuiceTimer: ReturnType<typeof setTimeout> = null;
 
   /**
    * The authentication method data.
@@ -143,6 +150,7 @@ export class LogInPasswordComponent implements OnInit {
     protected authorizationService: AuthorizationDataService,
     @Inject(PLATFORM_ID) protected platformId: object,
     protected storage: CookieService,
+    protected zone: NgZone,
   ) {
     this.authMethod = injectedAuthMethodModel;
   }
@@ -254,14 +262,46 @@ export class LogInPasswordComponent implements OnInit {
   }
 
   /**
-   * Show DiscoJuice login modal using javascript functions. The timeout must be set because of angular component
-   * lifecycle. Discojuice won't be showed up without timeout.
+   * Trigger the DiscoJuice popup by programmatically clicking the sign-on link that the AAI script
+   * binds DiscoJuice to (rendered in the CLARIN top navbar).
+   *
+   * The AAI/DiscoJuice scripts are loaded asynchronously (and in parallel) by the navbar component,
+   * so on a cold load DiscoJuice may not have bound its click handler by the time this component
+   * initialises. Clicking too early is a silent no-op and the popup never opens. We therefore poll
+   * (bounded) until DiscoJuice has created its popup markup (`div.discojuice`, built when it binds
+   * to the sign-on link) and only then click, which reliably opens the popup regardless of how long
+   * the scripts take to load.
+   *
+   * The polling runs OUTSIDE the Angular zone so it never keeps the application unstable (which
+   * would stall SSR rendering and `fixture.whenStable()` in tests). A programmatic `click()` also
+   * bypasses the sign-on link's `pointer-events: none` guard (that guard only blocks real pointer
+   * input), so the popup opens even while the link is still visually disabled for the mouse.
    * @private
    */
   private popUpDiscoJuiceLogin() {
-    setTimeout(() => {
-      document?.getElementById('clarin-signon-discojuice')?.click();
-    }, 250);
+    const maxAttempts = 40; // ~10s at 250ms intervals — well beyond a normal script load
+    let attempts = 0;
+    this.zone.runOutsideAngular(() => {
+      const tryOpen = () => {
+        const signOnLink = document?.getElementById('clarin-signon-discojuice');
+        // `div.discojuice` is created (hidden) when DiscoJuice binds to the sign-on link, so its
+        // presence means the click handler is wired and a click will actually open the popup.
+        if (signOnLink && document?.querySelector('div.discojuice')) {
+          signOnLink.click();
+          return;
+        }
+        if (++attempts < maxAttempts) {
+          this.discoJuiceTimer = setTimeout(tryOpen, 250);
+        }
+      };
+      this.discoJuiceTimer = setTimeout(tryOpen, 250);
+    });
+  }
+
+  ngOnDestroy(): void {
+    if (this.discoJuiceTimer) {
+      clearTimeout(this.discoJuiceTimer);
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem description
On the DSpace 9 branch (`dtq-dev-9-base`) the CLARIN/LINDAT **DiscoJuice** federated-login popup no longer appears when you open `/login` — it worked on DSpace 7 (`dtq-dev`).

Fixes dataquest-dev/dspace-customers#834

## Analysis
DiscoJuice is bound to the top-navbar sign-on link (`#clarin-signon-discojuice`) by the AAI scripts in both branches. What actually *auto-opens* the popup on `/login` lived in `LogInPasswordComponent`:

- a `SHOW_DISCOJUICE_POPUP` cookie (defaulted to `true`),
- `popUpDiscoJuiceLogin()` which programmatically clicks the sign-on link on `ngOnInit`,
- suppressed only when the user just chose *local* login (`aai.js` sets the cookie to `false`).

During the DSpace 9 upgrade (#1316) this component was re-based onto the upstream DSpace 9 version and **all of that logic was lost**, so nothing clicks the sign-on link and the popup never opens. The DiscoJuice scripts, CSS and assets themselves are fine — only the trigger was missing.

### Fix
Ported the DiscoJuice auto-popup logic back into `log-in-password.component.ts`:
- re-added `SHOW_DISCOJUICE_POPUP_CACHE_NAME`, `initializeDiscoJuiceCache()`, `toggleDiscojuiceLogin()`, `popUpDiscoJuiceLogin()`;
- injected `CookieService` + `PLATFORM_ID` and guarded the DOM/cookie work with `isPlatformBrowser` (SSR-safe — the newer Angular server renderer has no global `document`, unlike the clarin7 ngUniversal setup);
- updated the component spec to provide `CookieService`.

The cookie round-trips correctly with DSpace 9's `ClientCookieService` (it JSON-parses, so the `=== true` check works and the raw `false` written by `aai.js` reads back as `false`).

## Problems
No backend change is required for the popup to **appear**. Note: the IdP list *inside* the popup is fetched from the REST endpoint `…/server/api/discojuice/feeds` (`metadataFeed` in `aai_config.js`) — if the popup shows up empty on clarin9, that backend endpoint is where to check.

### Sync verification
No `en.json5` / `cs.json5` changes in this PR.

### Manual Testing (if applicable)
- [ ] Open `/login` on a clarin9 instance → DiscoJuice popup opens automatically
- [ ] Pick *Local authentication* in the popup → redirected to `/login` with the password form (popup suppressed via `SHOW_DISCOJUICE_POPUP=false`)
- [ ] Revisit `/login` → popup opens again

### Copilot review
- [x] Requested review from Copilot
