### PR TITLE
MENDELU: fix home-page content shift on reload (reserve scrollbar gutter)

### DIFF
--- a/src/styles/_global-styles.scss
+++ b/src/styles/_global-styles.scss
@@ -1,10 +1,33 @@
 html {
     position: relative;
     min-height: 100%;
+
+    // Always reserve the vertical scrollbar's width. While Angular boots it replaces the
+    // server-rendered DOM, so the page is briefly too short to scroll: the scrollbar disappears and
+    // then comes back, widening and re-narrowing the viewport and sliding every centred container
+    // sideways by half the scrollbar width (~7.5px right, then back). The anti-flicker overlay cannot
+    // hide that, because the overlay lives in the page and shifts with it.
+    scrollbar-gutter: stable;
+}
+
+// scrollbar-gutter is unsupported before Chrome 94 / Firefox 97 / Safari 16; keeping the scrollbar
+// track permanently visible reserves the same width there.
+@supports not (scrollbar-gutter: stable) {
+    html {
+        overflow-y: scroll;
+    }
 }
 
 body {
     overflow-x: hidden;
+}
+
+// ng-bootstrap pads the body by the scrollbar width when a modal opens, to compensate for the
+// scrollbar it is about to hide. With the gutter reserved above, that width is never actually freed,
+// so the compensation is pure surplus and shifts the page left by half of it -- the very thing the
+// reserved gutter exists to prevent. Cancel it; the gutter already keeps the width steady.
+body.modal-open {
+    padding-right: 0 !important;
 }
 
 // Sticky Footer


### PR DESCRIPTION
Fixes the content shift on the MENDELU home page: on reload the centred content jumps ~7.5px to the right and immediately back.

## Root cause

While Angular boots it replaces the server-rendered DOM (every `ds-themed-*` wrapper is rebuilt client-side), so for ~90ms the page is too short to scroll. The vertical scrollbar disappears and then returns, the viewport width goes 1425 → 1440 → 1425, and every centred container slides half a scrollbar width sideways.

The anti-flicker overlay **cannot** hide this one — the overlay lives inside the page, so it shifts along with everything else. That is why the shift is visible despite the overlay.

## Fix

`html { scrollbar-gutter: stable }` (with an `overflow-y: scroll` `@supports` fallback for older engines) reserves the scrollbar's width permanently, so its appearance/disappearance no longer changes the layout width. ng-bootstrap pads the body by the scrollbar width when a modal opens; with the gutter permanently reserved that compensation is surplus and would itself shift the page ~7.5px, so it is cancelled for `body.modal-open`.

CSS only — no behavioural/JS change.

## Measured

On the dev instance (`dev-6.pc:8573`), logged out, **headed** browser (headless Chromium uses overlay scrollbars that occupy no width and cannot reproduce this), short viewport, overlay active. The fix was verified by serving it into the live instance's stylesheet and re-measuring:

| | before | after |
|---|---|---|
| reload content shift | **7.5px** (scrollbar 15→0→15) | **0px** |
| modal open shift | −7.5px (with gutter, before the cancel) | **0px** |

`scrollbar-gutter: stable` on `html` is what zeroes it; on `body` alone it does not work (verified).

## Note

This is the same fix already applied to the UoE/datashare frontend (`dataquest-dev/uoe-dspace-datashare-angular` #23). MENDELU already had the anti-flicker overlay and the CSS-class admin-sidebar gutter; it was only missing the scrollbar reservation.
