### PR TITLE
JCU/fix(i18n): label the applied MyDSpace "Status" filter properly

### DIFF
--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -7333,10 +7333,6 @@
   // "search.filters.namedresourcetype.Workspace": "Workspace",
   "search.filters.namedresourcetype.Workspace": "Workspace",
 
-  // Stejné hodnoty klíčované podle authority key - viz komentář v en.json5.
-  // Fasetový seznam používá zobrazovanou hodnotu ("Archived"), zatímco už
-  // aplikovaný filtr (odznak nad výsledky i zaškrtnuté políčko) přichází
-  // z REST API pod svým authority key ("item").
   // "search.filters.namedresourcetype.item": "Archived",
   "search.filters.namedresourcetype.item": "Archivováno",
 

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -7333,6 +7333,25 @@
   // "search.filters.namedresourcetype.Workspace": "Workspace",
   "search.filters.namedresourcetype.Workspace": "Workspace",
 
+  // Stejné hodnoty klíčované podle authority key - viz komentář v en.json5.
+  // Fasetový seznam používá zobrazovanou hodnotu ("Archived"), zatímco už
+  // aplikovaný filtr (odznak nad výsledky i zaškrtnuté políčko) přichází
+  // z REST API pod svým authority key ("item").
+  // "search.filters.namedresourcetype.item": "Archived",
+  "search.filters.namedresourcetype.item": "Archivováno",
+
+  // "search.filters.namedresourcetype.validation": "Validation",
+  "search.filters.namedresourcetype.validation": "Ověřování",
+
+  // "search.filters.namedresourcetype.waitingforcontroller": "Waiting for reviewer",
+  "search.filters.namedresourcetype.waitingforcontroller": "Čeká na kontrolu",
+
+  // "search.filters.namedresourcetype.workflow": "Workflow",
+  "search.filters.namedresourcetype.workflow": "Workflow",
+
+  // "search.filters.namedresourcetype.workspace": "Workspace",
+  "search.filters.namedresourcetype.workspace": "Workspace",
+
   // "search.filters.withdrawn.true": "Yes",
   "search.filters.withdrawn.true": "Ano",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -4870,14 +4870,6 @@
 
   "search.filters.namedresourcetype.Workspace": "Workspace",
 
-  // The MyDSpace "Status" facet is an authority facet: the facet list is keyed by
-  // the Solr display value ("Archived"), but once the filter is applied the REST
-  // API reports it by its authority key ("item") instead - see
-  // discovery.cfg:discovery.facet.namedtype.* ("Archived###item") and
-  // SearchFilterToAppliedFilterConverter, which cannot resolve a label for a
-  // non-SOLRAuthority facet (upstream FIXME / DS-4209). The applied-filter chip
-  // and the checked checkbox therefore need the same labels keyed by authority
-  // key, otherwise they fall back to the raw value.
   "search.filters.namedresourcetype.item": "Archived",
 
   "search.filters.namedresourcetype.validation": "Validation",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -4870,6 +4870,24 @@
 
   "search.filters.namedresourcetype.Workspace": "Workspace",
 
+  // The MyDSpace "Status" facet is an authority facet: the facet list is keyed by
+  // the Solr display value ("Archived"), but once the filter is applied the REST
+  // API reports it by its authority key ("item") instead - see
+  // discovery.cfg:discovery.facet.namedtype.* ("Archived###item") and
+  // SearchFilterToAppliedFilterConverter, which cannot resolve a label for a
+  // non-SOLRAuthority facet (upstream FIXME / DS-4209). The applied-filter chip
+  // and the checked checkbox therefore need the same labels keyed by authority
+  // key, otherwise they fall back to the raw value.
+  "search.filters.namedresourcetype.item": "Archived",
+
+  "search.filters.namedresourcetype.validation": "Validation",
+
+  "search.filters.namedresourcetype.waitingforcontroller": "Waiting for reviewer",
+
+  "search.filters.namedresourcetype.workflow": "Workflow",
+
+  "search.filters.namedresourcetype.workspace": "Workspace",
+
   "search.filters.withdrawn.true": "Yes",
 
   "search.filters.withdrawn.false": "No",


### PR DESCRIPTION
Fixes the third item reported in dataquest-dev/dspace-customers#853 ("after clicking on archived").

## Problem

In MyDSpace the **Status** facet lists `Archived`. Click it, and the label changes:

- the applied-filter badge above the results reads **`Status: Item`**
- the now-checked checkbox in the facet reads **`item`** (lower case)

The result set is correct; only the labelling is wrong. But the user clicks "Archived" and ends up
looking at a filter called "Item", which reads like the wrong filter got applied.

Reproduced on a local DSpace 9.3 stack built from `customer/jcu`, with one archived submission —
the same shape as the reporter's screenshot (facet count 1).

## Cause

`namedresourcetype` is an *authority* facet, so two different strings identify the same entry, and
the UI uses each of them in a different place.

The backend indexes both halves (`dspace/config/modules/discovery.cfg`):

```
discovery.facet.namedtype.item = 000item\n|||\nArchived###item
                                              ^display  ^authority key
```

REST returns the display half as `label` and filters by the authority half. Verified against JCU's
own 9.3 test instance (`dev-6.pc:8593`), `/discover/facets/namedresourcetype` with the filter
applied:

```json
"_embedded": { "values": [ { "label": "Workspace", "authorityKey": "workspace" } ] },
"appliedFilters": [ { "filter": "namedresourcetype", "operator": "authority",
                      "value": "workspace", "label": "workspace" } ]
```

Note `appliedFilters[].label` is the **authority key**, not the display label. Three render sites,
three different sources:

| Render site | Key it looks up | Resolves to |
|---|---|---|
| `search-facet-option` (unselected entry) | `search.filters.namedresourcetype.` + `FacetValue.value` | `FacetValue.value` is `@autoserializeAs(String, 'label')`, i.e. the REST **label** → `….Archived` ✅ |
| `search-label` (applied badge) | `…` + `AppliedFilter.label` | `item` ❌ |
| `search-facet-selected-option` (checked box) | `…` + `AppliedFilter.value` | `item` ❌ |

`AppliedFilter` carries the authority key because `SearchFilterToAppliedFilterConverter` falls back
to the raw filter value whenever it cannot resolve an `AuthorityValue`:

```java
authorityValue = authorityValueService.findByUID(context, searchFilter.getValue());
...
if (authorityValue == null) {
    appliedFilter = new SearchResultsRest.AppliedFilter(name, operator,
                                                        searchFilter.getValue(),   // value
                                                        searchFilter.getValue());  // label
}
```

and it never can for `namedresourcetype`, because `AuthorityValueService` only knows SOLRAuthority
values. The method carries an upstream `FIXME` saying exactly this (DS-4209).

So the badge and the checked checkbox look up `search.filters.namedresourcetype.item`, find no such
key, and fall back to printing the raw value. The badge's `text-capitalize` class then renders
`item` as `Item`.

## Fix

The existing keys are keyed by display value (`.Archived`, `.Workspace`, …). This adds the same five
labels keyed by **authority key** as well, in both `cs.json5` and `en.json5`, so all three render
sites resolve:

```
search.filters.namedresourcetype.item                 = Archived / Archivováno
search.filters.namedresourcetype.workspace            = Workspace / Workspace
search.filters.namedresourcetype.workflow             = Workflow / Workflow
search.filters.namedresourcetype.validation           = Validation / Ověřování
search.filters.namedresourcetype.waitingforcontroller = Waiting for reviewer / Čeká na kontrolu
```

i18n-only: no code change, no REST contract change. A comment in `en.json5` explains why the two key
spellings coexist, so nobody "cleans up" the apparent duplication later.

**All five statuses were affected**, not just this one — `item` → `Archived` was simply the most
visible, because it is the only authority key that bears no resemblance to its label. The others
differ only in capitalisation, which `text-capitalize` disguised on the badge.

### Why not fix it in the backend instead

Making `SearchFilterToAppliedFilterConverter` resolve display labels for authority facets is the
real fix, but it changes the REST payload for every authority facet and needs the
authority-resolution rework DS-4209 describes. That is not something to carry as a customer patch.
The i18n aliases are contained, reviewable, and survive a rebase onto upstream.

## Verification

Local DSpace 9.3 backend built from `customer/jcu` + this frontend, one archived submission.
Screenshots taken on `customer/jcu` and then on this branch, same URL, nothing else changed.

**Before** — facet list before clicking (`Archivováno`)
<img width="1440" height="900" alt="B3-1-before-facet-list-archivovano" src="https://github.com/user-attachments/assets/a46e0ffd-12f0-4610-86a2-1a929c4c8b14" />
**Before** — after clicking: badge `Status: item`, checkbox `item`
<img width="1440" height="900" alt="B3-2-before-applied-item" src="https://github.com/user-attachments/assets/333621d1-2440-4173-aa6e-f433eb931b82" />
**After** — Czech UI: badge and checkbox both `Archivováno`
<img width="1440" height="900" alt="B3-4-after-applied-cs-archivovano" src="https://github.com/user-attachments/assets/10c4a7e7-411c-41a8-96f6-18879c58d89e" />
**After** — English UI: badge and checkbox both `Archived`
<img width="1440" height="900" alt="B3-3-after-applied-archived-en" src="https://github.com/user-attachments/assets/e303135b-0461-4264-a16b-4f2e20de6ff9" />

Measured values from the running page, before and after:

```
before   appliedChips: ["Status: item×"]      facet checkbox: "item"
after    appliedChips: ["Status: Archivováno×"] facet checkbox: "Archivováno"   (cs)
after    appliedChips: ["Status: Archived×"]    facet checkbox: "Archived"      (en)
```

Result set is unchanged (same item, same count) — this only affects how the applied filter is
labelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
