### PR TITLE
JCU/Port #1402 robots.txt rules for scoped search & facet links from customer/mendelu

### DIFF
--- a/src/robots.txt.ejs
+++ b/src/robots.txt.ejs
@@ -21,8 +21,7 @@ Disallow: /entities/*?f
 # Scoped search inside a community or collection, and every facet link.
 # "Disallow: /search" above only matches paths that START with /search, so
 # /collections/<uuid>/search and /communities/<uuid>/search stay crawlable.
-# Crawlers enumerating those facet combinations can saturate SSR
-# (observed at MENDELU, see PR #1402).
+# Crawlers enumerating those facet combinations can saturate SSR.
 Disallow: /collections/*/search
 Disallow: /communities/*/search
 # The two rules below cover any URL carrying a Discovery facet filter
@@ -31,8 +30,8 @@ Disallow: /communities/*/search
 # one (&f.), and robots.txt has no way to express "either".
 Disallow: /*?f.
 Disallow: /*&f.
-# NOTE: robots.txt is advisory only. The SSR-side enforcement used at MENDELU
-# (ssr.excludePathPatterns in config/config.yml) is not applied on this branch.
+# NOTE: robots.txt is advisory only; it does not stop crawlers that ignore it.
+# The SSR-side enforcement (ssr.excludePathPatterns) is not configured here.
 
 # Heavy Discovery facet queries on browse pages
 Disallow: /collections/*?f

--- a/src/robots.txt.ejs
+++ b/src/robots.txt.ejs
@@ -18,6 +18,21 @@ Disallow: /profile
 Disallow: /workflowitems
 # Crawlers should be able to access entity pages, but not the facet search links present on entity pages
 Disallow: /entities/*?f
+# Scoped search inside a community or collection, and every facet link.
+# "Disallow: /search" above only matches paths that START with /search, so
+# /collections/<uuid>/search and /communities/<uuid>/search stay crawlable.
+# Crawlers enumerating those facet combinations can saturate SSR
+# (observed at MENDELU, see PR #1402).
+Disallow: /collections/*/search
+Disallow: /communities/*/search
+# The two rules below cover any URL carrying a Discovery facet filter
+# (f.author, f.subject, f.dateIssued.min, ...), wherever it appears. Two of
+# them because the facet can be the first query parameter (?f.) or a later
+# one (&f.), and robots.txt has no way to express "either".
+Disallow: /*?f.
+Disallow: /*&f.
+# NOTE: robots.txt is advisory only. The SSR-side enforcement used at MENDELU
+# (ssr.excludePathPatterns in config/config.yml) is not applied on this branch.
 
 # Heavy Discovery facet queries on browse pages
 Disallow: /collections/*?f


### PR DESCRIPTION
Ports the `src/robots.txt.ejs` rules from `customer/mendelu` (PR #1402) to `customer/jcu`.

## Problem
`Disallow: /search` only matches paths that **start** with `/search`. Since DSpace 8 added
search to community and collection pages, `/collections/<uuid>/search` and
`/communities/<uuid>/search` stayed crawlable, and every facet permutation on them is a
distinct URL backed by a heavy Discovery query. A crawler enumerating those combinations
can saturate SSR — this is what happened at MENDELU and was fixed by #1402.

The same routes exist on JCU (`community-page-routes.ts`, `collection-page-routes.ts`),
and `customer/jcu` currently has no rule covering them.

## Fix
Adds 4 `Disallow:` rules (+ comments) to the `User-agent: *` group:

| rule | covers |
| --- | --- |
| `/collections/*/search` | scoped search inside a collection |
| `/communities/*/search` | scoped search inside a community |
| `/*?f.` | any URL where a Discovery facet is the **first** query param |
| `/*&f.` | any URL where a Discovery facet is a **later** query param |

Two `f.` rules are needed because robots.txt cannot express "`?` or `&`".
`f.` is the reserved Discovery facet prefix in this codebase
(`search-filter.service.ts` → `getQueryParamsWithPrefix('f.')`), so nothing we want indexed
is affected: browse pagination uses `bbm.*`, community sub-lists use `cmcl`/`cmscm`, and the
`Sitemap:` URLs carry no query string.

## Not a file copy — deliberately
`customer/mendelu` was cut from `dtq-dev-9` (2025-07-14) and therefore **predates** the
vanilla upstream block below, which `customer/jcu` inherits from `dtq-dev-9-base`:

```
# Heavy Discovery facet queries on browse pages
Disallow: /collections/*?f
Disallow: /communities/*?spc.page
```

That block is upstream DSpace (upstream commit `9b03e82a`, cherry-picked here as `c172b6d1`;
origin: upstream issue #4226 — *"the search queries, especially with many facets active, are
rather heavy queries. Bots should be disallowed from going there"* — i.e. the same failure
mode). Copying mendelu's file wholesale would have deleted it and re-diverged a file that is
currently byte-identical to `dtq-dev-9-base`.

It is **not** redundant with the new rules:
- `/collections/<uuid>?f=x`, `?filtertype=author`, `?format=json` — matched by `/collections/*?f`, **not** by `/*?f.` (which requires the dot).
- `/communities/<uuid>?spc.page=2` and `/communities/<uuid>/subcoms-cols?spc.page=2` — matched by **no** mendelu rule at all.

So this PR is a strictly additive **+14 / −0** patch. There are no `Allow:` directives in the
file, so adding `Disallow:` lines is monotonic and cannot unblock anything.

## Scope: robots.txt only
#1402 changed two files. This PR ports **only** `src/robots.txt.ejs`, not the
`ssr.excludePathPatterns` half in `config/config.yml`, which is what actually enforces this
against crawlers that ignore robots.txt. `customer/jcu`'s `config/config.yml` has no `ssr:`
section at all, so mendelu's *"see the comment in config/config.yml"* pointer was dropped and
replaced with a note that the SSR-side hardening is not configured here.

The comments in `src/robots.txt.ejs` are deliberately **customer-neutral**: this file is served
publicly at `/robots.txt`, so another customer's name, incident or PR number has no business
being in it. The provenance of the change lives in this PR description instead.

Follow-ups (intentionally out of scope):
- [ ] Add `ssr.excludePathPatterns` for the scoped-search routes to `customer/jcu`'s `config/config.yml`. ⚠️ `config.util.ts` merges arrays by **replacement**, so the full 11-entry default list from `src/environments/environment.production.ts` must be repeated alongside the new entries, or SSR is silently re-enabled for `/admin`, `/statistics`, `/processes`, …
- [ ] Check `ui.baseUrl` on the JCU host — on `dev-6.pc:8593` the served `robots.txt` advertises `Sitemap: http://localhost:4000/sitemap_index.xml`. Since this change hands item discovery to sitemaps, a wrong origin there would turn a load fix into a de-indexing problem.

## Verification
- `src/robots.txt.ejs` → `assets/robots.txt.ejs` via `webpack/webpack.common.ts`, served at `GET /robots.txt` by `server.ts`. Confirmed live: `http://dev-6.pc:8593/robots.txt` returns the current branch content.
- Diff is +14/−0, LF-only, no trailing whitespace, all new rules inside the contiguous `User-agent: *` group. File: 3474 → 4296 bytes.
- Nothing in the repo lints or tests this file, so review is the only gate.

After merge + deploy: `curl -s https://<jcu-host>/robots.txt | grep -E '/(collections|communities)/\*'` should show all four rules plus the two vanilla ones.
