### PR TITLE
Fix the causes of the REST self link console warnings

### DIFF
--- a/src/app/bitstream-page/clarin-zip-download-page/clarin-zip-download-page.component.ts
+++ b/src/app/bitstream-page/clarin-zip-download-page/clarin-zip-download-page.component.ts
@@ -20,6 +20,7 @@ import { BitstreamDataService } from '../../core/data/bitstream-data.service';
 import { createSuccessfulRemoteDataObject$ } from '../../shared/remote-data.utils';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
 import { TranslateService } from '@ngx-translate/core';
+import { MAX_PAGE_SIZE } from '../../core/data/find-list-options.model';
 
 /**
  * Fetch ZIP file from the server as a single file into `bitstreamRD$` property which is extended and then call
@@ -59,7 +60,7 @@ export class ClarinZipDownloadPageComponent extends ClarinBitstreamDownloadPageC
     this.itemRD$.subscribe((itemRD: RemoteData<Item>)  => {
       this.bitstreamDataService.findAllByItemAndBundleName(itemRD?.payload, 'ORIGINAL', {
         currentPage: 1,
-        elementsPerPage: 9999
+        elementsPerPage: MAX_PAGE_SIZE
       }).pipe(
         getFirstCompletedRemoteData(),
       ).subscribe((bitstreamsRD: RemoteData<PaginatedList<Bitstream>>) => {

--- a/src/app/clarin-licenses/clarin-all-licenses-page/clarin-all-licenses-page.component.ts
+++ b/src/app/clarin-licenses/clarin-all-licenses-page/clarin-all-licenses-page.component.ts
@@ -3,7 +3,7 @@ import { BehaviorSubject } from 'rxjs';
 import { ClarinLicense } from '../../core/shared/clarin/clarin-license.model';
 import { ClarinLicenseDataService } from '../../core/data/clarin/clarin-license-data.service';
 import { getFirstSucceededRemoteListPayload } from '../../core/shared/operators';
-import { FindListOptions } from '../../core/data/find-list-options.model';
+import { FindListOptions, MAX_PAGE_SIZE } from '../../core/data/find-list-options.model';
 import { ClarinLicenseRequiredInfo } from '../../core/shared/clarin/clarin-license.resource-type';
 import { ClarinLicenseRequiredInfoSerializer } from '../../core/shared/clarin/clarin-license-required-info-serializer';
 
@@ -36,7 +36,7 @@ export class ClarinAllLicensesPageComponent implements OnInit {
     const options = new FindListOptions();
     options.currentPage = 0;
     // Load all licenses
-    options.elementsPerPage = 1000;
+    options.elementsPerPage = MAX_PAGE_SIZE;
     return this.clarinLicenseService.findAll(options, false)
       .pipe(getFirstSucceededRemoteListPayload())
       .subscribe(res => {

--- a/src/app/core/browse/browse.service.ts
+++ b/src/app/core/browse/browse.service.ts
@@ -24,6 +24,7 @@ import { followLink, FollowLinkConfig } from '../../shared/utils/follow-link-con
 import { BrowseDefinitionDataService } from './browse-definition-data.service';
 import { SortDirection } from '../cache/models/sort-options.model';
 import { environment } from '../../../environments/environment';
+import { MAX_PAGE_SIZE } from '../data/find-list-options.model';
 
 
 export function getBrowseLinksToFollow(): FollowLinkConfig<BrowseEntry | Item>[] {
@@ -69,7 +70,7 @@ export class BrowseService {
    */
   getBrowseDefinitions(): Observable<RemoteData<PaginatedList<BrowseDefinition>>> {
     // TODO properly support pagination
-    return this.browseDefinitionDataService.findAll({ elementsPerPage: 9999 }).pipe(
+    return this.browseDefinitionDataService.findAll({ elementsPerPage: MAX_PAGE_SIZE }).pipe(
       getFirstSucceededRemoteData(),
     );
   }

--- a/src/app/core/data/bundle-data.service.ts
+++ b/src/app/core/data/bundle-data.service.ts
@@ -16,7 +16,7 @@ import { RequestService } from './request.service';
 import { PaginatedSearchOptions } from '../../shared/search/models/paginated-search-options.model';
 import { Bitstream } from '../shared/bitstream.model';
 import { RequestEntryState } from './request-entry-state.model';
-import { FindListOptions } from './find-list-options.model';
+import { FindListOptions, MAX_PAGE_SIZE } from './find-list-options.model';
 import { IdentifiableDataService } from './base/identifiable-data.service';
 import { PatchData, PatchDataImpl } from './base/patch-data';
 import { DSOChangeAnalyzer } from './dso-change-analyzer.service';
@@ -81,7 +81,7 @@ export class BundleDataService extends IdentifiableDataService<Bundle> implement
   findByItemAndName(item: Item, bundleName: string, useCachedVersionIfAvailable = true, reRequestOnStale = true, options?: FindListOptions, ...linksToFollow: FollowLinkConfig<Bundle>[]): Observable<RemoteData<Bundle>> {
     //Since we filter by bundleName where the pagination options are not indicated we need to load all the possible bundles.
     // This is a workaround, in substitution of the previously recursive call with expand
-    const paginationOptions = options ?? { elementsPerPage: 9999 };
+    const paginationOptions = options ?? { elementsPerPage: MAX_PAGE_SIZE };
     return this.findAllByItem(item, paginationOptions, useCachedVersionIfAvailable, reRequestOnStale, ...linksToFollow).pipe(
       map((rd: RemoteData<PaginatedList<Bundle>>) => {
         if (hasValue(rd.payload) && hasValue(rd.payload.page)) {

--- a/src/app/core/data/dspace-rest-response-parsing.service.spec.ts
+++ b/src/app/core/data/dspace-rest-response-parsing.service.spec.ts
@@ -146,6 +146,16 @@ describe('DspaceRestResponseParsingService', () => {
         expect(console.warn).toHaveBeenCalledWith(MISMATCH);
       });
 
+      it('should warn when a reduced page size hides another param that differs', () => {
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?page=0&size=9999');
+        service.callEnsureSelfLink(request, responseWithSelfLink(
+          'https://rest.api/core/items/eba1c085/bundles?page=3&size=1000',
+          { number: 3, size: 1000, totalPages: 4, totalElements: 3200 }));
+
+        expect(console.warn).toHaveBeenCalledTimes(1);
+        expect(console.warn).toHaveBeenCalledWith(MISMATCH);
+      });
+
       it('should warn when the self link claims an empty page', () => {
         const request = requestFor('https://rest.api/core/items/eba1c085/bundles?size=10');
         service.callEnsureSelfLink(request, responseWithSelfLink(

--- a/src/app/core/data/dspace-rest-response-parsing.service.spec.ts
+++ b/src/app/core/data/dspace-rest-response-parsing.service.spec.ts
@@ -93,6 +93,17 @@ describe('DspaceRestResponseParsingService', () => {
         expect(response.payload._links.self.href).toBe('https://rest.api/core/items/eba1c085/bundles?size=9999');
       });
 
+      it('should not warn when the self link only percent decoded a param value', () => {
+        // https://github.com/dataquest-dev/dspace-customers/issues/862
+        const request = requestFor('https://rest.api/statistics/usagereports/search/object?page=-1&size=10&uri=https%3A%2F%2Frest.api%2Fcore%2Fsites%2F8f842a80');
+        const response = service.callEnsureSelfLink(request, responseWithSelfLink(
+          'https://rest.api/statistics/usagereports/search/object?page=-1&size=10&uri=https://rest.api/core/sites/8f842a80'));
+
+        expect(console.warn).not.toHaveBeenCalled();
+        expect(response.payload._links.self.href)
+          .toBe('https://rest.api/statistics/usagereports/search/object?page=-1&size=10&uri=https%3A%2F%2Frest.api%2Fcore%2Fsites%2F8f842a80');
+      });
+
       it('should not warn or normalize when params are only in a different order', () => {
         const request = requestFor('https://rest.api/core/items/eba1c085/bundles?page=0&size=5');
         const response = service.callEnsureSelfLink(request,
@@ -141,6 +152,15 @@ describe('DspaceRestResponseParsingService', () => {
         service.callEnsureSelfLink(request, responseWithSelfLink(
           'https://rest.api/core/items/eba1c085/bundles?size=3',
           { number: 0, size: 3, totalPages: 1, totalElements: 2 }));
+
+        expect(console.warn).toHaveBeenCalledTimes(1);
+        expect(console.warn).toHaveBeenCalledWith(MISMATCH);
+      });
+
+      it('should still warn when a param value differs beyond its encoding', () => {
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?uri=https%3A%2F%2Frest.api%2Fcore%2Fsites%2Faaa');
+        service.callEnsureSelfLink(request,
+          responseWithSelfLink('https://rest.api/core/items/eba1c085/bundles?uri=https://rest.api/core/sites/bbb'));
 
         expect(console.warn).toHaveBeenCalledTimes(1);
         expect(console.warn).toHaveBeenCalledWith(MISMATCH);

--- a/src/app/core/data/dspace-rest-response-parsing.service.spec.ts
+++ b/src/app/core/data/dspace-rest-response-parsing.service.spec.ts
@@ -1,0 +1,201 @@
+import { DspaceRestResponseParsingService } from './dspace-rest-response-parsing.service';
+import { RestRequest } from './rest-request.model';
+import { GetRequest, PostRequest } from './request.models';
+import { RawRestResponse } from '../dspace-rest/raw-rest-response.model';
+import { ObjectCacheService } from '../cache/object-cache.service';
+
+/**
+ * Exposes the protected {@link DspaceRestResponseParsingService#ensureSelfLink} so it can be
+ * tested in isolation.
+ */
+class TestParsingService extends DspaceRestResponseParsingService {
+  public callEnsureSelfLink(request: RestRequest, response: RawRestResponse): RawRestResponse {
+    return this.ensureSelfLink(request, response);
+  }
+}
+
+describe('DspaceRestResponseParsingService', () => {
+  let service: TestParsingService;
+  let objectCache: ObjectCacheService;
+
+  const MISMATCH = jasmine.stringMatching(/These don't match/);
+  const NO_SELF_LINK = jasmine.stringMatching(/doesn't have a self link/);
+
+  const requestFor = (href: string): RestRequest =>
+    new GetRequest('c4f0b1b7-3ffa-4b1a-9f5f-8bd6b1c4de71', href);
+
+  const responseWithSelfLink = (href: string, page?: any): RawRestResponse => ({
+    payload: {
+      _links: {
+        self: { href },
+      },
+      ...(page ? { page } : {}),
+    },
+    statusCode: 200,
+    statusText: 'OK',
+  });
+
+  beforeEach(() => {
+    objectCache = jasmine.createSpyObj('objectCache', ['add', 'remove']);
+    service = new TestParsingService(objectCache);
+    spyOn(console, 'warn');
+  });
+
+  describe('ensureSelfLink', () => {
+
+    describe('differences the REST API is expected to introduce', () => {
+
+      it('should not warn when the self link matches the requested url', () => {
+        const href = 'https://rest.api/core/bundles/9d18168a/bitstreams?page=0&size=5';
+        const response = service.callEnsureSelfLink(requestFor(href), responseWithSelfLink(href));
+
+        expect(console.warn).not.toHaveBeenCalled();
+        expect(response.payload._links.self.href).toBe(href);
+      });
+
+      it('should not warn when the self link only echoes the embed params of the request', () => {
+        // https://github.com/dataquest-dev/dspace-customers/issues/862
+        const href = 'https://rest.api/core/bundles/9d18168a/bitstreams?page=0&embed=accessStatus&size=5';
+        const response = service.callEnsureSelfLink(requestFor(href), responseWithSelfLink(href));
+
+        expect(console.warn).not.toHaveBeenCalled();
+        // the self link is still normalized, because that's the url the response is cached under
+        expect(response.payload._links.self.href).toBe('https://rest.api/core/bundles/9d18168a/bitstreams?page=0&size=5');
+      });
+
+      it('should not warn when the self link echoes embed params and the request has no other params', () => {
+        // observed in the browser against a DSpace 9.1 backend
+        const href = 'https://rest.api/core/items/eba1c085/bundles?embed=primaryBitstream&embed=bitstreams/format&embed.size=bitstreams=5';
+        const response = service.callEnsureSelfLink(requestFor(href), responseWithSelfLink(href));
+
+        expect(console.warn).not.toHaveBeenCalled();
+        expect(response.payload._links.self.href).toBe('https://rest.api/core/items/eba1c085/bundles');
+      });
+
+      it('should not warn when the REST API reduced the requested page size', () => {
+        // https://github.com/dataquest-dev/dspace-customers/issues/862
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?embed=primaryBitstream&size=9999');
+        const response = service.callEnsureSelfLink(request, responseWithSelfLink(
+          'https://rest.api/core/items/eba1c085/bundles?embed=primaryBitstream&size=1000',
+          { number: 0, size: 1000, totalPages: 1, totalElements: 2 }));
+
+        expect(console.warn).not.toHaveBeenCalled();
+        expect(response.payload._links.self.href).toBe('https://rest.api/core/items/eba1c085/bundles?size=9999');
+      });
+
+      it('should not warn when params are only in a different order', () => {
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?page=0&size=5');
+        service.callEnsureSelfLink(request,
+          responseWithSelfLink('https://rest.api/core/items/eba1c085/bundles?size=5&page=0'));
+
+        expect(console.warn).not.toHaveBeenCalled();
+      });
+
+    });
+
+    describe('differences that point at a problem with the endpoint', () => {
+
+      it('should warn when the page size shrank but the page block contradicts the self link', () => {
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?size=100');
+        service.callEnsureSelfLink(request, responseWithSelfLink(
+          'https://rest.api/core/items/eba1c085/bundles?size=20',
+          { number: 0, size: 100, totalPages: 1, totalElements: 2 }));
+
+        expect(console.warn).toHaveBeenCalledTimes(1);
+        expect(console.warn).toHaveBeenCalledWith(MISMATCH);
+      });
+
+      it('should warn when the page size shrank but the response has no page block to confirm it', () => {
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?size=100');
+        service.callEnsureSelfLink(request,
+          responseWithSelfLink('https://rest.api/core/items/eba1c085/bundles?size=20'));
+
+        expect(console.warn).toHaveBeenCalledTimes(1);
+        expect(console.warn).toHaveBeenCalledWith(MISMATCH);
+      });
+
+      it('should warn when the returned page size is larger than the requested one', () => {
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?size=5');
+        service.callEnsureSelfLink(request, responseWithSelfLink(
+          'https://rest.api/core/items/eba1c085/bundles?size=50',
+          { number: 0, size: 50, totalPages: 1, totalElements: 2 }));
+
+        expect(console.warn).toHaveBeenCalledTimes(1);
+        expect(console.warn).toHaveBeenCalledWith(MISMATCH);
+      });
+
+      it('should warn when the url is ambiguous about the page size', () => {
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?size=5&size=10');
+        service.callEnsureSelfLink(request, responseWithSelfLink(
+          'https://rest.api/core/items/eba1c085/bundles?size=3',
+          { number: 0, size: 3, totalPages: 1, totalElements: 2 }));
+
+        expect(console.warn).toHaveBeenCalledTimes(1);
+        expect(console.warn).toHaveBeenCalledWith(MISMATCH);
+      });
+
+      it('should warn when a non-embed param differs', () => {
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?page=0&embed=primaryBitstream&size=5');
+        service.callEnsureSelfLink(request,
+          responseWithSelfLink('https://rest.api/core/items/eba1c085/bundles?page=3&embed=primaryBitstream&size=5'));
+
+        expect(console.warn).toHaveBeenCalledTimes(1);
+        expect(console.warn).toHaveBeenCalledWith(MISMATCH);
+      });
+
+      it('should warn when the self link has a param the request did not have', () => {
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?size=5');
+        service.callEnsureSelfLink(request,
+          responseWithSelfLink('https://rest.api/core/items/eba1c085/bundles?size=5&sort=name,ASC'));
+
+        expect(console.warn).toHaveBeenCalledTimes(1);
+        expect(console.warn).toHaveBeenCalledWith(MISMATCH);
+      });
+
+      it('should warn and fill in the requested url when the response has no self link', () => {
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?embed=primaryBitstream&size=5');
+        const response = service.callEnsureSelfLink(request, {
+          payload: { _links: {} },
+          statusCode: 200,
+          statusText: 'OK',
+        });
+
+        expect(console.warn).toHaveBeenCalledTimes(1);
+        expect(console.warn).toHaveBeenCalledWith(NO_SELF_LINK);
+        expect(response.payload._links.self.href).toBe('https://rest.api/core/items/eba1c085/bundles?size=5');
+      });
+
+    });
+
+    describe('normalization of the self link', () => {
+
+      it('should normalize the self link when it differs, so it matches the cache key', () => {
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?page=0&embed=primaryBitstream&size=5');
+        const response = service.callEnsureSelfLink(request,
+          responseWithSelfLink('https://rest.api/core/items/eba1c085/bundles?page=3&embed=primaryBitstream&size=5'));
+
+        expect(response.payload._links.self.href).toBe('https://rest.api/core/items/eba1c085/bundles?page=0&size=5');
+      });
+
+      it('should not touch a self link that points at a different path', () => {
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?size=5');
+        const response = service.callEnsureSelfLink(request,
+          responseWithSelfLink('https://rest.api/core/items/eba1c085?size=5'));
+
+        expect(console.warn).not.toHaveBeenCalled();
+        expect(response.payload._links.self.href).toBe('https://rest.api/core/items/eba1c085?size=5');
+      });
+
+      it('should leave non-GET requests alone', () => {
+        const request = new PostRequest('c4f0b1b7-3ffa-4b1a-9f5f-8bd6b1c4de71', 'https://rest.api/core/items/eba1c085/bundles?size=5');
+        const response = service.callEnsureSelfLink(request,
+          responseWithSelfLink('https://rest.api/core/items/eba1c085/bundles?size=1000'));
+
+        expect(console.warn).not.toHaveBeenCalled();
+        expect(response.payload._links.self.href).toBe('https://rest.api/core/items/eba1c085/bundles?size=1000');
+      });
+
+    });
+
+  });
+});

--- a/src/app/core/data/dspace-rest-response-parsing.service.spec.ts
+++ b/src/app/core/data/dspace-rest-response-parsing.service.spec.ts
@@ -72,27 +72,6 @@ describe('DspaceRestResponseParsingService', () => {
         expect(response.payload._links.self.href).toBe('https://rest.api/core/items/eba1c085/bundles');
       });
 
-      it('should not warn when the REST API reduced the requested page size', () => {
-        // https://github.com/dataquest-dev/dspace-customers/issues/862
-        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?embed=primaryBitstream&size=9999');
-        const response = service.callEnsureSelfLink(request, responseWithSelfLink(
-          'https://rest.api/core/items/eba1c085/bundles?embed=primaryBitstream&size=1000',
-          { number: 0, size: 1000, totalPages: 1, totalElements: 2 }));
-
-        expect(console.warn).not.toHaveBeenCalled();
-        expect(response.payload._links.self.href).toBe('https://rest.api/core/items/eba1c085/bundles?size=9999');
-      });
-
-      it('should not warn when the REST API reduced the page size and no embeds are involved', () => {
-        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?size=9999');
-        const response = service.callEnsureSelfLink(request, responseWithSelfLink(
-          'https://rest.api/core/items/eba1c085/bundles?size=1000',
-          { number: 0, size: 1000, totalPages: 1, totalElements: 2 }));
-
-        expect(console.warn).not.toHaveBeenCalled();
-        expect(response.payload._links.self.href).toBe('https://rest.api/core/items/eba1c085/bundles?size=9999');
-      });
-
       it('should not warn when the self link only percent decoded a param value', () => {
         // https://github.com/dataquest-dev/dspace-customers/issues/862
         const request = requestFor('https://rest.api/statistics/usagereports/search/object?page=-1&size=10&uri=https%3A%2F%2Frest.api%2Fcore%2Fsites%2F8f842a80');
@@ -118,20 +97,13 @@ describe('DspaceRestResponseParsingService', () => {
 
     describe('differences that point at a problem with the endpoint', () => {
 
-      it('should warn when the page size shrank but the page block contradicts the self link', () => {
-        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?size=100');
+      it('should warn when the REST API reduced the requested page size', () => {
+        // callers are expected to stay within MAX_PAGE_SIZE, so a reduced size means a caller asked
+        // for a page the API was never going to serve
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?size=9999');
         service.callEnsureSelfLink(request, responseWithSelfLink(
-          'https://rest.api/core/items/eba1c085/bundles?size=20',
-          { number: 0, size: 100, totalPages: 1, totalElements: 2 }));
-
-        expect(console.warn).toHaveBeenCalledTimes(1);
-        expect(console.warn).toHaveBeenCalledWith(MISMATCH);
-      });
-
-      it('should warn when the page size shrank but the response has no page block to confirm it', () => {
-        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?size=100');
-        service.callEnsureSelfLink(request,
-          responseWithSelfLink('https://rest.api/core/items/eba1c085/bundles?size=20'));
+          'https://rest.api/core/items/eba1c085/bundles?size=1000',
+          { number: 0, size: 1000, totalPages: 1, totalElements: 2 }));
 
         expect(console.warn).toHaveBeenCalledTimes(1);
         expect(console.warn).toHaveBeenCalledWith(MISMATCH);
@@ -147,60 +119,10 @@ describe('DspaceRestResponseParsingService', () => {
         expect(console.warn).toHaveBeenCalledWith(MISMATCH);
       });
 
-      it('should warn when the url is ambiguous about the page size', () => {
-        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?size=5&size=10');
-        service.callEnsureSelfLink(request, responseWithSelfLink(
-          'https://rest.api/core/items/eba1c085/bundles?size=3',
-          { number: 0, size: 3, totalPages: 1, totalElements: 2 }));
-
-        expect(console.warn).toHaveBeenCalledTimes(1);
-        expect(console.warn).toHaveBeenCalledWith(MISMATCH);
-      });
-
       it('should still warn when a param value differs beyond its encoding', () => {
         const request = requestFor('https://rest.api/core/items/eba1c085/bundles?uri=https%3A%2F%2Frest.api%2Fcore%2Fsites%2Faaa');
         service.callEnsureSelfLink(request,
           responseWithSelfLink('https://rest.api/core/items/eba1c085/bundles?uri=https://rest.api/core/sites/bbb'));
-
-        expect(console.warn).toHaveBeenCalledTimes(1);
-        expect(console.warn).toHaveBeenCalledWith(MISMATCH);
-      });
-
-      it('should warn when a reduced page size hides another param that differs', () => {
-        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?page=0&size=9999');
-        service.callEnsureSelfLink(request, responseWithSelfLink(
-          'https://rest.api/core/items/eba1c085/bundles?page=3&size=1000',
-          { number: 3, size: 1000, totalPages: 4, totalElements: 3200 }));
-
-        expect(console.warn).toHaveBeenCalledTimes(1);
-        expect(console.warn).toHaveBeenCalledWith(MISMATCH);
-      });
-
-      it('should warn when the self link claims an empty page', () => {
-        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?size=10');
-        service.callEnsureSelfLink(request, responseWithSelfLink(
-          'https://rest.api/core/items/eba1c085/bundles?size=0',
-          { number: 0, size: 0, totalPages: 0, totalElements: 0 }));
-
-        expect(console.warn).toHaveBeenCalledTimes(1);
-        expect(console.warn).toHaveBeenCalledWith(MISMATCH);
-      });
-
-      it('should not treat a param that merely ends in `size` as the page size', () => {
-        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?pagesize=9999');
-        service.callEnsureSelfLink(request, responseWithSelfLink(
-          'https://rest.api/core/items/eba1c085/bundles?pagesize=1000',
-          { number: 0, size: 1000, totalPages: 1, totalElements: 2 }));
-
-        expect(console.warn).toHaveBeenCalledTimes(1);
-        expect(console.warn).toHaveBeenCalledWith(MISMATCH);
-      });
-
-      it('should not accept a page block that confirms the reduced size only as a string', () => {
-        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?size=9999');
-        service.callEnsureSelfLink(request, responseWithSelfLink(
-          'https://rest.api/core/items/eba1c085/bundles?size=1000',
-          { number: 0, size: '1000', totalPages: 1, totalElements: 2 }));
 
         expect(console.warn).toHaveBeenCalledTimes(1);
         expect(console.warn).toHaveBeenCalledWith(MISMATCH);

--- a/src/app/core/data/dspace-rest-response-parsing.service.spec.ts
+++ b/src/app/core/data/dspace-rest-response-parsing.service.spec.ts
@@ -83,12 +83,24 @@ describe('DspaceRestResponseParsingService', () => {
         expect(response.payload._links.self.href).toBe('https://rest.api/core/items/eba1c085/bundles?size=9999');
       });
 
-      it('should not warn when params are only in a different order', () => {
+      it('should not warn when the REST API reduced the page size and no embeds are involved', () => {
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?size=9999');
+        const response = service.callEnsureSelfLink(request, responseWithSelfLink(
+          'https://rest.api/core/items/eba1c085/bundles?size=1000',
+          { number: 0, size: 1000, totalPages: 1, totalElements: 2 }));
+
+        expect(console.warn).not.toHaveBeenCalled();
+        expect(response.payload._links.self.href).toBe('https://rest.api/core/items/eba1c085/bundles?size=9999');
+      });
+
+      it('should not warn or normalize when params are only in a different order', () => {
         const request = requestFor('https://rest.api/core/items/eba1c085/bundles?page=0&size=5');
-        service.callEnsureSelfLink(request,
+        const response = service.callEnsureSelfLink(request,
           responseWithSelfLink('https://rest.api/core/items/eba1c085/bundles?size=5&page=0'));
 
         expect(console.warn).not.toHaveBeenCalled();
+        // the urls hold the same params, so nothing is rewritten here
+        expect(response.payload._links.self.href).toBe('https://rest.api/core/items/eba1c085/bundles?size=5&page=0');
       });
 
     });
@@ -134,6 +146,47 @@ describe('DspaceRestResponseParsingService', () => {
         expect(console.warn).toHaveBeenCalledWith(MISMATCH);
       });
 
+      it('should warn when the self link claims an empty page', () => {
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?size=10');
+        service.callEnsureSelfLink(request, responseWithSelfLink(
+          'https://rest.api/core/items/eba1c085/bundles?size=0',
+          { number: 0, size: 0, totalPages: 0, totalElements: 0 }));
+
+        expect(console.warn).toHaveBeenCalledTimes(1);
+        expect(console.warn).toHaveBeenCalledWith(MISMATCH);
+      });
+
+      it('should not treat a param that merely ends in `size` as the page size', () => {
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?pagesize=9999');
+        service.callEnsureSelfLink(request, responseWithSelfLink(
+          'https://rest.api/core/items/eba1c085/bundles?pagesize=1000',
+          { number: 0, size: 1000, totalPages: 1, totalElements: 2 }));
+
+        expect(console.warn).toHaveBeenCalledTimes(1);
+        expect(console.warn).toHaveBeenCalledWith(MISMATCH);
+      });
+
+      it('should not accept a page block that confirms the reduced size only as a string', () => {
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?size=9999');
+        service.callEnsureSelfLink(request, responseWithSelfLink(
+          'https://rest.api/core/items/eba1c085/bundles?size=1000',
+          { number: 0, size: '1000', totalPages: 1, totalElements: 2 }));
+
+        expect(console.warn).toHaveBeenCalledTimes(1);
+        expect(console.warn).toHaveBeenCalledWith(MISMATCH);
+      });
+
+      it('should report the normalized request url and the raw self link in the warning', () => {
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?page=0&embed=primaryBitstream&size=5');
+        service.callEnsureSelfLink(request,
+          responseWithSelfLink('https://rest.api/core/items/eba1c085/bundles?page=3&embed=primaryBitstream&size=5'));
+
+        expect(console.warn).toHaveBeenCalledWith(
+          'The response for \'https://rest.api/core/items/eba1c085/bundles?page=0&size=5\' has the self link ' +
+          '\'https://rest.api/core/items/eba1c085/bundles?page=3&embed=primaryBitstream&size=5\'. ' +
+          'These don\'t match. This could mean there\'s an issue with the REST endpoint');
+      });
+
       it('should warn when a non-embed param differs', () => {
         const request = requestFor('https://rest.api/core/items/eba1c085/bundles?page=0&embed=primaryBitstream&size=5');
         service.callEnsureSelfLink(request,
@@ -175,6 +228,32 @@ describe('DspaceRestResponseParsingService', () => {
           responseWithSelfLink('https://rest.api/core/items/eba1c085/bundles?page=3&embed=primaryBitstream&size=5'));
 
         expect(response.payload._links.self.href).toBe('https://rest.api/core/items/eba1c085/bundles?page=0&size=5');
+      });
+
+      it('should keep the other links when it normalizes the self link', () => {
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?page=0&size=5');
+        const response = service.callEnsureSelfLink(request, {
+          payload: {
+            _links: {
+              self: { href: 'https://rest.api/core/items/eba1c085/bundles?page=3&size=5' },
+              primaryBitstream: { href: 'https://rest.api/core/bitstreams/6a5f' },
+            },
+          },
+          statusCode: 200,
+          statusText: 'OK',
+        });
+
+        expect(response.payload._links.self.href).toBe('https://rest.api/core/items/eba1c085/bundles?page=0&size=5');
+        expect(response.payload._links.primaryBitstream.href).toBe('https://rest.api/core/bitstreams/6a5f');
+      });
+
+      it('should not touch a self link on a different host', () => {
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?size=5');
+        const response = service.callEnsureSelfLink(request,
+          responseWithSelfLink('https://other.api/core/items/eba1c085/bundles?size=5'));
+
+        expect(console.warn).not.toHaveBeenCalled();
+        expect(response.payload._links.self.href).toBe('https://other.api/core/items/eba1c085/bundles?size=5');
       });
 
       it('should not touch a self link that points at a different path', () => {

--- a/src/app/core/data/dspace-rest-response-parsing.service.ts
+++ b/src/app/core/data/dspace-rest-response-parsing.service.ts
@@ -54,6 +54,89 @@ const splitUrlInParts = (url: string): string[] => {
     .reduce((combined, current) => [...combined, ...current]);
 };
 
+/**
+ * Return true if two lists of url parts don't hold the same set of parts. The comparison is order
+ * insensitive, and — like {@link splitUrlInParts} — treats the part in front of the query string as
+ * just another part.
+ *
+ * @param expected the parts of the url we expected
+ * @param actual   the parts of the url we got
+ */
+const urlPartsDiffer = (expected: string[], actual: string[]): boolean => {
+  return expected.some((part: string) => !actual.includes(part))
+    || actual.some((part: string) => !expected.includes(part));
+};
+
+/**
+ * Matches a page size query param, e.g. `size=100`
+ */
+const PAGE_SIZE_PARAM = /^size=(\d+)$/;
+
+/**
+ * Return the page sizes among the given url parts. More than one means the url is ambiguous about
+ * the page size, and no conclusion can be drawn from it.
+ *
+ * @param parts the url parts, as returned by {@link splitUrlInParts}
+ */
+const getPageSizes = (parts: string[]): number[] => {
+  return parts
+    .map((part: string) => part.match(PAGE_SIZE_PARAM))
+    .filter((matches) => hasValue(matches))
+    .map((matches) => Number(matches[1]));
+};
+
+/**
+ * Return true if the requested url and the self link disagree about the page size only because the
+ * REST API reduced a size it wasn't willing to serve.
+ *
+ * The REST contract says a `size` over the configured maximum is "automatically reset to the
+ * maximum allowed value, no error is thrown", and it is that effective size which ends up in the
+ * self link. The frontend can't know the server's maximum, so it can't tell such a clamp apart from
+ * any other reduction — but it can require the response to be consistent with itself: the `page`
+ * block has to confirm the smaller size the self link advertises. A self link that contradicts the
+ * payload it describes is still reported.
+ *
+ * @param expected the requested url parts, without embed params
+ * @param actual   the self link parts, without embed params
+ * @param payload  the response body the self link belongs to
+ */
+const isReducedPageSize = (expected: string[], actual: string[], payload: any): boolean => {
+  const requestedSizes = getPageSizes(expected);
+  const effectiveSizes = getPageSizes(actual);
+  return requestedSizes.length === 1 && effectiveSizes.length === 1
+    && effectiveSizes[0] < requestedSizes[0]
+    && hasValue(payload) && hasValue(payload.page) && payload.page.size === effectiveSizes[0];
+};
+
+/**
+ * Determine whether the difference between the url that was requested and the self link the REST
+ * API returned for it points at an actual problem with the endpoint.
+ *
+ * Two kinds of difference are correct REST behaviour and are not reported:
+ *
+ * - The REST API echoes the request's `embed`/`embed.size` params in the self link, while the url
+ *   we compare against has had them stripped by {@link getUrlWithoutEmbedParams}. Comparing the two
+ *   as-is makes every request that embeds a subresource look broken, e.g.
+ *   `…/bitstreams?page=0&size=5` vs `…/bitstreams?page=0&embed=accessStatus&size=5`. Stripping both
+ *   sides also means a self link echoing embeds we never asked for goes unreported.
+ * - The REST API reduced the requested page size, see {@link isReducedPageSize}.
+ *
+ * @param requestedUrl the url that was requested, without embed params
+ * @param selfLink     the self link as returned by the REST API
+ * @param payload      the response body the self link belongs to
+ */
+const isUnexpectedSelfLink = (requestedUrl: string, selfLink: string, payload: any): boolean => {
+  const expected = splitUrlInParts(requestedUrl);
+  const actual = splitUrlInParts(getUrlWithoutEmbedParams(selfLink));
+
+  if (isReducedPageSize(expected, actual, payload)) {
+    const withoutPageSize = (parts: string[]): string[] =>
+      parts.filter((part: string) => !PAGE_SIZE_PARAM.test(part));
+    return urlPartsDiffer(withoutPageSize(expected), withoutPageSize(actual));
+  }
+  return urlPartsDiffer(expected, actual);
+};
+
 @Injectable({ providedIn: 'root' })
 export class DspaceRestResponseParsingService implements ResponseParsingService {
   protected serializerConstructor: GenericConstructor<Serializer<any>> = DSpaceSerializer;
@@ -156,10 +239,15 @@ export class DspaceRestResponseParsingService implements ResponseParsingService 
         });
 
       } else {
+        const selfLink = response.payload._links.self.href;
         const expected = splitUrlInParts(urlWithoutEmbedParams);
-        const actual = splitUrlInParts(response.payload._links.self.href);
-        if (expected[0] === actual[0] && (expected.some((e) => !actual.includes(e)) || actual.some((e) => !expected.includes(e)))) {
-          console.warn(`The response for '${urlWithoutEmbedParams}' has the self link '${response.payload._links.self.href}'. These don't match. This could mean there's an issue with the REST endpoint`);
+        const actual = splitUrlInParts(selfLink);
+        if (expected[0] === actual[0] && urlPartsDiffer(expected, actual)) {
+          // Report only the differences the REST API isn't expected to introduce by itself. Which
+          // url the self link is normalized to is deliberately left unchanged by this check.
+          if (isUnexpectedSelfLink(urlWithoutEmbedParams, selfLink, response.payload)) {
+            console.warn(`The response for '${urlWithoutEmbedParams}' has the self link '${selfLink}'. These don't match. This could mean there's an issue with the REST endpoint`);
+          }
           response.payload._links = Object.assign({}, response.payload._links, {
             self: {
               href: urlWithoutEmbedParams

--- a/src/app/core/data/dspace-rest-response-parsing.service.ts
+++ b/src/app/core/data/dspace-rest-response-parsing.service.ts
@@ -78,7 +78,7 @@ const decodeUrlParts = (parts: string[]): string[] => {
 
 /**
  * Return true if the self link differs from the requested url in a way that isn't just a different
- * way of writing the same request.
+ * way of writing the same request. Takes the requested url already split, since the caller has it.
  *
  * Both sides are brought to the same form first: `embed`/`embed.size` params are stripped, because
  * the frontend treats them as not part of a resource's identity and indexes without them, and both
@@ -86,9 +86,9 @@ const decodeUrlParts = (parts: string[]): string[] => {
  * what came back, including a page size the API reduced — callers are expected to stay within
  * `MAX_PAGE_SIZE` rather than have that reported difference filtered out here.
  */
-const isUnexpectedSelfLink = (requestedUrl: string, selfLink: string): boolean => {
+const isUnexpectedSelfLink = (requestedUrlParts: string[], selfLink: string): boolean => {
   return urlPartsDiffer(
-    decodeUrlParts(splitUrlInParts(requestedUrl)),
+    decodeUrlParts(requestedUrlParts),
     decodeUrlParts(splitUrlInParts(getUrlWithoutEmbedParams(selfLink))),
   );
 };
@@ -200,7 +200,7 @@ export class DspaceRestResponseParsingService implements ResponseParsingService 
         const actual = splitUrlInParts(selfLink);
         if (expected[0] === actual[0] && urlPartsDiffer(expected, actual)) {
           // the self link is normalized either way, only the warning is filtered
-          if (isUnexpectedSelfLink(urlWithoutEmbedParams, selfLink)) {
+          if (isUnexpectedSelfLink(expected, selfLink)) {
             console.warn(`The response for '${urlWithoutEmbedParams}' has the self link '${selfLink}'. These don't match. This could mean there's an issue with the REST endpoint`);
           }
           response.payload._links = Object.assign({}, response.payload._links, {

--- a/src/app/core/data/dspace-rest-response-parsing.service.ts
+++ b/src/app/core/data/dspace-rest-response-parsing.service.ts
@@ -63,11 +63,6 @@ const urlPartsDiffer = (expected: string[], actual: string[]): boolean => {
 };
 
 /**
- * Matches a page size query param, e.g. `size=100`
- */
-const PAGE_SIZE_PARAM = /^size=(\d+)$/;
-
-/**
  * Percent decode each url part, so `uri=http%3A%2F%2Fx` and `uri=http://x` compare equal. Parts are
  * decoded one by one, after the url was split, so a decoded `&` can't merge two params.
  */
@@ -82,46 +77,20 @@ const decodeUrlParts = (parts: string[]): string[] => {
 };
 
 /**
- * Return the page sizes among the given url parts. More than one means the url is ambiguous
- */
-const getPageSizes = (parts: string[]): number[] => {
-  return parts
-    .map((part: string) => part.match(PAGE_SIZE_PARAM))
-    .filter((matches) => hasValue(matches))
-    .map((matches) => Number(matches[1]));
-};
-
-/**
- * Return true if the self link only shrank the page size to a value the response confirms itself.
+ * Return true if the self link differs from the requested url in a way that isn't just a different
+ * way of writing the same request.
  *
- * The REST API silently resets a `size` over its configured maximum. The frontend can't know that
- * maximum, so it requires the `page` block to corroborate the smaller size, and reports a self link
- * that contradicts the payload it describes. Zero is never a maximum, so an empty page isn't a
- * clamp either.
+ * Both sides are brought to the same form first: `embed`/`embed.size` params are stripped, because
+ * the frontend treats them as not part of a resource's identity and indexes without them, and both
+ * are percent decoded. Anything still differing is a real difference between what was asked for and
+ * what came back, including a page size the API reduced — callers are expected to stay within
+ * `MAX_PAGE_SIZE` rather than have that reported difference filtered out here.
  */
-const isReducedPageSize = (expected: string[], actual: string[], payload: any): boolean => {
-  const requestedSizes = getPageSizes(expected);
-  const effectiveSizes = getPageSizes(actual);
-  return requestedSizes.length === 1 && effectiveSizes.length === 1
-    && effectiveSizes[0] > 0 && effectiveSizes[0] < requestedSizes[0]
-    && hasValue(payload.page) && payload.page.size === effectiveSizes[0];
-};
-
-/**
- * Return true if the self link differs from the requested url in a way the REST API isn't expected
- * to introduce by itself. Not reported: `embed` params the API echoes back (they are stripped from
- * the requested url but not from the self link), percent encoding, and a confirmed page size clamp.
- */
-const isUnexpectedSelfLink = (requestedUrl: string, selfLink: string, payload: any): boolean => {
-  const expected = decodeUrlParts(splitUrlInParts(requestedUrl));
-  const actual = decodeUrlParts(splitUrlInParts(getUrlWithoutEmbedParams(selfLink)));
-
-  if (isReducedPageSize(expected, actual, payload)) {
-    const withoutPageSize = (parts: string[]): string[] =>
-      parts.filter((part: string) => !PAGE_SIZE_PARAM.test(part));
-    return urlPartsDiffer(withoutPageSize(expected), withoutPageSize(actual));
-  }
-  return urlPartsDiffer(expected, actual);
+const isUnexpectedSelfLink = (requestedUrl: string, selfLink: string): boolean => {
+  return urlPartsDiffer(
+    decodeUrlParts(splitUrlInParts(requestedUrl)),
+    decodeUrlParts(splitUrlInParts(getUrlWithoutEmbedParams(selfLink))),
+  );
 };
 
 @Injectable({ providedIn: 'root' })
@@ -231,7 +200,7 @@ export class DspaceRestResponseParsingService implements ResponseParsingService 
         const actual = splitUrlInParts(selfLink);
         if (expected[0] === actual[0] && urlPartsDiffer(expected, actual)) {
           // the self link is normalized either way, only the warning is filtered
-          if (isUnexpectedSelfLink(urlWithoutEmbedParams, selfLink, response.payload)) {
+          if (isUnexpectedSelfLink(urlWithoutEmbedParams, selfLink)) {
             console.warn(`The response for '${urlWithoutEmbedParams}' has the self link '${selfLink}'. These don't match. This could mean there's an issue with the REST endpoint`);
           }
           response.payload._links = Object.assign({}, response.payload._links, {

--- a/src/app/core/data/dspace-rest-response-parsing.service.ts
+++ b/src/app/core/data/dspace-rest-response-parsing.service.ts
@@ -55,12 +55,7 @@ const splitUrlInParts = (url: string): string[] => {
 };
 
 /**
- * Return true if two lists of url parts don't hold the same set of parts. The comparison is order
- * insensitive, and — like {@link splitUrlInParts} — treats the part in front of the query string as
- * just another part.
- *
- * @param expected the parts of the url we expected
- * @param actual   the parts of the url we got
+ * Return true if two lists of url parts don't hold the same parts, ignoring their order
  */
 const urlPartsDiffer = (expected: string[], actual: string[]): boolean => {
   return expected.some((part: string) => !actual.includes(part))
@@ -73,10 +68,21 @@ const urlPartsDiffer = (expected: string[], actual: string[]): boolean => {
 const PAGE_SIZE_PARAM = /^size=(\d+)$/;
 
 /**
- * Return the page sizes among the given url parts. More than one means the url is ambiguous about
- * the page size, and no conclusion can be drawn from it.
- *
- * @param parts the url parts, as returned by {@link splitUrlInParts}
+ * Percent decode each url part, so `uri=http%3A%2F%2Fx` and `uri=http://x` compare equal. Parts are
+ * decoded one by one, after the url was split, so a decoded `&` can't merge two params.
+ */
+const decodeUrlParts = (parts: string[]): string[] => {
+  return parts.map((part: string) => {
+    try {
+      return decodeURIComponent(part);
+    } catch (e) {
+      return part;
+    }
+  });
+};
+
+/**
+ * Return the page sizes among the given url parts. More than one means the url is ambiguous
  */
 const getPageSizes = (parts: string[]): number[] => {
   return parts
@@ -86,53 +92,29 @@ const getPageSizes = (parts: string[]): number[] => {
 };
 
 /**
- * Return true if the requested url and the self link disagree about the page size only because the
- * REST API reduced a size it wasn't willing to serve.
+ * Return true if the self link only shrank the page size to a value the response confirms itself.
  *
- * The REST contract says a `size` over the configured maximum is "automatically reset to the
- * maximum allowed value, no error is thrown", and it is that effective size which ends up in the
- * self link. The frontend can't know the server's maximum, so it can't tell such a clamp apart from
- * any other reduction — but it can require the response to be consistent with itself: the `page`
- * block has to confirm the smaller size the self link advertises. A self link that contradicts the
- * payload it describes is still reported.
- *
- * @param expected the requested url parts, without embed params
- * @param actual   the self link parts, without embed params
- * @param payload  the response body the self link belongs to
+ * The REST API silently resets a `size` over its configured maximum. The frontend can't know that
+ * maximum, so it requires the `page` block to corroborate the smaller size, and reports a self link
+ * that contradicts the payload it describes. Zero is never a maximum, so an empty page isn't a
+ * clamp either.
  */
 const isReducedPageSize = (expected: string[], actual: string[], payload: any): boolean => {
   const requestedSizes = getPageSizes(expected);
   const effectiveSizes = getPageSizes(actual);
   return requestedSizes.length === 1 && effectiveSizes.length === 1
-    // a maximum page size is never zero, so an empty page isn't a clamp and stays reportable
     && effectiveSizes[0] > 0 && effectiveSizes[0] < requestedSizes[0]
     && hasValue(payload.page) && payload.page.size === effectiveSizes[0];
 };
 
 /**
- * Determine whether the difference between the url that was requested and the self link the REST
- * API returned for it points at an actual problem with the endpoint.
- *
- * Two kinds of difference are correct REST behaviour and are not reported:
- *
- * - The REST API echoes the request's `embed`/`embed.size` params in the self link, while the url
- *   we compare against has had them stripped by {@link getUrlWithoutEmbedParams}. Comparing the two
- *   as-is makes every request that embeds a subresource look broken, e.g.
- *   `…/bitstreams?page=0&size=5` vs `…/bitstreams?page=0&embed=accessStatus&size=5`. Stripping both
- *   sides also means a self link echoing embeds we never asked for goes unreported.
- * - The REST API reduced the requested page size, see {@link isReducedPageSize}.
- *
- * Note that {@link getUrlWithoutEmbedParams} rebuilds the url it is given, so running the self link
- * through it also drops a fragment and a trailing slash on the path. Differences limited to those
- * stop being reported too.
- *
- * @param requestedUrl the url that was requested, without embed params
- * @param selfLink     the self link as returned by the REST API
- * @param payload      the response body the self link belongs to
+ * Return true if the self link differs from the requested url in a way the REST API isn't expected
+ * to introduce by itself. Not reported: `embed` params the API echoes back (they are stripped from
+ * the requested url but not from the self link), percent encoding, and a confirmed page size clamp.
  */
 const isUnexpectedSelfLink = (requestedUrl: string, selfLink: string, payload: any): boolean => {
-  const expected = splitUrlInParts(requestedUrl);
-  const actual = splitUrlInParts(getUrlWithoutEmbedParams(selfLink));
+  const expected = decodeUrlParts(splitUrlInParts(requestedUrl));
+  const actual = decodeUrlParts(splitUrlInParts(getUrlWithoutEmbedParams(selfLink)));
 
   if (isReducedPageSize(expected, actual, payload)) {
     const withoutPageSize = (parts: string[]): string[] =>
@@ -248,8 +230,7 @@ export class DspaceRestResponseParsingService implements ResponseParsingService 
         const expected = splitUrlInParts(urlWithoutEmbedParams);
         const actual = splitUrlInParts(selfLink);
         if (expected[0] === actual[0] && urlPartsDiffer(expected, actual)) {
-          // Report only the differences the REST API isn't expected to introduce by itself. Which
-          // url the self link is normalized to is deliberately left unchanged by this check.
+          // the self link is normalized either way, only the warning is filtered
           if (isUnexpectedSelfLink(urlWithoutEmbedParams, selfLink, response.payload)) {
             console.warn(`The response for '${urlWithoutEmbedParams}' has the self link '${selfLink}'. These don't match. This could mean there's an issue with the REST endpoint`);
           }

--- a/src/app/core/data/dspace-rest-response-parsing.service.ts
+++ b/src/app/core/data/dspace-rest-response-parsing.service.ts
@@ -104,8 +104,9 @@ const isReducedPageSize = (expected: string[], actual: string[], payload: any): 
   const requestedSizes = getPageSizes(expected);
   const effectiveSizes = getPageSizes(actual);
   return requestedSizes.length === 1 && effectiveSizes.length === 1
-    && effectiveSizes[0] < requestedSizes[0]
-    && hasValue(payload) && hasValue(payload.page) && payload.page.size === effectiveSizes[0];
+    // a maximum page size is never zero, so an empty page isn't a clamp and stays reportable
+    && effectiveSizes[0] > 0 && effectiveSizes[0] < requestedSizes[0]
+    && hasValue(payload.page) && payload.page.size === effectiveSizes[0];
 };
 
 /**
@@ -120,6 +121,10 @@ const isReducedPageSize = (expected: string[], actual: string[], payload: any): 
  *   `…/bitstreams?page=0&size=5` vs `…/bitstreams?page=0&embed=accessStatus&size=5`. Stripping both
  *   sides also means a self link echoing embeds we never asked for goes unreported.
  * - The REST API reduced the requested page size, see {@link isReducedPageSize}.
+ *
+ * Note that {@link getUrlWithoutEmbedParams} rebuilds the url it is given, so running the self link
+ * through it also drops a fragment and a trailing slash on the path. Differences limited to those
+ * stop being reported too.
  *
  * @param requestedUrl the url that was requested, without embed params
  * @param selfLink     the self link as returned by the REST API

--- a/src/app/core/data/find-list-options.model.ts
+++ b/src/app/core/data/find-list-options.model.ts
@@ -2,6 +2,16 @@ import { SortOptions } from '../cache/models/sort-options.model';
 import { RequestParam } from '../cache/models/request-param.model';
 
 /**
+ * The largest page the REST API will serve. Asking for more is not an error: the API silently
+ * reduces the size to this maximum, so a bigger number returns the exact same page while making the
+ * request claim something the API never honours.
+ *
+ * The limit is Spring Data REST's `spring.data.rest.max-page-size`, which DSpace leaves at its
+ * default. Use this instead of an arbitrary large number when a caller needs "everything".
+ */
+export const MAX_PAGE_SIZE = 1000;
+
+/**
  * The options for a find list request
  */
 export class FindListOptions {

--- a/src/app/core/registry/registry.service.ts
+++ b/src/app/core/registry/registry.service.ts
@@ -30,7 +30,7 @@ import { MetadataBitstreamDataService } from '../data/metadata-bitstream-data.se
 import { FollowLinkConfig } from '../../shared/utils/follow-link-config.model';
 import { RequestParam } from '../cache/models/request-param.model';
 import { NoContent } from '../shared/NoContent.model';
-import { FindListOptions } from '../data/find-list-options.model';
+import { FindListOptions, MAX_PAGE_SIZE } from '../data/find-list-options.model';
 import { MetadataBitstream } from '../metadata/metadata-bitstream.model';
 
 const metadataRegistryStateSelector = (state: AppState) => state.metadataRegistry;
@@ -81,7 +81,7 @@ export class RegistryService {
   public getMetadataSchemaByPrefix(prefix: string, useCachedVersionIfAvailable = true, reRequestOnStale = true, ...linksToFollow: FollowLinkConfig<MetadataSchema>[]): Observable<RemoteData<MetadataSchema>> {
     // Temporary options to get ALL metadataschemas until there's a rest api endpoint for fetching a specific schema
     const options: FindListOptions = Object.assign(new FindListOptions(), {
-      elementsPerPage: 10000
+      elementsPerPage: MAX_PAGE_SIZE
     });
     return this.getMetadataSchemas(options).pipe(
       getFirstSucceededRemoteDataPayload(),

--- a/src/app/core/statistics/usage-report-data.service.ts
+++ b/src/app/core/statistics/usage-report-data.service.ts
@@ -46,8 +46,7 @@ export class UsageReportDataService extends IdentifiableDataService<UsageReport>
   searchStatistics(uri: string, page: number, size: number): Observable<UsageReport[]> {
     return this.searchBy('object', {
       searchParams: [
-        // TODO fix encode the uri parameter in the self link in the backend and set encodeValue to true afterwards
-        new RequestParam('uri', uri, false),
+        new RequestParam('uri', uri),
       ],
       currentPage: page,
       elementsPerPage: size,

--- a/src/app/core/statistics/usage-report-data.service.ts
+++ b/src/app/core/statistics/usage-report-data.service.ts
@@ -46,7 +46,8 @@ export class UsageReportDataService extends IdentifiableDataService<UsageReport>
   searchStatistics(uri: string, page: number, size: number): Observable<UsageReport[]> {
     return this.searchBy('object', {
       searchParams: [
-        new RequestParam('uri', uri),
+        // TODO fix encode the uri parameter in the self link in the backend and set encodeValue to true afterwards
+        new RequestParam('uri', uri, false),
       ],
       currentPage: page,
       elementsPerPage: size,

--- a/src/app/item-page/edit-item-page/item-bitstreams/item-bitstreams.service.ts
+++ b/src/app/item-page/edit-item-page/item-bitstreams/item-bitstreams.service.ts
@@ -24,6 +24,7 @@ import { MoveOperation } from 'fast-json-patch';
 import { BundleDataService } from '../../../core/data/bundle-data.service';
 import { RequestService } from '../../../core/data/request.service';
 import { LiveRegionService } from '../../../shared/live-region/live-region.service';
+import { MAX_PAGE_SIZE } from '../../../core/data/find-list-options.model';
 
 export const MOVE_KEY = 'item.edit.bitstreams.notifications.move';
 
@@ -344,7 +345,7 @@ export class ItemBitstreamsService {
     return Object.assign(new PaginationComponentOptions(), {
       id: 'bundles-pagination-options',
       currentPage: 1,
-      pageSize: 9999
+      pageSize: MAX_PAGE_SIZE
     });
   }
 

--- a/src/app/item-page/edit-item-page/item-license-mapper/item-license-mapper.component.ts
+++ b/src/app/item-page/edit-item-page/item-license-mapper/item-license-mapper.component.ts
@@ -8,7 +8,7 @@ import { ClarinLicenseDataService } from '../../../core/data/clarin/clarin-licen
 import { getFirstCompletedRemoteData, getFirstSucceededRemoteListPayload } from '../../../core/shared/operators';
 import { PaginatedList } from '../../../core/data/paginated-list.model';
 import { ClarinLicense } from '../../../core/shared/clarin/clarin-license.model';
-import { FindListOptions } from '../../../core/data/find-list-options.model';
+import { FindListOptions, MAX_PAGE_SIZE } from '../../../core/data/find-list-options.model';
 import { PutRequest } from '../../../core/data/request.models';
 import { HALEndpointService } from '../../../core/shared/hal-endpoint.service';
 import { RequestService } from '../../../core/data/request.service';
@@ -90,7 +90,7 @@ export class ItemLicenseMapperComponent implements OnInit {
       const options = new FindListOptions();
       options.currentPage = 0;
       // Load all licenses
-      options.elementsPerPage = 1000;
+      options.elementsPerPage = MAX_PAGE_SIZE;
 
       this.clarinLicenseService.findAll(options, false)
         .pipe(

--- a/src/app/item-page/simple/field-components/clarin-item-versions-field/clarin-item-versions-field.component.ts
+++ b/src/app/item-page/simple/field-components/clarin-item-versions-field/clarin-item-versions-field.component.ts
@@ -5,6 +5,7 @@ import { ItemVersionsComponent } from '../../../versions/item-versions.component
 import { Item } from '../../../../core/shared/item.model';
 import { Version } from '../../../../core/shared/version.model';
 import { RemoteData } from '../../../../core/data/remote-data';
+import { MAX_PAGE_SIZE } from '../../../../core/data/find-list-options.model';
 
 /**
  * Local type definition matching the parent component's VersionsDTO structure
@@ -43,7 +44,7 @@ export class ClarinItemVersionsFieldComponent extends ItemVersionsComponent impl
   /**
    * Maximum number of versions to fetch at once for the dropdown display.
    */
-  private readonly MAX_VERSIONS_TO_DISPLAY = 9999;
+  private readonly MAX_VERSIONS_TO_DISPLAY = MAX_PAGE_SIZE;
 
   /**
    * Icon name for the clarin field

--- a/src/app/shared/clarin-item-box-view/clarin-item-box-view.component.ts
+++ b/src/app/shared/clarin-item-box-view/clarin-item-box-view.component.ts
@@ -29,7 +29,7 @@ import { ListableObject } from '../object-collection/shared/listable-object.mode
 import { ItemSearchResult } from '../object-collection/shared/item-search-result.model';
 import { getItemPageRoute } from '../../item-page/item-page-routing-paths';
 import { metadataLangToBcp47 } from '../utils/metadata-language.util';
-import { FindListOptions } from '../../core/data/find-list-options.model';
+import { FindListOptions, MAX_PAGE_SIZE } from '../../core/data/find-list-options.model';
 import { ClarinDateService } from '../clarin-date.service';
 import { AUTHOR_METADATA_FIELDS } from '../../core/shared/clarin/constants';
 import {RequestParam} from '../../core/cache/models/request-param.model';
@@ -181,7 +181,7 @@ export class ClarinItemBoxViewComponent implements OnInit {
       return;
     }
     const configAllElements: FindListOptions = Object.assign(new FindListOptions(), {
-      elementsPerPage: 9999
+      elementsPerPage: MAX_PAGE_SIZE
     });
 
     this.bundleService.findByItemAndName(this.item, 'ORIGINAL', true, true,

--- a/src/app/submission/sections/clarin-license-resource/section-license.component.ts
+++ b/src/app/submission/sections/clarin-license-resource/section-license.component.ts
@@ -35,6 +35,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { FindListOptions } from 'src/app/core/data/find-list-options.model';
 import { hasFailed } from 'src/app/core/data/request-entry-state.model';
 import {RequestParam} from '../../../core/cache/models/request-param.model';
+import { MAX_PAGE_SIZE } from '../../../core/data/find-list-options.model';
 
 /**
  * This component render resource license step in the submission workflow.
@@ -551,7 +552,7 @@ export class SubmissionSectionClarinLicenseComponent extends SectionModelCompone
     const options = new FindListOptions();
     options.currentPage = 0;
     // Load all licenses
-    options.elementsPerPage = 1000;
+    options.elementsPerPage = MAX_PAGE_SIZE;
     return this.clarinLicenseService.findAll(options, false)
       .pipe(getFirstSucceededRemoteListPayload())
       .toPromise();

--- a/src/app/submission/sections/clarin-license-resource/section-license.component.ts
+++ b/src/app/submission/sections/clarin-license-resource/section-license.component.ts
@@ -32,10 +32,9 @@ import { ItemDataService } from '../../../core/data/item-data.service';
 import { Item } from '../../../core/shared/item.model';
 import { MetadataValue } from '../../../core/shared/metadata.models';
 import { TranslateService } from '@ngx-translate/core';
-import { FindListOptions } from 'src/app/core/data/find-list-options.model';
+import { FindListOptions, MAX_PAGE_SIZE } from 'src/app/core/data/find-list-options.model';
 import { hasFailed } from 'src/app/core/data/request-entry-state.model';
 import {RequestParam} from '../../../core/cache/models/request-param.model';
-import { MAX_PAGE_SIZE } from '../../../core/data/find-list-options.model';
 
 /**
  * This component render resource license step in the submission workflow.


### PR DESCRIPTION
## References

* Fixes dataquest-dev/dspace-customers#862
* Upstream: DSpace/DSpace issue 8577 (open since 2022, no PR ever opened), dspace-angular issue 2513 / PR 3694
* No REST API PR required — no endpoint or response changes

## Description

`ensureSelfLink()` floods the console with "…has the self link… These don't match" warnings. Three
causes: once the frontend asks for a page size the API can't serve (fixed at the source), twice the
comparison treats two spellings of the same url as a difference (fixed there).

## Instructions for Reviewers

List of changes in this PR:

* Added `MAX_PAGE_SIZE` (1000) next to `FindListOptions` and used it instead of `9999`/`10000` in ten
  call sites. The REST API already capped these at 1000, so the data returned is identical — only the
  request stops claiming something the API never honours. This is upstream #2513, whose fix (#3694)
  missed `BundleDataService.findByItemAndName`.
* `ensureSelfLink` now strips `embed` params and percent-decodes **both** sides before comparing.
  Those are two ways of writing the same request; a difference in a real value still warns. This also
  removes the need for the `encodeValue=false` workaround the frontend carries for `uri` params: the
  backend does not decode self links, it re-encodes values minimally, and `:` and `/` are legal in a
  query per RFC 3986 — `encodeURIComponent` simply encodes more than it has to.
* New `dspace-rest-response-parsing.service.spec.ts` (17 cases) — this service had no spec at all,
  here or upstream.

**How to test:** open an item page, the home page and `/browse/title` with DevTools open. On
`dtq-dev` each logs a self-link warning; on this branch none do. Measured on the same item against a
local DSpace 9.1: **3 warnings → 0**. Full suite 5484 passing.

## Checklist

- [ ] My PR is **created against the `main` branch** of code — no: fork PR, base is `dtq-dev`. A
  patch for the upstream-only files, rebased on vanilla `main`, is prepared separately.
- [x] My PR is **small in size** (14 files, +310/-19).
- [x] My PR **follows all coding best practices** based on the Code Conventions Guide.
- [x] My PR **passes ESLint** validation using `yarn lint`.
- [x] My PR **doesn't introduce circular dependencies** (verified with `madge`; the
  `check-circ-deps` script itself can't run on Windows — pre-existing quoting bug).
- [x] My PR **includes TypeDoc comments** for all new (or modified) public methods and classes.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests**.
- [x] My PR **aligns with Accessibility guidelines** — no UI changes.
- [x] My PR **uses i18n keys** instead of hardcoded English text — no user-facing text added.
- [x] If my PR includes new libraries/dependencies — none.
- [x] If my PR includes new features or configurations — `MAX_PAGE_SIZE` is documented at its definition.
- [x] If my PR fixes an issue ticket, I've linked them together.
