### PR TITLE
ZCU-PUB/fix: split merged providers in file-download-link spec (TS1117)

### DIFF
--- a/src/app/shared/file-download-link/file-download-link.component.spec.ts
+++ b/src/app/shared/file-download-link/file-download-link.component.spec.ts
@@ -53,7 +53,8 @@ describe('FileDownloadLinkComponent', () => {
       ],
       declarations: [FileDownloadLinkComponent, RouterLinkDirectiveStub],
       providers: [
-        {provide: AuthorizationDataService, useValue: authorizationService, provide: DSONameService, useValue: dsoNameService},
+        {provide: AuthorizationDataService, useValue: authorizationService},
+        {provide: DSONameService, useValue: dsoNameService},
       ],
       schemas: [NO_ERRORS_SCHEMA],
     })


### PR DESCRIPTION
## Problem

The `run specs` (`yarn run test:headless`) build on `customer/zcu-pub` fails at compile time, blocking the **entire** test suite:

```
src/app/shared/file-download-link/file-download-link.component.spec.ts:56:77 - error TS1117: An object literal cannot have multiple properties with the same name.

56  {provide: AuthorizationDataService, useValue: authorizationService, provide: DSONameService, useValue: dsoNameService},
```

Both providers were declared in a **single** object literal, so the second `provide`/`useValue` pair silently overwrote the first. TypeScript rejects the duplicate keys (TS1117), Karma reports `Found 1 load error`, and no specs run.

## Fix

Split the entry into two separate provider objects:

```ts
providers: [
  {provide: AuthorizationDataService, useValue: authorizationService},
  {provide: DSONameService, useValue: dsoNameService},
],
```

Both services are genuinely required — `FileDownloadLinkComponent` injects `dsoNameService` and uses it in `getBitstreamPath` (`file-download-link.component.ts`), and the tests stub `AuthorizationDataService.isAuthorized`.

## Verification

- `npx tsc -p tsconfig.spec.json --noEmit` → exit code **0** (previously failed with TS1117). The spec project now compiles cleanly with no new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)