### PR TITLE
ZCU-PUB/Enable per-bitstream embargo badge (item.bitstream.showAccessStatuses)

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -190,7 +190,5 @@ languages:
 # Item view configuration
 item:
   bitstream:
-    # Per-bitstream embargo-date badge in the Item View (dspace-customers#823).
-    # Enabled now that the backend accessStatus endpoint is deployed (DSpace#1377).
-    # The frontend fails closed if the endpoint is missing, so this is safe.
+    # Per-bitstream embargo-date badge in the Item View
     showAccessStatuses: true

--- a/config/config.yml
+++ b/config/config.yml
@@ -186,3 +186,11 @@ languages:
   - code: uk
     label: Yкраї́нська
     active: false
+
+# Item view configuration
+item:
+  bitstream:
+    # Per-bitstream embargo-date badge in the Item View (dspace-customers#823).
+    # Enabled now that the backend accessStatus endpoint is deployed (DSpace#1377).
+    # The frontend fails closed if the endpoint is missing, so this is safe.
+    showAccessStatuses: true


### PR DESCRIPTION
## What
Enables the per-bitstream embargo-date badge in the Item View by setting `item.bitstream.showAccessStatuses: true` in `config/config.yml`.

## Why
The badge (dspace-customers#823, FE #1378 + #1390) is gated behind this flag, which defaults to `false` in `default-app-config.ts`. On the dev instance the flag is off, so the badge never renders even though the frontend build and the backend `accessStatus` endpoint (#1377) are already deployed. Verified live: `GET /server/api/core/bitstreams/{uuid}/accessStatus` returns `{status, embargoDate}`, while `/assets/config.json` shows the flag `false`.

## Notes
- `config.yml` is the base config (merged *before* `config.prod.yml`), so this takes effect on redeploy **unless** the deployment's mounted `config.prod.yml` or a `DSPACE_ITEM_BITSTREAM_SHOWACCESSSTATUSES` env var overrides it. Verify after deploy at `/assets/config.json`.
- Config is regenerated at UI startup, so a **redeploy/restart of the dspace-angular container** is required (no rebuild needed).
- Sibling flag `item.showAccessStatuses` (item-level badge) is intentionally left at its default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)