### PR TITLE
MENDELU: force a permanent scrollbar so reload really stops shifting

### DIFF
--- a/src/styles/_global-styles.scss
+++ b/src/styles/_global-styles.scss
@@ -2,20 +2,22 @@ html {
     position: relative;
     min-height: 100%;
 
-    // Always reserve the vertical scrollbar's width. While Angular boots it replaces the
+    // Keep the vertical scrollbar's width reserved at all times. While Angular boots it replaces the
     // server-rendered DOM, so the page is briefly too short to scroll: the scrollbar disappears and
-    // then comes back, widening and re-narrowing the viewport and sliding every centred container
-    // sideways by half the scrollbar width (~7.5px right, then back). The anti-flicker overlay cannot
-    // hide that, because the overlay lives in the page and shifts with it.
+    // then comes back, widening and re-narrowing the viewport and sliding centred content and every
+    // right-anchored element (search icon, login/user menu) sideways by the scrollbar width, then
+    // back. The anti-flicker overlay cannot hide that, because the overlay lives in the page and
+    // shifts with it.
+    //
+    // We force a permanent scrollbar with overflow-y: scroll. scrollbar-gutter: stable would be the
+    // tidier tool (it reserves the space without drawing a track on short pages), but it is IGNORED
+    // on this theme: `body { overflow-x: hidden }` below makes BODY the propagated viewport scroll
+    // container, so a gutter declared on `html` is never actually held -- verified on the live build,
+    // where clientWidth still toggled 1425<->1440 on every reload despite the stable gutter. Making
+    // `html` a definite scroll container is what pins the width. scrollbar-gutter is kept as a
+    // progressive enhancement for browsers/themes where it does take effect.
+    overflow-y: scroll;
     scrollbar-gutter: stable;
-}
-
-// scrollbar-gutter is unsupported before Chrome 94 / Firefox 97 / Safari 16; keeping the scrollbar
-// track permanently visible reserves the same width there.
-@supports not (scrollbar-gutter: stable) {
-    html {
-        overflow-y: scroll;
-    }
 }
 
 body {


### PR DESCRIPTION
## Why

PR #1406 tried to stop the home-page content shift on reload by reserving the scrollbar gutter with `scrollbar-gutter: stable` on `html`. It merged, but **the shift is still there on the deployed dev instance** — because on this theme that declaration is silently ignored.

`body { overflow-x: hidden }` makes **body** the propagated viewport scroll container, so a `scrollbar-gutter` declared on `html` is never actually held. Verified on the live build: `clientWidth` still toggles **1425 ↔ 1440** on every reload (the scrollbar disappears while Angular re-renders the page too short, then comes back), sliding centred content and the right-anchored header chrome (search icon, login / user menu) sideways by the scrollbar width. The anti-flicker overlay can't hide this — it lives in the page and shifts with it.

## Fix

Force a permanent scrollbar with `overflow-y: scroll` on `html`. This was already present, but only inside the `@supports not (scrollbar-gutter: stable)` fallback — which every modern browser skips, so the working branch never ran. Making it unconditional pins the viewport width. `scrollbar-gutter: stable` is kept as a progressive enhancement for browsers/themes where it does take effect.

## Verification (live dev instance, real-user condition, overlay active, per-rAF)

| | clientWidth across reload | result |
|---|---|---|
| as-deployed (`scrollbar-gutter` only) | 1425 → **1440** → 1425 | scrollbar toggles → shift |
| **this PR (`overflow-y: scroll`)** | **1425 .. 1425** | **pinned → no shift** |

Also confirmed the rule bakes correctly into the built theme CSS: `html{position:relative;min-height:100%;overflow-y:scroll;scrollbar-gutter:stable}`.

Net change: 1 file, comment update + move `overflow-y: scroll` out of the skipped `@supports` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)