### PR TITLE
JCU/fix(breadcrumbs): stop showing the previous page's trail while resolving

### DIFF
--- a/src/app/breadcrumbs/breadcrumbs.service.spec.ts
+++ b/src/app/breadcrumbs/breadcrumbs.service.spec.ts
@@ -41,14 +41,34 @@ describe('BreadcrumbsService', () => {
     breadcrumbConfigB = { provider: breadcrumbProvider, key: 'another.path', url: 'another.com' };
   };
 
-  const changeActivatedRoute = (newRootRoute: any) => {
+  const changeActivatedRoute = (newRootRoute: any, url = '') => {
     // update the ActivatedRoute that the service will receive
     currentRootRoute = newRootRoute;
 
-    // the pipeline of BreadcrumbsService#listenForRouteChanges needs a NavigationEnd event,
-    // but the actual payload does not matter, since ActivatedRoute is mocked too.
-    routerEventsObs.next(new NavigationEnd(0, '', ''));
+    // the pipeline of BreadcrumbsService#listenForRouteChanges needs a NavigationEnd event.
+    // Its url only matters for tests that care whether we moved to a different page, since
+    // ActivatedRoute is mocked too.
+    routerEventsObs.next(new NavigationEnd(0, url, url));
   };
+
+  /**
+   * A breadcrumb provider that only resolves once you tell it to, so a test can inspect what
+   * breadcrumbs$ holds while a page is still resolving.
+   */
+  class DeferredBreadcrumbsService implements BreadcrumbsProviderService<string> {
+    subject: Subject<Breadcrumb[]> = new Subject();
+
+    getBreadcrumbs(): Observable<Breadcrumb[]> {
+      return this.subject;
+    }
+  }
+
+  const routeWith = (config: BreadcrumbConfig<string>) => ({
+    snapshot: {
+      data: { breadcrumb: config },
+      routeConfig: { resolve: { breadcrumb: {} } },
+    },
+  });
 
   beforeEach(() => {
     initBreadcrumbs();
@@ -125,6 +145,43 @@ describe('BreadcrumbsService', () => {
 
       changeActivatedRoute(route2);
       expect(service.breadcrumbs$).toBeObservable(cold('a', { a: expectation2 }));
+    });
+
+    describe('while a newly opened page is still resolving its breadcrumbs', () => {
+      let deferred: DeferredBreadcrumbsService;
+      let emissions: Breadcrumb[][];
+
+      beforeEach(() => {
+        deferred = new DeferredBreadcrumbsService();
+        emissions = [];
+        service.breadcrumbs$.subscribe((breadcrumbs: Breadcrumb[]) => emissions.push(breadcrumbs));
+      });
+
+      it('should not keep showing the previous page\'s breadcrumbs', () => {
+        changeActivatedRoute(routeWith(breadcrumbConfigA), '/items/aaa');
+        expect(emissions[emissions.length - 1])
+          .toEqual([new Breadcrumb(breadcrumbConfigA.key, breadcrumbConfigA.url)]);
+
+        // navigate somewhere else; its provider has not resolved yet
+        changeActivatedRoute(routeWith({ provider: deferred, key: 'slow.path', url: 'slow.com' }), '/items/bbb');
+        expect(emissions[emissions.length - 1]).toEqual([]);
+
+        // once it resolves, the new page's breadcrumbs show up
+        deferred.subject.next([new Breadcrumb('slow.path', 'slow.com')]);
+        expect(emissions[emissions.length - 1]).toEqual([new Breadcrumb('slow.path', 'slow.com')]);
+      });
+
+      it('should keep the breadcrumbs when only the query params changed', () => {
+        changeActivatedRoute(routeWith(breadcrumbConfigA), '/search');
+        const resolved = [new Breadcrumb(breadcrumbConfigA.key, breadcrumbConfigA.url)];
+        expect(emissions[emissions.length - 1]).toEqual(resolved);
+        const emittedSoFar = emissions.length;
+
+        // paging/filtering on the same page must not blank the trail out
+        changeActivatedRoute(routeWith({ provider: deferred, key: 'slow.path', url: 'slow.com' }), '/search?page=2');
+        expect(emissions[emissions.length - 1]).toEqual(resolved);
+        expect(emissions.slice(emittedSoFar)).not.toContain([]);
+      });
     });
   });
 

--- a/src/app/breadcrumbs/breadcrumbs.service.spec.ts
+++ b/src/app/breadcrumbs/breadcrumbs.service.spec.ts
@@ -54,14 +54,18 @@ describe('BreadcrumbsService', () => {
   /**
    * A breadcrumb provider that only resolves once you tell it to, so a test can inspect what
    * breadcrumbs$ holds while a page is still resolving.
+   *
+   * A factory rather than a class: this file already declares TestBreadcrumbsService, and
+   * max-classes-per-file allows one.
    */
-  class DeferredBreadcrumbsService implements BreadcrumbsProviderService<string> {
-    subject: Subject<Breadcrumb[]> = new Subject();
+  const deferredBreadcrumbsProvider = (): BreadcrumbsProviderService<string> & { subject: Subject<Breadcrumb[]> } => {
+    const subject: Subject<Breadcrumb[]> = new Subject();
 
-    getBreadcrumbs(): Observable<Breadcrumb[]> {
-      return this.subject;
-    }
-  }
+    return {
+      subject,
+      getBreadcrumbs: (): Observable<Breadcrumb[]> => subject,
+    };
+  };
 
   const routeWith = (config: BreadcrumbConfig<string>) => ({
     snapshot: {
@@ -148,11 +152,11 @@ describe('BreadcrumbsService', () => {
     });
 
     describe('while a newly opened page is still resolving its breadcrumbs', () => {
-      let deferred: DeferredBreadcrumbsService;
+      let deferred: ReturnType<typeof deferredBreadcrumbsProvider>;
       let emissions: Breadcrumb[][];
 
       beforeEach(() => {
-        deferred = new DeferredBreadcrumbsService();
+        deferred = deferredBreadcrumbsProvider();
         emissions = [];
         service.breadcrumbs$.subscribe((breadcrumbs: Breadcrumb[]) => emissions.push(breadcrumbs));
       });

--- a/src/app/breadcrumbs/breadcrumbs.service.ts
+++ b/src/app/breadcrumbs/breadcrumbs.service.ts
@@ -39,6 +39,11 @@ export class BreadcrumbsService {
    */
   showBreadcrumbs$: ReplaySubject<boolean> = new ReplaySubject(1);
 
+  /**
+   * Path (without query params) of the page the current breadcrumbs belong to
+   */
+  private currentPath: string;
+
   constructor(
     private route: ActivatedRoute,
     private router: Router,
@@ -52,7 +57,7 @@ export class BreadcrumbsService {
     // supply events to this.breadcrumbs$
     this.router.events.pipe(
       filter((e): e is NavigationEnd => e instanceof NavigationEnd),
-      tap(() => this.reset()),
+      tap((event: NavigationEnd) => this.reset(event)),
       switchMap(() => this.resolveBreadcrumbs(this.route.root)),
     ).subscribe(this.breadcrumbs$);
   }
@@ -91,9 +96,26 @@ export class BreadcrumbsService {
 
   /**
    * Resets the state of the breadcrumbs
+   *
+   * The breadcrumb providers resolved below are asynchronous, so between arriving on a page and
+   * its breadcrumbs being resolved there is a gap - on a cold cache, seconds. `breadcrumbs$` is a
+   * ReplaySubject, so for the whole of that gap it keeps replaying the *previous* page's trail,
+   * and the new page renders a breadcrumb belonging to somewhere else entirely.
+   *
+   * Clearing it here means the trail is empty until the new one arrives; the component still
+   * renders the "Home" crumb on its own, so the bar keeps its height and nothing jumps.
+   *
+   * Only done when the path actually changed: paging and filtering re-emit NavigationEnd for the
+   * same page, and dropping the trail on those would make it flicker on every click.
    */
-  private reset() {
+  private reset(event?: NavigationEnd) {
     this.showBreadcrumbs$.next(true);
+
+    const path = (event?.urlAfterRedirects ?? '').split('?')[0];
+    if (path !== this.currentPath) {
+      this.currentPath = path;
+      this.breadcrumbs$.next([]);
+    }
   }
 
 }


### PR DESCRIPTION
Fixes the fourth item reported in dataquest-dev/dspace-customers#853 ("nefunguje breadcrumbs?").

## What is actually wrong

Breadcrumbs are not missing. They are **the wrong page's breadcrumbs**, for a couple of seconds
after you arrive.

That distinction matters, because it is why the report is hard to confirm: by the time you open
DevTools and look, the trail is already correct. Checked first and all fine:

- item page, direct load (production + `dev-6`) ✅ full trail
- item page, client-side navigation from `/search` ✅ full trail
- item **edit** page `/items/{uuid}/edit` (`dev-6`, logged in) ✅ full trail incl. "Edit Item"

So instead of reading the DOM after the fact, I sampled the rendered breadcrumb every 40 ms across
the exact navigation from the issue — MyDSpace → *View* on an archived item — on a cold cache:

| t | URL | breadcrumb rendered |
|---|---|---|
| 54 ms | `/mydspace` | `Home › MyDSpace` |
| 248 ms | `/items/{uuid}` | `Home › MyDSpace` ← **item page, MyDSpace trail** |
| 2935 ms | `/items/{uuid}` | `Home › Kvalifikační práce › … › {item title}` |

For ~2.7 s the item page claims to be MyDSpace. That is exactly the state the screenshot in the
issue captured.

## Cause

`BreadcrumbsService`:

```ts
this.router.events.pipe(
  filter((e): e is NavigationEnd => e instanceof NavigationEnd),
  tap(() => this.reset()),
  switchMap(() => this.resolveBreadcrumbs(this.route.root)),
).subscribe(this.breadcrumbs$);

private reset() {
  this.showBreadcrumbs$.next(true);
}
```

`breadcrumbs$` is a `ReplaySubject(1)`. `reset()` only touches `showBreadcrumbs$` — nothing clears
`breadcrumbs$`. So on navigation the subject keeps replaying the previous page's trail until the new
route's providers emit, and those providers are async REST lookups (the item, its owning collection,
its parent communities). On a warm cache that is a flash; on a cold cache, seconds; on production
with a large repository, longer still.

This code is identical in upstream `main`, so it is not a JCU regression — worth offering upstream
separately.

## Fix

`reset()` now also clears `breadcrumbs$`:

```ts
private reset(event?: NavigationEnd) {
  this.showBreadcrumbs$.next(true);

  const path = (event?.urlAfterRedirects ?? '').split('?')[0];
  if (path !== this.currentPath) {
    this.currentPath = path;
    this.breadcrumbs$.next([]);
  }
}
```

Two things worth noting for review:

- **Empty is safe, not blank.** `breadcrumbs.component.html` renders the `Home` crumb itself,
  outside the `@for` over the trail, so an empty array still renders a one-item bar. The bar keeps
  its height, and the page does not jump.
- **Only when the path changed.** Paging and filtering re-emit `NavigationEnd` for the same page.
  Clearing on those would blank the trail on every pagination click, so the guard compares the path
  without query params. There is a regression test for each branch of that condition.

## Verification

Same navigation, same sampling, on this branch:

| t | URL | breadcrumb rendered |
|---|---|---|
| 42 ms | `/mydspace` | `Home › MyDSpace` |
| 180 ms | `/items/{uuid}` | `Home` ← neutral, no wrong trail |
| 2926 ms | `/items/{uuid}` | `Home › Jihočeská univerzita … › {item title}` |

The wrong trail is gone; the correct one still arrives.

Tests — `src/app/breadcrumbs/`, Node 22, ChromeHeadless:

```
TOTAL: 8 SUCCESS
  ✔ should not keep showing the previous page's breadcrumbs      (new)
  ✔ should keep the breadcrumbs when only the query params changed (new)
  ✔ should return a breadcrumb corresponding to the current route
  ✔ should return false / should return that value / should be created
  ✔ (breadcrumbs.component.spec.ts, 2 tests)
```

Screenshots:

End state on the MyDSpace → item path is correct (this branch)
<img width="1440" height="900" alt="B4-4-after-item-from-mydspace-neutral-home" src="https://github.com/user-attachments/assets/d1e00fe2-043d-4892-9107-0a20ac739ea1" />
Item **edit** page on `dev-6` — trail was already fine, included to show what was *not* broken
<img width="929" height="869" alt="B4-2-dev6-item-edit-breadcrumbs-present" src="https://github.com/user-attachments/assets/87d36111-4420-4a8b-8815-0616bbb1eee4" />


The transient state itself is sub-second on a warm cache, so it is documented by the sampled tables
above rather than a screenshot; the screenshot in the issue is the production capture of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
