### PR TITLE
JCU/fix(item-page): link metadata values to the metadata browse, not a vocabulary tree

### DIFF
--- a/src/app/item-page/simple/field-components/specific-field/item-page-field.component.spec.ts
+++ b/src/app/item-page/simple/field-components/specific-field/item-page-field.component.spec.ts
@@ -18,12 +18,17 @@ import { APP_CONFIG } from '../../../../../config/app-config.interface';
 import { environment } from '../../../../../environments/environment';
 import { BrowseService } from '../../../../core/browse/browse.service';
 import { BrowseDefinitionDataService } from '../../../../core/browse/browse-definition-data.service';
+import { buildPaginatedList } from '../../../../core/data/paginated-list.model';
+import { BrowseDefinition } from '../../../../core/shared/browse-definition.model';
+import { HierarchicalBrowseDefinition } from '../../../../core/shared/hierarchical-browse-definition.model';
 import { Item } from '../../../../core/shared/item.model';
 import { MathService } from '../../../../core/shared/math.service';
 import {
   MetadataMap,
   MetadataValue,
 } from '../../../../core/shared/metadata.models';
+import { PageInfo } from '../../../../core/shared/page-info.model';
+import { ValueListBrowseDefinition } from '../../../../core/shared/value-list-browse-definition.model';
 import { TranslateLoaderMock } from '../../../../shared/mocks/translate-loader.mock';
 import { createSuccessfulRemoteDataObject$ } from '../../../../shared/remote-data.utils';
 import { BrowseDefinitionDataServiceStub } from '../../../../shared/testing/browse-definition-data-service.stub';
@@ -180,6 +185,71 @@ describe('ItemPageFieldComponent', () => {
 
     it('should NOT have a rendered (non-browse) link since the value matches ^test', () => {
       expect(fixture.debugElement.query(By.css('a.ds-simple-metadata-link'))).toBeNull();
+    });
+  });
+
+  describe('picking the browse definition to link a metadata value to', () => {
+    /**
+     * Stands in for the stock DSpace config: a `subject` metadata browse over `dc.subject.*`, plus
+     * the hierarchical browse DSpace auto-creates for the `srsc` vocabulary, whose metadata is the
+     * `dc.subject` field the vocabulary is bound to in submission-forms.xml. `srsc` comes second,
+     * as it does over REST.
+     */
+    const subjectBrowse = Object.assign(new ValueListBrowseDefinition(), {
+      id: 'subject',
+      metadataKeys: ['dc.subject.*'],
+    });
+    const srscBrowse = Object.assign(new HierarchicalBrowseDefinition(), {
+      id: 'srsc',
+      vocabulary: 'srsc',
+      metadataKeys: ['dc.subject'],
+    });
+
+    const withDefinitions = (definitions: BrowseDefinition[]) => {
+      (comp as any).browseService = {
+        getBrowseDefinitions: () =>
+          createSuccessfulRemoteDataObject$(buildPaginatedList(new PageInfo(), definitions)),
+      };
+    };
+
+    const resolve = (): { value: BrowseDefinition, emitted: boolean } => {
+      const result = { value: undefined, emitted: false };
+      comp.browseDefinition.subscribe((def: BrowseDefinition) => {
+        result.value = def;
+        result.emitted = true;
+      });
+      return result;
+    };
+
+    it('should use the metadata browse for an unqualified field covered by a ".*" spec', () => {
+      comp.fields = ['dc.subject'];
+      withDefinitions([subjectBrowse, srscBrowse]);
+
+      const result = resolve();
+
+      expect(result.emitted).toBeTrue();
+      expect(result.value.id).toEqual('subject');
+    });
+
+    it('should not link to a hierarchical browse even when it is the only match', () => {
+      comp.fields = ['dc.subject'];
+      withDefinitions([srscBrowse]);
+
+      const result = resolve();
+
+      // nothing emitted -> the template falls back to plain text instead of linking into a
+      // vocabulary tree that ignores startsWith
+      expect(result.emitted).toBeFalse();
+    });
+
+    it('should still match a qualified field against a ".*" spec', () => {
+      comp.fields = ['dc.subject.lcsh'];
+      withDefinitions([subjectBrowse]);
+
+      const result = resolve();
+
+      expect(result.emitted).toBeTrue();
+      expect(result.value.id).toEqual('subject');
     });
   });
 });

--- a/src/app/item-page/simple/field-components/specific-field/item-page-field.component.ts
+++ b/src/app/item-page/simple/field-components/specific-field/item-page-field.component.ts
@@ -11,6 +11,7 @@ import {
   take,
 } from 'rxjs/operators';
 
+import { BrowseByDataType } from '../../../../browse-by/browse-by-switcher/browse-by-data-type';
 import { BrowseService } from '../../../../core/browse/browse.service';
 import { BrowseDefinitionDataService } from '../../../../core/browse/browse-definition-data.service';
 import { BrowseDefinition } from '../../../../core/shared/browse-definition.model';
@@ -88,6 +89,12 @@ export class ItemPageFieldComponent {
         getRemoteDataPayload(),
         getPaginatedListPayload(),
         mergeAll(),
+        // A hierarchical browse renders a controlled-vocabulary tree and ignores startsWith, so it
+        // can never answer "show me the other items with this value" - which is the only thing this
+        // link is for. DSpace auto-creates one per vocabulary used in submission-forms.xml, and its
+        // metadata is whatever field the vocabulary is bound to (srsc -> dc.subject), so without
+        // this it can shadow the real metadata browse for that field.
+        filter((def: BrowseDefinition) => def.getRenderType() !== BrowseByDataType.Hierarchy),
         filter((def: BrowseDefinition) =>
           intersectionWith(def.metadataKeys, this.fields, ItemPageFieldComponent.fieldMatch).length > 0,
         ),
@@ -97,12 +104,26 @@ export class ItemPageFieldComponent {
 
     /**
      * Returns true iff the spec and field match.
+     *
+     * A ".*" spec covers the unqualified field as well as any qualified form, i.e. "dc.subject.*"
+     * matches both "dc.subject" and "dc.subject.lcsh". That is how the backend expands the same
+     * wildcard when it builds the browse index: with `subject:metadata:dc.subject.*:text`
+     * configured and items carrying only unqualified `dc.subject`, the subject index is fully
+     * populated. Requiring a qualifier here made this method disagree with the index it is meant
+     * to describe.
+     *
      * @param spec  Specification of a metadata field name: either a metadata field, or a prefix ending in ".*".
      * @param field A metadata field name.
      * @private
      */
     private static fieldMatch(spec: string, field: string): boolean {
-      return field === spec
-        || (spec.endsWith('.*') && field.substring(0, spec.length - 1) === spec.substring(0, spec.length - 1));
+      if (field === spec) {
+        return true;
+      }
+      if (!spec.endsWith('.*')) {
+        return false;
+      }
+      const prefix = spec.slice(0, -2);
+      return field === prefix || field.startsWith(prefix + '.');
     }
 }


### PR DESCRIPTION
Fixes H5 from the dataquest-dev/dspace-customers#853 review.

## Problem

On an item page every keyword linked to the `srsc` browse:

```html
<a class="ds-browse-link" href="/browse/srsc?startsWith=porod">porod</a>
```

`srsc` is *Swedish Research Subject Categories* — a controlled hierarchical vocabulary with nothing
to do with free-text Czech keywords. Its page renders a category tree and ignores `startsWith`
entirely, so the user asks for "porod" and gets an English category tree. Subject navigation was dead
on every record in the repository.

The correct target works fine — on `dev-6`:

```
/browse/subject?startsWith=porod   ->  "Procházet podle Předmět, začíná na "porod""
                                       Nyní se zobrazuje 1 - 20 z 58
```

Reproduced on `dev-6.pc:8593` (all 8 keywords of an item → `/browse/srsc?startsWith=…`) and again on
a local DSpace 9.3 stack built from `customer/jcu`.

## Cause

Two independent problems, both in `ItemPageFieldComponent`, and it takes both to produce the bug.

**1. `fieldMatch` required a qualifier after a `.*` spec.**

```ts
return field === spec
  || (spec.endsWith('.*') && field.substring(0, spec.length - 1) === spec.substring(0, spec.length - 1));
```

For spec `dc.subject.*` and field `dc.subject` this compares `"dc.subject"` against `"dc.subject."`
— no match. So the `subject` browse did not match items' unqualified `dc.subject`.

The backend expands the same wildcard the other way. With `webui.browse.index.4 =
subject:metadata:dc.subject.*:text` configured, and JCU items carrying **only** unqualified
`dc.subject`:

```
/server/api/discover/browses/subject/entries   ->  totalElements: 168846
/server/api/core/items/{uuid}                  ->  "dc.subject": ["zátěž", "zdraví", …]
                                                   (no dc.subject.* qualified fields at all)
```

The index is fully populated from unqualified values, so this method disagreed with the very index
it is meant to describe.

**2. Nothing excluded hierarchical browses.**

DSpace auto-creates a hierarchical browse for every controlled vocabulary used in
`submission-forms.xml`, and its metadata is whatever field the vocabulary is bound to:

```
/server/api/discover/browses/srsc
  -> id: srsc, browseType: hierarchicalBrowse, vocabulary: srsc, metadata: ["dc.subject"]
```

That is an *exact* match on `dc.subject`. With (1) hiding the real `subject` browse, `srsc` was the
only candidate left, and `take(1)` picked it.

## Fix

- `.*` now covers the unqualified field as well as any qualified form, matching how the backend
  builds the index: `dc.subject.*` matches both `dc.subject` and `dc.subject.lcsh`.
- Hierarchical browses are filtered out before the match. A vocabulary tree cannot answer "show me
  the other items with this value", which is the only thing this link is for — so it is never a
  valid target regardless of ordering.

The second part matters beyond this bug: the old behaviour depended on which definition REST
happened to return first. Filtering by kind removes that dependency instead of relying on `subject`
being configured before `srsc`.

Only affects which browse a metadata value links to. The browse pages themselves are untouched, and
`author` / `dateissued` links are unchanged (verified below).

## Verification

Local DSpace 9.3 backend built from `customer/jcu`, item with one unqualified `dc.subject`.
Same item, same page, `customer/jcu` then this branch:

```
BEFORE   2026            -> /browse/dateissued?startsWith=2026
         Kasak, Matus    -> /browse/author?startsWith=Kasak,%20Matus
         cestovní ruch   -> /browse/srsc?startsWith=cestovní%20ruch      <-- dead end

AFTER    2026            -> /browse/dateissued?startsWith=2026           (unchanged)
         Kasak, Matus    -> /browse/author?startsWith=Kasak,%20Matus     (unchanged)
         cestovní ruch   -> /browse/subject?startsWith=cestovní%20ruch   <-- fixed
```

Following the fixed link lands on a working page: *"Browsing by Subject, starting with 'cestovní
ruch'"*, `Now showing 1 - 1 of 1`.

**Before** — item page, keyword → `/browse/srsc`
<img width="1440" height="900" alt="H5-1-before-keyword-links-to-srsc" src="https://github.com/user-attachments/assets/0ec5c8f3-13e9-4124-b97a-24f6c005d95c" />
**Before** — where that link lands: category tree, `startsWith` ignored
<img width="1440" height="900" alt="H5-2-before-srsc-page-ignores-startswith" src="https://github.com/user-attachments/assets/ac951879-a2ce-4488-a4d6-4bd42b905751" />
**After** — item page, keyword → `/browse/subject` 
<img width="1440" height="900" alt="H5-3-after-keyword-links-to-subject" src="https://github.com/user-attachments/assets/92059d68-e437-4500-98b9-ca016a9b6ebd" />
**After** — where that link lands: the matching subject entry
<img width="1440" height="900" alt="H5-4-after-subject-page-returns-results" src="https://github.com/user-attachments/assets/f7b847bc-c872-467c-9b99-686ff48d5c45" />

Tests — `item-page-field.component.spec.ts`, Node 22, ChromeHeadless:

```
TOTAL: 11 SUCCESS
  ✔ should use the metadata browse for an unqualified field covered by a ".*" spec  (new)
  ✔ should not link to a hierarchical browse even when it is the only match         (new)
  ✔ should still match a qualified field against a ".*" spec                        (new)
  ✔ (8 pre-existing tests, unchanged)
```

No reindex or backend config change needed — the `subject` index already contains these values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
