### PR TITLE
JCU/fix(i18n-cs): drop unresolvable {{ collection }} from browse.title

### DIFF
--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -1691,8 +1691,7 @@
   "browse.taxonomy.button": "Procházet",
 
   // "browse.title": "Browsing by {{ field }}{{ startsWith }} {{ value }}",
-  // TODO Source message changed - Revise the translation
-  "browse.title": "Procházet {{ collection }} podle {{ field }}{{ startsWith }} {{ value }}",
+  "browse.title": "Procházet podle {{ field }}{{ startsWith }} {{ value }}",
 
   // "browse.taxonomy.show_next_results": "Show next results",
   // TODO New key - Add a translation


### PR DESCRIPTION
Fixes the first item reported in dataquest-dev/dspace-customers#853.

## Problem

On the Czech UI, `/browse/srsc?startsWith=deferred%20tax` renders the placeholder literally:

> Procházet **{{ collection }}** podle Subject Category

Reproduced on the JCU test instance (`dev-6.pc:8593`, Czech UI) and visible in the reporter's
production screenshot in the issue.

## Cause

The Czech translation of `browse.title` carries a `{{ collection }}` interpolation parameter that
the English source message does not have:

```
en.json5  "browse.title": "Browsing by {{ field }}{{ startsWith }} {{ value }}"
cs.json5  "browse.title": "Procházet {{ collection }} podle {{ field }}{{ startsWith }} {{ value }}"
```

Neither call site passes such a parameter — both pass exactly `field`, `startsWith`, `value`:

- `src/app/browse-by/browse-by-metadata/browse-by-metadata.component.html`
- `src/app/browse-by/browse-by-taxonomy/browse-by-taxonomy.component.html` (this is `/browse/srsc`)

ngx-translate leaves an unmatched parameter untouched, so the user sees the raw `{{ collection }}`.

The key was already flagged in `cs.json5` with `// TODO Source message changed - Revise the
translation`: upstream dropped `{{ collection }}` from the English message, and the Czech
translation was never revised. It is revised now, so the TODO marker goes too.

## Fix

One line in `src/assets/i18n/cs.json5`:

```diff
- // TODO Source message changed - Revise the translation
- "browse.title": "Procházet {{ collection }} podle {{ field }}{{ startsWith }} {{ value }}",
+ "browse.title": "Procházet podle {{ field }}{{ startsWith }} {{ value }}",
```

The wording now matches the neighbouring `browse.title.page` key, which already reads
`"Procházet podle {{ field }} {{ value }}"`.

## Whole-bundle audit

Rather than fix only the reported key, every key in `cs.json5` was compared against `en.json5` for
interpolation mismatches (placeholders present in one and not the other). `browse.title` was the
only user-visible offender. Two further findings are **deliberately left alone**:

| Key | Finding | Why not fixed here |
|---|---|---|
| `admin.access-control.epeople.notification.deleted.failure` | CS uses `{{name}}`, EN uses `{{id}}`/`{{statusCode}}`/`{{restResponse.errorMessage}}` | The key is **orphaned** — no component renders it. `epeople-registry.component.ts:251` mistakenly reuses `notification.deleted.success` for the error branch. That is a separate upstream FE bug, not a translation bug. |
| `deny-request-copy.email.message` | CS drops `{{ recipientName }}`, so the outgoing email has no salutation | Restoring it means choosing Czech wording with gender agreement on a person's name. That is a content decision for JCU, not a rendering defect. |

## Verification

Same page, same locale, before and after.


**Before** — JCU test instance `dev-6.pc:8593`, Czech UI
<img width="1280" height="720" alt="B1-1-before-dev6-cs-browse-srsc" src="https://github.com/user-attachments/assets/5796fa79-11d8-4bc1-9e83-60ae4f24690b" />
**Before** — local UI on this branch's parent (`customer/jcu`)
<img width="1440" height="900" alt="B1-2-before-local-cs-browse-srsc" src="https://github.com/user-attachments/assets/767d483c-8fda-43c1-81ec-069aa2494b54" />
**After** — local UI on this branch
<img width="1440" height="900" alt="B1-3-after-local-cs-browse-srsc" src="https://github.com/user-attachments/assets/21572f15-9ea6-47db-abde-d66850ba75f2" />

<!-- reviewer: the three PNGs above are attached as comments on this PR -->

Note that `Subject Category` in the heading stays English in the "after" shot. That is a **different**
untranslated key (`browse.metadata.srsc`) tracked separately as M5 in the #853 checklist, and is
intentionally out of scope here.

Also checked in the same locale, before and after: `/browse/subject`, `/browse/title`,
`/browse/author`, `/browse/dateissued` — no other browse heading regressed, and the English UI is
untouched (only `cs.json5` changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
