### PR TITLE
CLARIN-DSpace v9/Port #1339 + #1337 (ROR display surfaces + i18n labels) to the v9 base

### DIFF
--- a/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.html
+++ b/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.html
@@ -42,7 +42,7 @@
             }
             @if (type === 'search') {
               <span class="d-inline-flex pe-1">
-                <a [href]="getLinkToSearch(i)">{{mdValue.value | dsReplace: this.replaceCharacter}}</a>
+                <a [href]="getLinkToSearch(i)">{{mdValue.value | dsReplace: this.replaceCharacter}} @if (mdValue.authority && (fields?.includes('dc.publisher') || fields?.includes('creativework.publisher'))) {<img src="assets/images/ror-icon.svg" alt="ROR ID" height="16" class="ror-icon ms-1 align-middle">}</a>
                 @if (!last) {
                   <span [innerHTML]="separator"></span>
                 }

--- a/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.spec.ts
+++ b/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.spec.ts
@@ -1,0 +1,125 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import {
+  ComponentFixture,
+  TestBed,
+} from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
+
+import { DSONameService } from '../../../../core/breadcrumbs/dso-name.service';
+import { ConfigurationDataService } from '../../../../core/data/configuration-data.service';
+import { Item } from '../../../../core/shared/item.model';
+import { ClarinGenericItemFieldComponent } from './clarin-generic-item-field.component';
+
+describe('ClarinGenericItemFieldComponent', () => {
+  let component: ClarinGenericItemFieldComponent;
+  let fixture: ComponentFixture<ClarinGenericItemFieldComponent>;
+
+  const configurationServiceSpy = jasmine.createSpyObj('configurationService', {
+    findByPropertyName: of(true),
+  });
+  const dsoNameServiceSpy = jasmine.createSpyObj('dsoNameService', ['getName']);
+
+  /** Build an Item carrying a single metadata value (dc.publisher by default) with the given authority. */
+  function itemWith(authority: string | null, field = 'dc.publisher', value = 'ACME Press'): Item {
+    const item = new Item();
+    item.metadata = {
+      [field]: [
+        {
+          value,
+          authority,
+          confidence: authority ? 600 : -1,
+          place: 0,
+          language: null,
+          uuid: 'mock-uuid',
+          isVirtual: false,
+          virtualValue: null,
+        } as any,
+      ],
+    };
+    return item;
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        TranslateModule.forRoot(),
+        ClarinGenericItemFieldComponent,
+      ],
+      providers: [
+        { provide: ConfigurationDataService, useValue: configurationServiceSpy },
+        { provide: DSONameService, useValue: dsoNameServiceSpy },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ClarinGenericItemFieldComponent);
+    component = fixture.componentInstance;
+    // Avoid ngOnInit (detectChanges) for the isolation tests so we can exercise getLinkToSearch directly.
+    component.baseUrl = 'http://localhost:4000';
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('getLinkToSearch', () => {
+    it('uses the authority operator and key when the metadata value has an authority', () => {
+      component.item = itemWith('02mhbdp94');
+      component.fields = ['dc.publisher'];
+      expect(component.getLinkToSearch(0))
+        .toBe('http://localhost:4000/search?f.publisher=02mhbdp94,authority');
+    });
+
+    it('uses the equals operator and plain value when the metadata value has no authority', () => {
+      component.item = itemWith(null);
+      component.fields = ['dc.publisher'];
+      expect(component.getLinkToSearch(0))
+        .toBe('http://localhost:4000/search?f.publisher=ACME%20Press,equals');
+    });
+
+    it('uses the explicitly provided value (e.g. a split subject) with the equals operator', () => {
+      const item = new Item();
+      item.metadata = {
+        'dc.subject': [
+          { value: 'history;art', authority: null, confidence: -1, place: 0, language: null } as any,
+        ],
+      };
+      component.item = item;
+      component.fields = ['dc.subject'];
+      expect(component.getLinkToSearch(-1, 'history'))
+        .toBe('http://localhost:4000/search?f.subject=history,equals');
+    });
+
+    it('falls back to the bare search endpoint when the index is out of range', () => {
+      component.item = itemWith(null);
+      component.fields = ['dc.publisher'];
+      expect(component.getLinkToSearch(5)).toBe('http://localhost:4000/search');
+    });
+  });
+
+  describe('ROR icon rendering (guard scope)', () => {
+    it('renders the ROR icon for an authority-bearing dc.publisher search field', () => {
+      component.item = itemWith('02mhbdp94', 'dc.publisher');
+      component.fields = ['dc.publisher'];
+      component.type = 'search';
+      fixture.detectChanges();
+      const img = fixture.debugElement.query(By.css('img.ror-icon'));
+      expect(img).not.toBeNull();
+      expect(img.nativeElement.getAttribute('src')).toContain('ror-icon.svg');
+    });
+
+    it('does NOT render the ROR icon for an authority-bearing NON-publisher field (dc.subject)', () => {
+      component.item = itemWith('some-authority', 'dc.subject', 'History');
+      component.fields = ['dc.subject'];
+      component.type = 'search';
+      fixture.detectChanges();
+      const imgs = fixture.debugElement.queryAll(By.css('img'))
+        .filter((de) => (de.nativeElement.getAttribute('src') || '').includes('ror-icon.svg'));
+      expect(imgs.length).toBe(0);
+    });
+  });
+});

--- a/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.ts
+++ b/src/app/item-page/simple/field-components/clarin-generic-item-field/clarin-generic-item-field.component.ts
@@ -18,6 +18,7 @@ import { Item } from '../../../../core/shared/item.model';
 import { getFirstSucceededRemoteDataPayload } from '../../../../core/shared/operators';
 import { ClarinItemAuthorPreviewComponent } from '../../../../shared/clarin-item-author-preview/clarin-item-author-preview.component';
 import {
+  buildAuthoritySearchFilter,
   convertMetadataFieldIntoSearchType,
   getBaseUrl,
 } from '../../../../shared/clarin-shared-util';
@@ -172,38 +173,17 @@ export class ClarinGenericItemFieldComponent implements OnInit {
    * @param index
    */
   public getLinkToSearch(index, value = '') {
-    let metadataValue = 'Error: value is empty';
-    if (isEmpty(value)) {
-      // Get metadata value from the Item's metadata field
-      metadataValue = this.getMetadataValue(index);
-    } else {
-      // The metadata value is passed from the parameter.
-      metadataValue = value;
-    }
-
     const searchType = convertMetadataFieldIntoSearchType(this.fields);
-    return this.baseUrl + '/search?f.' + encodeURIComponent(searchType) + '=' +
-      encodeURIComponent(metadataValue) + ',equals';
-  }
 
-  /**
-   * If the metadata field has more than 1 value return the value based on the index.
-   * @param index of the metadata value
-   */
-  public getMetadataValue(index) {
-    let metadataValue = '';
-    if (index === 0) {
-      // Return first metadata value.
-      return this.item.firstMetadataValue(this.fields);
+    // If a value is explicitly provided (e.g. a single subject from a split list), search by that plain value.
+    // Otherwise resolve the full MetadataValue for this index so an authority (e.g. ROR) can be used.
+    const mdValue = !isEmpty(value) ? { value } : this.item.allMetadata(this.fields)?.[index];
+    if (!mdValue) {
+      // ultimate fallback (should not happen)
+      return this.baseUrl + '/search';
     }
-    // The metadata field has more metadata values - get the actual one
-    this.item.allMetadataValues(this.fields)?.forEach((metadataValueArray, arrayIndex) => {
-      if (index !== arrayIndex) {
-        return metadataValue;
-      }
-      metadataValue = metadataValueArray;
-    });
-    return metadataValue;
+
+    return this.baseUrl + '/search?' + buildAuthoritySearchFilter(searchType, mdValue);
   }
 
   /**

--- a/src/app/shared/clarin-item-box-view/clarin-item-box-view.component.html
+++ b/src/app/shared/clarin-item-box-view/clarin-item-box-view.component.html
@@ -22,7 +22,7 @@
                   <!-- truthiness check: a missing dc.publisher is undefined, and an empty <a>
                        has no accessible name (axe link-name) -->
                   <span>(@if (itemPublisher) {
-                    <span><a [href]="publisherRedirectLink">{{itemPublisher}}</a> / </span>
+                    <span><a [attr.href]="publisherRedirectLink">{{itemPublisher}} @if (hasPublisherRorAuthority) {<img src="assets/images/ror-icon.svg" alt="ROR ID" height="16" class="ror-icon ms-1 align-middle">}</a> / </span>
                   }{{itemDate}})</span>
                 </div>
               }

--- a/src/app/shared/clarin-item-box-view/clarin-item-box-view.component.spec.ts
+++ b/src/app/shared/clarin-item-box-view/clarin-item-box-view.component.spec.ts
@@ -1,0 +1,246 @@
+import {
+  ComponentFixture,
+  TestBed,
+  waitForAsync,
+} from '@angular/core/testing';
+import { DomSanitizer } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import { StoreModule } from '@ngrx/store';
+import { provideMockStore } from '@ngrx/store/testing';
+import {
+  TranslateLoader,
+  TranslateModule,
+} from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { DSONameService } from 'src/app/core/breadcrumbs/dso-name.service';
+import { BundleDataService } from 'src/app/core/data/bundle-data.service';
+import { ClarinLicenseDataService } from 'src/app/core/data/clarin/clarin-license-data.service';
+import { CollectionDataService } from 'src/app/core/data/collection-data.service';
+import { ConfigurationDataService } from 'src/app/core/data/configuration-data.service';
+
+import { Item } from '../../core/shared/item.model';
+import { ClarinDateService } from '../clarin-date.service';
+import { DSONameServiceMock } from '../mocks/dso-name.service.mock';
+import { TranslateLoaderMock } from '../mocks/translate-loader.mock';
+import { ClarinItemBoxViewComponent } from './clarin-item-box-view.component';
+
+describe('ClarinItemBoxViewComponent', () => {
+  let component: ClarinItemBoxViewComponent;
+  let fixture: ComponentFixture<ClarinItemBoxViewComponent>;
+  let sanitizerStub: DomSanitizer;
+
+  const initialState = {
+    core: { auth: { loading: false } },
+  };
+
+  const collectionDataServiceMock = jasmine.createSpyObj(
+    'CollectionDataService',
+    ['findByHref'],
+  );
+
+  const bundleDataServiceMock = jasmine.createSpyObj('BundleDataService', [
+    'findByItemAndName',
+  ]);
+
+  const configurationServiceMock = jasmine.createSpyObj(
+    'ConfigurationDataService',
+    ['findByPropertyName'],
+  );
+
+  const clarinLicenseServiceMock = jasmine.createSpyObj(
+    'ClarinLicenseDataService',
+    ['searchBy'],
+  );
+
+  const clarinDateServiceMock = jasmine.createSpyObj('ClarinDateService', [
+    'composeItemDate',
+  ]);
+
+  beforeEach(waitForAsync(() => {
+    configurationServiceMock.findByPropertyName.and.returnValue(of({ values: ['http://localhost:4000'] }));
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: TranslateLoader,
+            useClass: TranslateLoaderMock,
+          },
+        }),
+        StoreModule.forRoot(),
+        ClarinItemBoxViewComponent,
+      ],
+      providers: [
+        { provide: CollectionDataService, useValue: collectionDataServiceMock },
+        { provide: BundleDataService, useValue: bundleDataServiceMock },
+        {
+          provide: ConfigurationDataService,
+          useValue: configurationServiceMock,
+        },
+        {
+          provide: ClarinLicenseDataService,
+          useValue: clarinLicenseServiceMock,
+        },
+        { provide: ClarinDateService, useValue: clarinDateServiceMock },
+        { provide: DSONameService, useValue: new DSONameServiceMock() },
+        { provide: DomSanitizer, useValue: sanitizerStub },
+        provideMockStore({ initialState }),
+        provideRouter([]),
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ClarinItemBoxViewComponent);
+    component = fixture.componentInstance;
+    component.baseUrl = 'http://localhost:4000';
+    fixture.detectChanges();
+  });
+
+  it('Should create', () => {
+    expect(component).toBeDefined();
+  });
+
+  describe('formateIconsAltText', () => {
+    it('should format camelCase item type correctly', () => {
+      const result = component.formateIconsAltText('researchData');
+      expect(result).toBe('Research data icon');
+    });
+
+    it('should format kebab-case item type correctly', () => {
+      const result = component.formateIconsAltText('research-data');
+      expect(result).toBe('Research data icon');
+    });
+
+    it('should handle single word item type', () => {
+      const result = component.formateIconsAltText('article');
+      expect(result).toBe('Article icon');
+    });
+
+    it('should handle empty string', () => {
+      const result = component.formateIconsAltText('');
+      expect(result).toBe('icon');
+    });
+
+    it('should handle empty string', () => {
+      const result = component.formateIconsAltText('research_data');
+      expect(result).toBe('Research data icon');
+    });
+  });
+
+  it('should build publisher link with authority when authority exists', async () => {
+    const mockItem = new Item();
+    mockItem.metadata = {
+      'dc.publisher': [
+        {
+          value: 'Test Publisher',
+          authority: 'test123',
+          confidence: 600,
+          place: 0,
+          language: null,
+          uuid: 'mock-uuid-1',
+          isVirtual: false,
+          virtualValue: null,
+        } as any,
+      ],
+    };
+    component.object = mockItem;
+    component.isSearchResult = true;
+    spyOn(component, 'assignBaseUrl').and.returnValue(Promise.resolve());
+    spyOn(component as any, 'getItemCommunity').and.stub();
+    spyOn(component as any, 'getItemFilesSize').and.stub();
+    spyOn(component as any, 'loadItemLicense').and.stub();
+    await component.ngOnInit();
+    fixture.detectChanges();
+    expect(component.publisherRedirectLink).toContain('f.publisher=test123,authority');
+    expect(component.hasPublisherRorAuthority).toBeTrue();
+  });
+
+  it('should build publisher link with equals when no authority', async () => {
+    const mockItem = new Item();
+    mockItem.metadata = {
+      'dc.publisher': [
+        {
+          value: 'Test Publisher',
+          authority: null,
+          confidence: -1,
+          place: 0,
+          language: null,
+          uuid: 'mock-uuid-2',
+          isVirtual: false,
+          virtualValue: null,
+        } as any,
+      ],
+    };
+    component.object = mockItem;
+    component.isSearchResult = true;
+    spyOn(component, 'assignBaseUrl').and.returnValue(Promise.resolve());
+    spyOn(component as any, 'getItemCommunity').and.stub();
+    spyOn(component as any, 'getItemFilesSize').and.stub();
+    spyOn(component as any, 'loadItemLicense').and.stub();
+    await component.ngOnInit();
+    fixture.detectChanges();
+    expect(component.publisherRedirectLink).toContain('f.publisher=Test%20Publisher,equals');
+    expect(component.hasPublisherRorAuthority).toBeFalse();
+  });
+
+  it('should show ROR icon when hasPublisherRorAuthority is true', async () => {
+    const mockItem = new Item();
+    mockItem.metadata = {
+      'dc.publisher': [
+        {
+          value: 'Test Publisher',
+          authority: 'test123',
+          confidence: 600,
+          place: 0,
+          language: null,
+          uuid: 'mock-uuid-1',
+          isVirtual: false,
+          virtualValue: null,
+        } as any,
+      ],
+    };
+    component.object = mockItem;
+    component.isSearchResult = true;
+    spyOn(component, 'assignBaseUrl').and.returnValue(Promise.resolve());
+    spyOn(component as any, 'getItemCommunity').and.stub();
+    spyOn(component as any, 'getItemFilesSize').and.stub();
+    spyOn(component as any, 'loadItemLicense').and.stub();
+    await component.ngOnInit();
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement;
+    const icon = compiled.querySelector('img[src*="ror-icon.svg"]');
+    expect(icon).toBeTruthy();
+    expect(icon.src).toContain('ror-icon.svg');
+  });
+
+  it('should hide ROR icon when hasPublisherRorAuthority is false', async () => {
+    const mockItem = new Item();
+    mockItem.metadata = {
+      'dc.publisher': [
+        {
+          value: 'Test Publisher',
+          authority: null,
+          confidence: -1,
+          place: 0,
+          language: null,
+          uuid: 'mock-uuid-2',
+          isVirtual: false,
+          virtualValue: null,
+        } as any,
+      ],
+    };
+    component.object = mockItem;
+    component.isSearchResult = true;
+    spyOn(component, 'assignBaseUrl').and.returnValue(Promise.resolve());
+    spyOn(component as any, 'getItemCommunity').and.stub();
+    spyOn(component as any, 'getItemFilesSize').and.stub();
+    spyOn(component as any, 'loadItemLicense').and.stub();
+    await component.ngOnInit();
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement;
+    const icon = compiled.querySelector('img[src*="ror-icon.svg"]');
+    expect(icon).toBeFalsy();
+  });
+});

--- a/src/app/shared/clarin-item-box-view/clarin-item-box-view.component.ts
+++ b/src/app/shared/clarin-item-box-view/clarin-item-box-view.component.ts
@@ -42,6 +42,7 @@ import { getItemPageRoute } from '../../item-page/item-page-routing-paths';
 import { ClarinDateService } from '../clarin-date.service';
 import { ClarinItemAuthorPreviewComponent } from '../clarin-item-author-preview/clarin-item-author-preview.component';
 import {
+  buildAuthoritySearchFilter,
   getBaseUrl,
   secureImageData,
 } from '../clarin-shared-util';
@@ -136,6 +137,10 @@ export class ClarinItemBoxViewComponent implements OnInit {
    */
   publisherRedirectLink: string;
   /**
+   * Whether the publisher has an authority (e.g., ROR ID)
+   */
+  hasPublisherRorAuthority = false;
+  /**
    * Composed date of the Item.
    */
   itemDate: string;
@@ -178,12 +183,15 @@ export class ClarinItemBoxViewComponent implements OnInit {
     this.itemName = this.item?.firstMetadataValue('dc.title');
     this.itemUri = getItemPageRoute(this.item);
     this.itemDescription = this.item?.firstMetadataValue('dc.description');
-    this.itemPublisher = this.item?.firstMetadataValue('dc.publisher');
+    const publisherMd = this.item?.allMetadata(['dc.publisher', 'creativework.publisher'])?.[0];
+    this.hasPublisherRorAuthority = !!publisherMd?.authority;
+    this.itemPublisher = publisherMd?.value;
     this.itemDate = this.clarinDateService.composeItemDate(this.item);
 
     await this.assignBaseUrl();
-    this.publisherRedirectLink = this.getSearchEndpoint() + '?f.publisher=' + encodeURIComponent(this.itemPublisher)
-      + ',equals';
+    if (publisherMd) {
+      this.publisherRedirectLink = this.getSearchEndpoint() + '?' + buildAuthoritySearchFilter('publisher', publisherMd);
+    }
     this.getItemCommunity();
     this.loadItemLicense();
     this.getItemFilesSize();

--- a/src/app/shared/clarin-shared-util.spec.ts
+++ b/src/app/shared/clarin-shared-util.spec.ts
@@ -1,0 +1,42 @@
+import {
+  buildAuthoritySearchFilter,
+  convertMetadataFieldIntoSearchType,
+} from './clarin-shared-util';
+
+describe('clarin-shared-util', () => {
+  describe('buildAuthoritySearchFilter', () => {
+    it('uses the authority operator and key when an authority is present', () => {
+      expect(buildAuthoritySearchFilter('publisher', { value: 'ACME Press', authority: '02mhbdp94' }))
+        .toBe('f.publisher=02mhbdp94,authority');
+    });
+
+    it('uses the equals operator and value when no authority is present', () => {
+      expect(buildAuthoritySearchFilter('publisher', { value: 'ACME Press', authority: null }))
+        .toBe('f.publisher=ACME%20Press,equals');
+    });
+
+    it('treats an empty-string authority as absent', () => {
+      expect(buildAuthoritySearchFilter('author', { value: 'Doe, J', authority: '' }))
+        .toBe('f.author=Doe%2C%20J,equals');
+    });
+
+    it('url-encodes both the filter name and the value', () => {
+      expect(buildAuthoritySearchFilter('publisher', { value: 'A&B', authority: null }))
+        .toBe('f.publisher=A%26B,equals');
+    });
+  });
+
+  describe('convertMetadataFieldIntoSearchType', () => {
+    it('maps dc.publisher to the publisher filter', () => {
+      expect(convertMetadataFieldIntoSearchType(['dc.publisher'])).toBe('publisher');
+    });
+
+    it('maps creativework.publisher to the publisher filter', () => {
+      expect(convertMetadataFieldIntoSearchType(['creativework.publisher'])).toBe('publisher');
+    });
+
+    it('maps dc.type to the type filter', () => {
+      expect(convertMetadataFieldIntoSearchType(['dc.type'])).toBe('type');
+    });
+  });
+});

--- a/src/app/shared/clarin-shared-util.ts
+++ b/src/app/shared/clarin-shared-util.ts
@@ -5,6 +5,7 @@ import { MetadataValue } from '../core/shared/metadata.models';
 import { getFirstSucceededRemoteDataPayload } from '../core/shared/operators';
 import { AuthorNameLink } from './clarin-item-box-view/clarin-author-name-link.model';
 import {
+  isEmpty,
   isNull,
   isUndefined,
 } from './empty.util';
@@ -56,6 +57,23 @@ export function convertMetadataFieldIntoSearchType(field: string[]) {
  * @param baseUrl e.g. localhost:8080
  * @param fields metadata fields where authors are stored
  */
+/**
+ * Build the discovery search filter fragment for a metadata value's search link.
+ * When the value carries an authority (e.g. a ROR ID for a publisher or an ORCID for an author),
+ * the `authority` operator is used with the authority key; otherwise the plain `equals` operator is
+ * used with the text value.
+ *
+ * @param searchType discovery filter name (e.g. `author`, `publisher`), see {@link convertMetadataFieldIntoSearchType}
+ * @param mdValue metadata value providing the `authority` (preferred) or text `value`
+ * @returns query fragment, e.g. `f.publisher=02mhbdp94,authority` or `f.publisher=ACME,equals`
+ */
+export function buildAuthoritySearchFilter(searchType: string, mdValue: { authority?: string | null; value?: string }): string {
+  const hasAuthority = !isEmpty(mdValue?.authority);
+  const filterValue = hasAuthority ? mdValue.authority : mdValue?.value;
+  const operator = hasAuthority ? 'authority' : 'equals';
+  return 'f.' + encodeURIComponent(searchType) + '=' + encodeURIComponent(filterValue ?? '') + ',' + operator;
+}
+
 export function loadItemAuthors(item, itemAuthors, baseUrl, fields) {
   if (isNull(item) || isNull(itemAuthors) || isNull(baseUrl)) {
     return;
@@ -67,15 +85,7 @@ export function loadItemAuthors(item, itemAuthors, baseUrl, fields) {
   }
   const itemAuthorsLocal = [];
   authorsMV.forEach((authorMV: MetadataValue) => {
-    let value: string, operator: string;
-    if (authorMV.authority) {
-      value = encodeURIComponent(authorMV.authority);
-      operator = 'authority';
-    } else {
-      value = encodeURIComponent(authorMV.value);
-      operator = 'equals';
-    }
-    const authorSearchLink = baseUrl + '/search?f.author=' + value + ',' + operator;
+    const authorSearchLink = baseUrl + '/search?' + buildAuthoritySearchFilter('author', authorMV);
     const authorNameLink = Object.assign(new AuthorNameLink(), {
       name: authorMV.value,
       url: authorSearchLink,

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -3548,11 +3548,17 @@
   // "form.other-information.last-name": "Last Name",
   "form.other-information.last-name": "Příjmení",
 
+  // "form.other-information.location": "Location",
+  "form.other-information.location": "Místo",
+
   // "form.other-information.orcid": "ORCID",
   "form.other-information.orcid": "ORCID",
 
   // "form.other-information.other-names": "Other Names",
   "form.other-information.other-names": "Další jména",
+
+  // "form.other-information.ror-id": "ROR ID",
+  "form.other-information.ror-id": "ROR ID",
 
   // "form.remove": "Remove",
   "form.remove": "Odstranit",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -2091,7 +2091,11 @@
 
   "form.other-information.last-name": "Last Name",
 
+  "form.other-information.location": "Location",
+
   "form.other-information.orcid": "ORCID",
+
+  "form.other-information.ror-id": "ROR ID",
 
   "form.remove": "Remove",
 


### PR DESCRIPTION
## Tranža FE-3 (Vlna 3) — ROR display cluster (FE side)

Per CLARIN_V9_POST_SNAPSHOT_SYNC_PLAN.md §4 Vlna 3 / FE-3. Pairs with the already-merged **BE-3 #1381** (SimpleRORAuthority) — so the feature is live-verifiable on dev-6.

### `a9fc7f538b` (#1339) — authority-based publisher links + ROR icon — ADAPT
When `dc.publisher`/`creativework.publisher` carries an authority (a ROR ID from BE SimpleRORAuthority), the CLARIN item-page untyped field and the search-result card build the discovery link as `f.publisher=<authority>,authority` (not `,equals`) and render a ROR icon.
- New shared helper `buildAuthoritySearchFilter()` centralises the authority-vs-equals logic; `loadItemAuthors` refactored onto it (behaviour-preserving).
- `getLinkToSearch` resolves the full `MetadataValue` via `allMetadata()[index]`; `getMetadataValue` removed.
- `[href]` → `[attr.href]` on the box-view publisher anchor (no transient link to `undefined` before `assignBaseUrl` resolves).

### `0ac3e53c8e` (#1337) — ROR i18n labels — PORT
`form.other-information.ror-id` / `.location` added to en.json5 + cs.json5.

### v9 adaptations
- Templates `*ngIf` → `@if` (v9 is @if-migrated); BS4 `ml-1` → BS5 `ms-1`.
- Did **not** drag in the fork pre-image's `metadataLangToBcp47` (from the not-yet-ported a11y commit d154682a9f).
- `ror-icon.svg`: kept the vanilla blob `24735df519` (add/add collision), not the fork blob.
- i18n placement: location before orcid, ror-id after orcid (en) / after other-names (cs).

### Local gates (on `16090f6386`) — GREEN
- **Karma 24/24**: shared-util 7 (`buildAuthoritySearchFilter` + `convertMetadataFieldIntoSearchType`), generic-item-field 7 (incl. **AC5 negative-icon test**: no ROR icon on `dc.subject`), box-view 10 (authority/equals links, ROR icon show/hide).
- `npm run lint:nobuild`: **0 errors**.
- build:prod → CI (local disk constrained on the dev host).
- All 3 specs were dropped by the v9 squash and are restored here, adapted to standalone TestBed.
- Live ROR display (icon + `,authority` link) → dev-6 check with enable-ror.cfg ON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)