### PR TITLE
Fix untranslated subjectFirstValue facet keys

### DIFF
--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -8347,6 +8347,15 @@
   // "search.filters.filter.subject.label": "Search subject",
   "search.filters.filter.subject.label": "Hledat předmět",
 
+  // "search.filters.filter.subjectFirstValue.head": "Subject",
+  "search.filters.filter.subjectFirstValue.head": "Předmět",
+
+  // "search.filters.filter.subjectFirstValue.placeholder": "Subject",
+  "search.filters.filter.subjectFirstValue.placeholder": "Předmět",
+
+  // "search.filters.filter.subjectFirstValue.label": "Search subject",
+  "search.filters.filter.subjectFirstValue.label": "Hledat předmět",
+
   // "search.filters.filter.submitter.head": "Submitter",
   "search.filters.filter.submitter.head": "Odesílatel",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -4820,6 +4820,12 @@
 
   "search.filters.filter.subject.label": "Search subject",
 
+  "search.filters.filter.subjectFirstValue.head": "Subject",
+
+  "search.filters.filter.subjectFirstValue.placeholder": "Subject",
+
+  "search.filters.filter.subjectFirstValue.label": "Search subject",
+
   "search.filters.filter.submitter.head": "Submitter",
 
   "search.filters.filter.submitter.placeholder": "Submitter",


### PR DESCRIPTION
## Problem
On the search page with the `homepage` discovery configuration (e.g. `/repository/search?configuration=homepage&f.subjectFirstValue=People,equals`), the **subject** facet rendered untranslated i18n keys instead of labels — the facet header, input placeholder and search label showed the raw keys `search.filters.filter.subjectFirstValue.head` / `.placeholder` / `.label`.

The `subjectFirstValue` hierarchical facet had no translation keys at all, while the generic filter UI builds its labels from `search.filters.filter.<name>.head|placeholder|label`.

## Fix
Add the missing keys for `subjectFirstValue`, mirroring the existing `subject` facet strings:
- `en.json5` → "Subject" / "Subject" / "Search subject"
- `cs.json5` → "Předmět" / "Předmět" / "Hledat předmět"

## Sweep for other untranslated keys
As requested, I checked the dev machine (`dev-6.pc:8603`) for other untranslated keys:
- Enumerated the facets of **every** discovery configuration exposed by the REST API (default, homepage, site, workspace, workflow, administrativeView, supervision, publication, person, orgunit, project, funding) and verified each facet's `.head` key resolves. `subjectFirstValue` was the **only** facet missing its keys.
- Verified all statically-referenced i18n keys on the home page (`/repository/home`) exist in `en.json5`.

No other genuinely-missing keys were found.

Fixes dataquest-dev/dspace-customers#835

🤖 Generated with [Claude Code](https://claude.com/claude-code)