### PR TITLE
Keep metadata registry in sync: run `database migrate force` in REST entrypoint

### DIFF
--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -63,12 +63,21 @@ services:
     # 1. While a TCP connection to dspacedb port 5432 is not available, continue to sleep
     # 2. Then, run database migration to init database tables
     # 3. Finally, start DSpace
+    #
+    # Why `migrate force` and not plain `migrate`:
+    # New metadata registry entries (config/registries/*.xml) reach the database ONLY via the
+    # Flyway AFTER_MIGRATE callback `RegistryUpdater`. DatabaseUtils.updateDatabase() skips
+    # flyway.migrate() altogether when no migrations are pending, so on an existing database the
+    # callback never fires and registry entries added by newer DSpace releases are never inserted.
+    # `force` is a strict superset of plain `migrate`: pending migrations are still applied first,
+    # it only adds the no-op migrate that triggers the callbacks. This keeps the registry in sync
+    # on every deploy/restart instead of requiring a manual `dspace database migrate force`.
     entrypoint:
     - /bin/bash
     - '-c'
     - |
       while (!</dev/tcp/dspacedb/5432) > /dev/null 2>&1; do sleep 1; done;
-      /dspace/bin/dspace database migrate
+      /dspace/bin/dspace database migrate force
       java -jar /dspace/webapps/server-boot.jar
   # DSpace database container    
   dspacedb:


### PR DESCRIPTION
## Problem

`dspace-new.jcu.cz` logs HTTP 422 on `PATCH /server/api/eperson/epersons/{uuid}`:

```
ERROR org.dspace.app.rest.RestResourceController @ Metadata field does not exist
org.dspace.app.rest.exception.UnprocessableEntityException: Metadata field does not exist
    at DSpaceObjectMetadataPatchUtils.getMetadataField(DSpaceObjectMetadataPatchUtils.java:151)
    at DSpaceObjectMetadataAddOperation.perform(DSpaceObjectMetadataAddOperation.java:44)
    ...
    at EPersonRestRepository.patch(EPersonRestRepository.java:365)
```

The field is `dspace.accessibility.settings`, written by `AccessibilitySettingsService.setSettingsInMetadata()`. It is present in `dspace/config/registries/dspace-types.xml` but **missing from `metadatafieldregistry` in the database**.

Upstream provenance — added by commit `10a95ae9` (2024-10-23):

| tag | present |
|---|---|
| `dspace-7.6.1`, `dspace-8.0` | no |
| `dspace-7.6.4`, `dspace-8.2`, `dspace-9.0` | yes |

## Root cause

Metadata registry entries reach the database **only** through the Flyway `AFTER_MIGRATE` callback [`RegistryUpdater`](https://github.com/dataquest-dev/DSpace/blob/customer/jcu/dspace-api/src/main/java/org/dspace/storage/rdbms/RegistryUpdater.java). No SQL migration inserts them — there is not a single reference to `accessibility` anywhere under `storage/rdbms/`.

And `DatabaseUtils.updateDatabase()` does not call `flyway.migrate()` at all when nothing is pending:

```java
if (pending != null && pending.length > 0) {
    flyway.migrate();          // callback fires, registry loaded
} else if (forceMigrate) {
    flyway.migrate();          // only with `force`
} else {
    log.info("DSpace database schema is up to date");   // migrate() NOT called
}                                                       // -> RegistryUpdater never runs
```

Its own javadoc states the intent: *"forceMigrate: If true, always run a Flyway migration, even if no 'Pending' migrations exist. **This can be used to trigger Flyway Callbacks manually.**"*

The REST entrypoint in `docker/docker-compose-rest.yml` runs plain `dspace database migrate` on every container start. Once the schema is current that command is a no-op, so any registry entry added by a newer DSpace release is never inserted — the deploy silently drifts from the shipped config. Restarting does not help either, even though `Context.init()` auto-migrates ([`Context.java:172`](https://github.com/dataquest-dev/DSpace/blob/customer/jcu/dspace-api/src/main/java/org/dspace/core/Context.java#L172)), because it goes down the same `else` branch.

## Fix

`database migrate` → `database migrate force` in the REST entrypoint, so registry sync happens on every deploy/restart instead of needing a manual one-off.

`force` is a **strict superset** of plain `migrate` — pending migrations are still applied first (same `if` branch, including the Discovery reindex flag); it only adds the otherwise-skipped no-op migrate that fires the callbacks.

## Impact & risk

- Adds a few seconds to backend startup: `RegistryUpdater` re-reads the ~20 registry XMLs plus `bitstream-formats.xml`. Idempotent — `MetadataImporter.loadType()` returns early for fields that already exist (`if (mf != null) return;`) and only creates missing ones.
- No schema change, no data migration.
- User-visible effect of the bug was small: accessibility settings fall back to a cookie when the PATCH fails, so settings simply did not persist to the profile. The same class of failure on `dspace.agreements.end-user` would be worse — it has no fallback.

## Verification

Already confirmed on the running instance: `dspace database migrate force` was run manually and inserted the field. This PR makes that automatic.

After merge + redeploy:

```sql
SELECT s.short_id, f.element, f.qualifier
FROM metadatafieldregistry f
JOIN metadataschemaregistry s ON s.metadata_schema_id = f.metadata_schema_id
WHERE s.short_id = 'dspace' AND f.element = 'accessibility';
```

Expected: one row, `dspace | accessibility | settings`.

## Reviewer note — please confirm

The deploy applies a per-instance overlay **after** these files:

```
docker compose -f docker/docker-compose.yml -f docker/docker-compose-rest.yml \
  -f $CONFIG_PATH/docker-compose-rest.yml -f $CONFIG_PATH/docker-compose.yml up -d
```

If `/opt/dspace-envs/443/docker-compose-rest.yml` defines its own `entrypoint`, it overrides this one and the change has no effect on JCU. Worth checking on the runner:

```bash
grep -A10 entrypoint /opt/dspace-envs/443/docker-compose-rest.yml
```

## Not changed (deliberately)

- `docker/docker-compose-ci.yml` and `docker/db.entities.yml` use `migrate ignored`, which is `outOfOrder=true, forceMigrate=false` — so it has the same blind spot. Left alone since both normally run against a fresh database where migrations are pending anyway.
- `docker-compose.yml:65` in `dataquest-dev/DSpace` has the same plain `migrate`, but it is the backend repo's local-dev compose and is not used by this deploy path. Happy to send a matching one-liner if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
