### PR TITLE
MENDELU/Stop crawler facet trap from saturating SSR (HTTP 504)

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -148,3 +148,58 @@ languages:
   - code: uk
     label: Yкраї́нська
     active: false
+
+# ===========================================================================
+# Server-side rendering
+#
+# Added 2026-07-22, after repozitar.mendelu.cz started answering HTTP 504 - to
+# real visitors and to our New Relic availability monitor alike. nginx
+# error.log showed the SSR upstream (127.0.0.1:4000) failing to produce a
+# response header inside its 60 s proxy_read_timeout, and every single
+# timed-out request looked like this:
+#
+#   GET /collections/<uuid>/search?f.author=...,equals&f.subject=...,equals&f.dateIssued.min=2017
+#   GET /communities/<uuid>/search?f.dateAccessioned.min=2021&spc.page=1&f.author=...,equals
+#
+# The clients were crawlers - 116.179.32.0/24 and 220.181.108.0/24 (Baiduspider),
+# plus 111.225.214.0/24 and 119.249.100.0/24 - walking the facet links on
+# community and collection pages. Every facet combination is a distinct URL, so
+# the SSR page cache (keyed by URL) never hits, and each one costs a full
+# Angular render plus Discovery queries against the REST backend. That
+# combination space is effectively unbounded, so the PM2 workers stay saturated
+# and unrelated requests - including the home page - queue until nginx gives up.
+# For reference, the home page normally answers in ~0.24 s.
+#
+# The upstream defaults already exclude browse on communities and collections
+# and the *global* search ("^/search$" is anchored), but NOT the scoped search
+# inside a community or collection - which is the most expensive route in the
+# application. The two patterns marked below close that gap: those paths are
+# served as a plain CSR shell from now on. src/robots.txt.ejs closes the same
+# gap for crawlers that honour robots.txt; this setting is the part that does
+# not depend on their goodwill.
+#
+# The whole upstream default list is repeated here deliberately. Config merging
+# replaces this array instead of appending to it, so listing only the two new
+# patterns would silently drop every default exclusion.
+# ===========================================================================
+ssr:
+  excludePathPatterns:
+    - pattern: "^/communities/[a-f0-9-]{36}/browse(/.*)?$"
+      flag: "i"
+    - pattern: "^/collections/[a-f0-9-]{36}/browse(/.*)?$"
+      flag: "i"
+    # --- added 2026-07-22: scoped search + its facet links (the crawler trap)
+    - pattern: "^/communities/[a-f0-9-]{36}/search(/.*)?$"
+      flag: "i"
+    - pattern: "^/collections/[a-f0-9-]{36}/search(/.*)?$"
+      flag: "i"
+    # --- end added
+    - pattern: "^/browse/"
+    - pattern: "^/search$"
+    - pattern: "^/community-list$"
+    - pattern: "^/admin/"
+    - pattern: "^/processes/?"
+    - pattern: "^/notifications/"
+    - pattern: "^/statistics/?"
+    - pattern: "^/access-control/"
+    - pattern: "^/health$"

--- a/src/robots.txt.ejs
+++ b/src/robots.txt.ejs
@@ -25,6 +25,10 @@ Disallow: /entities/*?f
 # (HTTP 504 for everyone); see the comment in config/config.yml.
 Disallow: /collections/*/search
 Disallow: /communities/*/search
+# The two rules below cover any URL carrying a Discovery facet filter
+# (f.author, f.subject, f.dateIssued.min, ...), wherever it appears. Two of
+# them because the facet can be the first query parameter (?f.) or a later
+# one (&f.), and robots.txt has no way to express "either".
 Disallow: /*?f.
 Disallow: /*&f.
 

--- a/src/robots.txt.ejs
+++ b/src/robots.txt.ejs
@@ -18,6 +18,15 @@ Disallow: /profile
 Disallow: /workflowitems
 # Crawlers should be able to access entity pages, but not the facet search links present on entity pages
 Disallow: /entities/*?f
+# Scoped search inside a community or collection, and every facet link.
+# "Disallow: /search" above only matches paths that START with /search, so
+# /collections/<uuid>/search and /communities/<uuid>/search stayed crawlable.
+# Crawlers enumerating those facet combinations saturated SSR on 2026-07-22
+# (HTTP 504 for everyone); see the comment in config/config.yml.
+Disallow: /collections/*/search
+Disallow: /communities/*/search
+Disallow: /*?f.
+Disallow: /*&f.
 
 # Optionally uncomment the following line ONLY if sitemaps are working
 # and you have verified that your site is being indexed correctly.


### PR DESCRIPTION
## What happened

On **2026-07-22 07:22 UTC** `repozitar.mendelu.cz` returned **HTTP 504** — to real visitors, and to our New Relic availability monitor (`PING MENDELU: DSPACE FE`, which failed with a duration of exactly 60 204 ms — nginx's default `proxy_read_timeout`).

The nginx error log names the culprit precisely. The stuck upstream is the SSR process, and every timed-out request is a faceted search:

```
2026/07/22 07:23:43 [error] upstream timed out (110: Connection timed out) while reading
response header from upstream, client: 116.179.32.102, request:
"GET /collections/ce25e38c-.../search?f.dateIssued.min=2017&spc.page=1&f.dateAccessioned.min=2022
&f.dateIssued.max=2017&f.subject=Benford%20law,equals&f.dateAccessioned.max=2022"
upstream: "http://127.0.0.1:4000/collections/ce25e38c-.../search?..."

2026/07/22 07:23:51 [error] ... client: 111.225.214.151, request:
"GET /collections/c0183fe2-.../search?f.dateIssued.min=2023&spc.page=1&f.subject=brewing%20test,equals"
```

The clients are crawlers — `116.179.32.0/24` and `220.181.108.0/24` are Baiduspider, plus `111.225.214.0/24` and `119.249.100.0/24` — walking the facet links on community and collection pages.

## Why it saturates SSR

Each of those URLs is a **unique combination of facet filters**, so:

1. the SSR page cache is keyed by URL and therefore **never hits**,
2. each render costs a full Angular SSR pass **plus** Discovery queries against the REST backend,
3. the number of facet combinations is effectively **unbounded**.

The PM2 workers stay busy rendering pages nobody will ever read, unrelated requests queue behind them, and nginx eventually returns 504. For reference, the home page normally answers in **~0.24 s** — this was not gradual slowness, it was saturation.

## The gap this PR closes

The upstream defaults already exclude `browse` on communities and collections, and the *global* search — but `"^/search$"` is **anchored**, so it only matches `/search`. The **scoped** search inside a community or collection is not excluded, and it is the most expensive route in the application.

`robots.txt` has exactly the same hole: `Disallow: /search` only matches paths that *start* with `/search`, so `/collections/<uuid>/search` was fully crawlable, and `Disallow: /entities/*?f` covers only `/entities/`.

### `config/config.yml`

Adds an `ssr.excludePathPatterns` block with two new patterns:

```yaml
- pattern: "^/communities/[a-f0-9-]{36}/search(/.*)?$"
  flag: "i"
- pattern: "^/collections/[a-f0-9-]{36}/search(/.*)?$"
  flag: "i"
```

Those paths are now served as a plain CSR shell — no Angular render, no Discovery queries. This is the part that **does not depend on crawlers behaving well**.

> The complete upstream default list is repeated in the block on purpose: config merging *replaces* this array rather than appending to it, so listing only the two new patterns would silently drop every default exclusion. Please keep that in mind when reviewing the diff — nothing was removed.

### `src/robots.txt.ejs`

```
Disallow: /collections/*/search
Disallow: /communities/*/search
Disallow: /*?f.
Disallow: /*&f.
```

Baidu honours robots.txt, so this should remove a large share of the load at the source. The other two ranges may not — hence the SSR exclusion above.

## Impact

- **SEO:** none worth worrying about. These pages were never meant to be indexed; that is exactly what the existing `Disallow: /search` and `Disallow: /entities/*?f` already express.
- **Users:** scoped search keeps working — it renders client-side, the same way `/search` and `browse` already do on this deployment.
- **Not covered here:** crawlers that ignore robots.txt will still *request* these URLs, they will just be cheap to serve now. If the request rate itself becomes a problem, the next step is `limit_req` in nginx for `111.225.214.0/24` and `119.249.100.0/24`.

## Please verify before merging

The running container may mount its own `config.yml` instead of using the one baked into the image — the live `docker-compose-rest.yml` on `repozitar2025` is known to differ from the repo. If so, the same block has to be applied to the mounted file for this to take effect in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
