### PR TITLE
JCU/fix(i18n-cs): give the srsc browse its own Czech label

### DIFF
--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -1540,9 +1540,6 @@
   "browse.comcol.by.subject": "Podle předmětu",
 
   // "browse.comcol.by.srsc": "By Subject Category",
-  // Must stay distinct from browse.comcol.by.subject ("Podle předmětu"): both links sit next to
-  // each other in the comcol sidebar, and srsc is a different index (the controlled category
-  // vocabulary), not a second copy of the free-text subject browse.
   "browse.comcol.by.srsc": "Podle předmětové kategorie",
 
   // "browse.comcol.by.nsi": "By Norwegian Science Index",

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -1540,7 +1540,10 @@
   "browse.comcol.by.subject": "Podle předmětu",
 
   // "browse.comcol.by.srsc": "By Subject Category",
-  "browse.comcol.by.srsc": "Podle předmětu",
+  // Must stay distinct from browse.comcol.by.subject ("Podle předmětu"): both links sit next to
+  // each other in the comcol sidebar, and srsc is a different index (the controlled category
+  // vocabulary), not a second copy of the free-text subject browse.
+  "browse.comcol.by.srsc": "Podle předmětové kategorie",
 
   // "browse.comcol.by.nsi": "By Norwegian Science Index",
   "browse.comcol.by.nsi": "Podle Norwegian Science Index",
@@ -1567,8 +1570,7 @@
   "browse.metadata.title": "Název",
 
   // "browse.metadata.srsc": "Subject Category",
-  // TODO New key - Add a translation
-  "browse.metadata.srsc": "Subject Category",
+  "browse.metadata.srsc": "Předmětová kategorie",
 
   // "browse.metadata.author.breadcrumbs": "Browse by Author",
   "browse.metadata.author.breadcrumbs": "Procházet podle autora",


### PR DESCRIPTION
Fixes M4 from the dataquest-dev/dspace-customers#853 review.

## Problem

The Czech comcol sidebar lists **"Podle předmětu" twice**. Confirmed on `dev-6.pc:8593`, community
*Bakalářské práce*:

```
Podle data vydání   -> /browse/dateissued
Podle autora        -> /browse/author
Podle názvu         -> /browse/title
Podle předmětu      -> /browse/subject
Podle předmětu      -> /browse/srsc      <-- same label, different index
```

Two identical links side by side that go to different places.

## Cause

Two different browse indexes had been given the same Czech translation:

```
"browse.comcol.by.subject": "Podle předmětu",   // EN: "By Subject"
"browse.comcol.by.srsc":    "Podle předmětu",   // EN: "By Subject Category"
```

`srsc` is the controlled category vocabulary, not a second copy of the free-text subject browse.

## Fix

```diff
- "browse.comcol.by.srsc": "Podle předmětu",
+ "browse.comcol.by.srsc": "Podle předmětové kategorie",
```

Also translated the matching page heading, which was still English and still carried its
`// TODO New key - Add a translation` marker:

```diff
- "browse.metadata.srsc": "Subject Category",
+ "browse.metadata.srsc": "Předmětová kategorie",
```

That second key is listed under M5 rather than M4 in the checklist, but it is the heading you land on
from this very sidebar link — translating the link and leaving the destination in English would just
move the confusion one click along.

## Duplicate-value check

Rather than fix only the reported key, I grouped every `cs.json5` key by prefix and looked for
repeated values. It reports **127 groups, and this was the only real defect.** The rest are
deliberate:

- a page's `.title` / `.head` / `.breadcrumbs` sharing one string (`info.privacy.*`, `login.*`, …)
- a filter's `.head` / `.placeholder` pair (`search.filters.filter.*`)
- the same label in two different menus (`menu.section.browse_community_by_author` vs
  `…browse_global_by_author`)

So this is not worth turning into a CI rule as it stands — it would need a per-prefix allowlist to be
anything other than noise. Flagging that here so nobody re-derives it.

`browse.comcol.by.nsi` is deliberately left alone: the Norwegian Science Index browse is not
configured on the JCU instances (REST reports only `dateissued, author, title, subject, srsc`), so
nothing renders it.

## Verification

Local DSpace 9.3 stack built from `customer/jcu`, Czech UI.

```
BEFORE (dev-6)   Podle data vydání, Podle autora, Podle názvu, Podle předmětu, Podle předmětu
AFTER  (local)   Podle data vydání, Podle autora, Podle názvu, Podle předmětu, Podle předmětové kategorie
                 -> all five distinct
```

**Before** — `dev-6`, duplicate label in the sidebar
<img width="1440" height="900" alt="M4-1-before-dev6-duplicate-podle-predmetu" src="https://github.com/user-attachments/assets/52828033-5739-4143-a4cd-5253325b1684" />
**After** — five distinct sidebar labels
<img width="1440" height="900" alt="M4-2-after-local-distinct-sidebar-labels" src="https://github.com/user-attachments/assets/fdd1f822-3292-4761-a418-a40ceffc67e8" />
**After** — `/browse/srsc` heading now Czech
<img width="1440" height="900" alt="M4-3-after-local-srsc-heading-translated" src="https://github.com/user-attachments/assets/ff3f6018-0bb7-4e03-80ac-11ffb438a93e" />

### Two things for the reviewer

- The "after" heading screenshot still shows the literal `{{ collection }}`. That is B1, fixed
  separately in #1416 — the two branches are independent, so it is still present here.
- `"Procházet podle Předmětová kategorie"` is grammatically imperfect; Czech would want the genitive
  after *podle*. This matches the existing convention though — the sibling keys give
  `"Procházet podle Předmět"`, `"…podle Autor"`, `"…podle Název"`, all nominative, because
  `browse.metadata.*` is also used standalone as a column/breadcrumb label. Fixing the case properly
  means restructuring `browse.title`, which is out of scope here. Happy to change the value if you
  would rather have it read well in the heading than as a standalone label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
