### PR TITLE
Lindat/Different name for playwright

### DIFF
--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -20,7 +20,7 @@ jobs:
         working-directory: dspace-ui-tests/scripts
         env:
           HOME_URL: https://dev-5.pc:8443/repository/
-          NAME: DEFAULT
+          NAME: LINDAT
           PASSWORD_ADMIN: ${{ secrets.DSPACE_ADMIN_PASSWORD }}
         run: |
           ./test.sh


### PR DESCRIPTION
## Problem description
The lindat specific tests were not run because the name was set to default.

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot