### PR TITLE
ZCU-DATA/Enable per-bitstream embargo badge (item.bitstream.showAccessStatuses)

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -97,7 +97,5 @@ languages:
 # Item view configuration
 item:
   bitstream:
-    # Per-bitstream embargo-date badge in the Item View (dspace-customers#823).
-    # Enabled now that the backend accessStatus endpoint is deployed (DSpace#1380).
-    # The frontend fails closed if the endpoint is missing, so this is safe.
+    # Per-bitstream embargo-date badge in the Item View
     showAccessStatuses: true

--- a/config/config.yml
+++ b/config/config.yml
@@ -93,3 +93,11 @@ languages:
   - code: cs
     label: Čeština
     active: true
+
+# Item view configuration
+item:
+  bitstream:
+    # Per-bitstream embargo-date badge in the Item View (dspace-customers#823).
+    # Enabled now that the backend accessStatus endpoint is deployed (DSpace#1380).
+    # The frontend fails closed if the endpoint is missing, so this is safe.
+    showAccessStatuses: true


### PR DESCRIPTION
## What
Enables the per-bitstream embargo-date badge in the (CLARIN) Item View file listing by setting `item.bitstream.showAccessStatuses: true` in `config/config.yml`.

## Why
The badge (dspace-customers#823, FE #1394) is gated behind this flag, which defaults to `false` in `default-app-config.ts`. On the dev instance the flag is off, so the badge never renders even though the frontend build and the backend `accessStatus` endpoint (#1380) are already deployed. Verified live: the CLARIN `metadatabitstreams/search/byHandle` endpoint returns `status=embargo, embargoDate` for an embargoed file (e.g. item handle 20.500.14592/1973), while `/assets/config.json` shows the flag `false`.

## Notes
- `config.yml` is the base config (merged *before* `config.prod.yml`), so this takes effect on redeploy **unless** the deployment's mounted `config.prod.yml` or a `DSPACE_ITEM_BITSTREAM_SHOWACCESSSTATUSES` env var overrides it. Verify after deploy at `/assets/config.json`.
- Config is regenerated at UI startup, so a **redeploy/restart of the dspace-angular container** is required (no rebuild needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)