### PR TITLE
MENDELU/Add "Allow external URLs" toggle to collection Content Source (#860)

### DIFF
--- a/src/app/collection-page/edit-collection-page/collection-source/collection-source.component.html
+++ b/src/app/collection-page/edit-collection-page/collection-source/collection-source.component.html
@@ -52,6 +52,26 @@ class="fas fa-save"></i>
     (cancel)="onCancel()"></ds-form>
   }
 </div>
+@if (contentSource && (contentSource?.harvestType === harvestTypeMetadataAndBitstreams)) {
+  <div class="container mt-2">
+    <div class="row">
+      <div class="col-12">
+        <div class="form-check">
+          <input type="checkbox" class="form-check-input" id="allowExternalUrlsCheck"
+            [checked]="contentSource.allowExternalUrls" (change)="changeAllowExternalUrls()"
+            [attr.aria-describedby]="'allowExternalUrlsWarning'">
+          <label class="form-check-label"
+          for="allowExternalUrlsCheck">{{ 'collection.edit.tabs.source.allow-external-urls' | translate }}</label>
+        </div>
+        <!-- Warning styling only in the risky state; no role="alert", this is static help text -->
+        <div id="allowExternalUrlsWarning" class="mt-2"
+          [ngClass]="contentSource.allowExternalUrls ? 'alert alert-warning' : 'form-text'">
+          {{ 'collection.edit.tabs.source.allow-external-urls.warning' | translate }}
+        </div>
+      </div>
+    </div>
+  </div>
+}
 @if ((contentSource?.harvestType !== harvestTypeNone)) {
   <div class="container mt-2">
     <div class="row">

--- a/src/app/collection-page/edit-collection-page/collection-source/collection-source.component.spec.ts
+++ b/src/app/collection-page/edit-collection-page/collection-source/collection-source.component.spec.ts
@@ -214,6 +214,72 @@ describe('CollectionSourceComponent', () => {
     });
   });
 
+  describe('when selecting the allow external URLs checkbox', () => {
+    let input;
+
+    beforeEach(() => {
+      comp.contentSource.harvestType = ContentSourceHarvestType.MetadataAndBitstreams;
+      fixture.detectChanges();
+      input = fixture.debugElement.query(By.css('#allowExternalUrlsCheck')).nativeElement;
+      input.click();
+      fixture.detectChanges();
+    });
+
+    it('should enable allowExternalUrls', () => {
+      expect(comp.contentSource.allowExternalUrls).toBeTrue();
+    });
+
+    it('should send a field update', () => {
+      expect(objectUpdatesService.saveAddFieldUpdate).toHaveBeenCalledWith(router.url, comp.contentSource);
+    });
+  });
+
+  describe('the allow external URLs checkbox and warning', () => {
+    it('should be hidden when only metadata is harvested', () => {
+      comp.contentSource.harvestType = ContentSourceHarvestType.Metadata;
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('#allowExternalUrlsCheck'))).toBeNull();
+      expect(fixture.debugElement.query(By.css('#allowExternalUrlsWarning'))).toBeNull();
+    });
+
+    it('should be hidden when only references to bitstreams are harvested', () => {
+      comp.contentSource.harvestType = ContentSourceHarvestType.MetadataAndRef;
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('#allowExternalUrlsCheck'))).toBeNull();
+      expect(fixture.debugElement.query(By.css('#allowExternalUrlsWarning'))).toBeNull();
+    });
+
+    it('should be shown when bitstreams are harvested', () => {
+      comp.contentSource.harvestType = ContentSourceHarvestType.MetadataAndBitstreams;
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('#allowExternalUrlsCheck'))).not.toBeNull();
+      expect(fixture.debugElement.query(By.css('#allowExternalUrlsWarning'))).not.toBeNull();
+    });
+
+    it('should describe the checkbox with the warning, so screen readers announce the risk', () => {
+      comp.contentSource.harvestType = ContentSourceHarvestType.MetadataAndBitstreams;
+      fixture.detectChanges();
+      const checkbox = fixture.debugElement.query(By.css('#allowExternalUrlsCheck')).nativeElement;
+      expect(checkbox.getAttribute('aria-describedby')).toEqual('allowExternalUrlsWarning');
+    });
+
+    it('should show the text unstyled before the checkbox is ticked', () => {
+      comp.contentSource.harvestType = ContentSourceHarvestType.MetadataAndBitstreams;
+      fixture.detectChanges();
+      expect(fixture.debugElement.query(By.css('#allowExternalUrlsCheck')).nativeElement.checked).toBeFalse();
+      const warning = fixture.debugElement.query(By.css('#allowExternalUrlsWarning')).nativeElement;
+      expect(warning.classList.contains('alert-warning')).toBeFalse();
+    });
+
+    it('should style the text as a warning once the checkbox is ticked', () => {
+      comp.contentSource.harvestType = ContentSourceHarvestType.MetadataAndBitstreams;
+      comp.contentSource.allowExternalUrls = true;
+      fixture.detectChanges();
+      const warning = fixture.debugElement.query(By.css('#allowExternalUrlsWarning')).nativeElement;
+      expect(warning.classList.contains('alert-warning')).toBeTrue();
+    });
+  });
+
   describe('isValid', () => {
     it('should return true when ContentSource is disabled but the form invalid', () => {
       spyOnProperty(comp.formGroup, 'valid').and.returnValue(false);

--- a/src/app/collection-page/edit-collection-page/collection-source/collection-source.component.ts
+++ b/src/app/collection-page/edit-collection-page/collection-source/collection-source.component.ts
@@ -1,6 +1,7 @@
 import {
   AsyncPipe,
   Location,
+  NgClass,
 } from '@angular/common';
 import {
   Component,
@@ -79,6 +80,7 @@ import { CollectionSourceControlsComponent } from './collection-source-controls/
     BtnDisabledDirective,
     CollectionSourceControlsComponent,
     FormComponent,
+    NgClass,
     ThemedLoadingComponent,
     TranslateModule,
   ],
@@ -253,6 +255,11 @@ export class CollectionSourceComponent extends AbstractTrackableComponent implem
    * The content harvesting type used when harvesting is disabled
    */
   harvestTypeNone = ContentSourceHarvestType.None;
+
+  /**
+   * The content harvesting type that downloads bitstreams, the only one the external URL flag applies to
+   */
+  harvestTypeMetadataAndBitstreams = ContentSourceHarvestType.MetadataAndBitstreams;
 
   /**
    * The previously selected harvesting type
@@ -463,6 +470,16 @@ export class CollectionSourceComponent extends AbstractTrackableComponent implem
       this.contentSource.harvestType = ContentSourceHarvestType.None;
     }
     this.updateContentSource(false);
+  }
+
+  /**
+   * Switch the allowExternalUrls flag on or off and fire a field update
+   * Deliberately not a dynamic form control: the patchValue() in initializeOriginalContentSource() only names the
+   * three form containers, so a control here would not revert on Discard/Reinstate
+   */
+  changeAllowExternalUrls() {
+    this.contentSource.allowExternalUrls = !this.contentSource.allowExternalUrls;
+    this.saveFieldUpdate();
   }
 
   /**

--- a/src/app/core/shared/content-source.model.ts
+++ b/src/app/core/shared/content-source.model.ts
@@ -74,6 +74,13 @@ export class ContentSource extends CacheableObject {
   harvestType = ContentSourceHarvestType.None;
 
   /**
+   * Whether bitstreams may be fetched from hosts other than the OAI provider
+   * Initialised to false on purpose: cerialize omits undefined values, so without it the key would never reach the backend
+   */
+  @autoserializeAs('allow_external_urls')
+  allowExternalUrls = false;
+
+  /**
    * The available metadata configurations
    */
   metadataConfigs: MetadataConfig[];

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -1916,6 +1916,12 @@
   // "collection.edit.tabs.roles.title": "Collection Edit - Roles",
   "collection.edit.tabs.roles.title": "Upravit kolekci - Role",
 
+  // "collection.edit.tabs.source.allow-external-urls": "Allow external URLs",
+  "collection.edit.tabs.source.allow-external-urls": "Povolit externí URL",
+
+  // "collection.edit.tabs.source.allow-external-urls.warning": "When off, files are fetched only from the same scheme and host as the OAI provider above, and a record pointing elsewhere is skipped in full. When on, your server fetches from any address the provider names — that provider, not you, decides what is downloaded and republished here, so enable it only for providers you trust. Private and internal addresses stay blocked either way.",
+  "collection.edit.tabs.source.allow-external-urls.warning": "Když je vypnuto, stahují se soubory jen ze stejného schématu a hostitele, jaké má adresa poskytovatele OAI výše; záznam odkazující jinam se přeskočí celý. Když je zapnuto, stahuje váš server z libovolné adresy, kterou poskytovatel uvede — o tom, co se zde stáhne a znovu zveřejní, tak rozhoduje on, a ne vy. Zapínejte jen u poskytovatelů, kterým důvěřujete. Privátní a interní adresy zůstávají blokované tak či tak.",
+
   // "collection.edit.tabs.source.external": "This collection harvests its content from an external source",
   "collection.edit.tabs.source.external": "Tato kolekce získává svůj obsah z externího zdroje",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1277,6 +1277,10 @@
 
   "collection.edit.tabs.roles.title": "Collection Edit - Roles",
 
+  "collection.edit.tabs.source.allow-external-urls": "Allow external URLs",
+
+  "collection.edit.tabs.source.allow-external-urls.warning": "When off, files are fetched only from the same scheme and host as the OAI provider above, and a record pointing elsewhere is skipped in full. When on, your server fetches from any address the provider names — that provider, not you, decides what is downloaded and republished here, so enable it only for providers you trust. Private and internal addresses stay blocked either way.",
+
   "collection.edit.tabs.source.external": "This collection harvests its content from an external source",
 
   "collection.edit.tabs.source.form.errors.oaiSource.required": "You must provide a set id of the target collection.",


### PR DESCRIPTION
## Problem description
Issue: https://github.com/dataquest-dev/dspace-customers/issues/860

UI part of the fix. Adds the **Allow external URLs** checkbox to Collection → Edit → Content Source, with a short note on what it does and what the risk is when it is ticked.

## Analysis
The checkbox only shows for "Harvest metadata and bitstreams", since that is the only type that downloads files. Unticked it renders as plain help text, ticked it renders as a warning, so the two states cannot be confused. The note is tied to the checkbox with `aria-describedby`.

It is a plain checkbox rather than a dynamic form control — the form's `patchValue` only covers the three existing containers, so a dynamic control would not revert on Discard.

Needs the backend: dataquest-dev/DSpace#1387. Merge that one first, otherwise the UI reports success while nothing is saved.

### Manual Testing (if applicable)
- [x] Verified in docker against the backend branch
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)


https://github.com/user-attachments/assets/490c22c6-34fa-408f-b4ed-1a79ae3bd905

https://github.com/user-attachments/assets/dba16755-ec8a-4236-87f3-5916b60d2d2f

<img width="900" height="563" alt="860-1-control" src="https://github.com/user-attachments/assets/e9d43795-6b0a-4b0c-88bc-68111c97eae7" />


### Copilot review
- [x] Requested review from Copilot
