### PR TITLE
JCU/fix(a11y): do not render a second h1 on community and collection pages

### DIFF
--- a/src/app/shared/comcol/sections/comcol-search-section/comcol-search-section.component.html
+++ b/src/app/shared/comcol/sections/comcol-search-section/comcol-search-section.component.html
@@ -3,5 +3,6 @@
   [showSidebar]="showSidebar$ | async"
   [showScopeSelector]="false"
   [hideScopeInUrl]="true"
-  [scope]="(comcol$ | async)?.id">
+  [scope]="(comcol$ | async)?.id"
+  [headingLevel]="2">
 </ds-search>

--- a/src/app/shared/search/search-results/search-results.component.html
+++ b/src/app/shared/search/search-results/search-results.component.html
@@ -12,7 +12,11 @@
 
 <div class="d-flex justify-content-between">
   @if (!disableHeader) {
-    <h1>{{ (configuration ? configuration + '.search.results.head' : 'search.results.head') | translate }}</h1>
+    @if (headingLevel === 2) {
+      <h2>{{ (configuration ? configuration + '.search.results.head' : 'search.results.head') | translate }}</h2>
+    } @else {
+      <h1>{{ (configuration ? configuration + '.search.results.head' : 'search.results.head') | translate }}</h1>
+    }
   }
   @if (showCsvExport) {
     <ds-search-export-csv [searchConfig]="searchConfig" [total]="searchResults?.payload?.totalElements"></ds-search-export-csv>

--- a/src/app/shared/search/search-results/search-results.component.spec.ts
+++ b/src/app/shared/search/search-results/search-results.component.spec.ts
@@ -133,6 +133,36 @@ describe('SearchResultsComponent', () => {
     expect(routerLinkQuery[0].queryParams.query).toBe('"foobar"', 'query params should be "foobar"');
   });
 
+  describe('the results header', () => {
+    beforeEach(() => {
+      (comp as any).searchResults = { hasSucceeded: true, isLoading: false, payload: { page: { length: 2 } } };
+      (comp as any).searchConfig = {};
+    });
+
+    it('should be an h1 by default, as the main heading of a standalone search page', () => {
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('h1'))).not.toBeNull();
+      expect(fixture.debugElement.query(By.css('h2'))).toBeNull();
+    });
+
+    it('should be an h2 when embedded under a page that already owns the h1', () => {
+      comp.headingLevel = 2;
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('h1'))).toBeNull();
+      expect(fixture.debugElement.query(By.css('h2'))).not.toBeNull();
+    });
+
+    it('should render no heading at all when the header is disabled', () => {
+      comp.disableHeader = true;
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('h1'))).toBeNull();
+      expect(fixture.debugElement.query(By.css('h2'))).toBeNull();
+    });
+  });
+
   it('should add quotes around the given string', () => {
     expect(comp.surroundStringWithQuotes('teststring')).toEqual('"teststring"');
   });

--- a/src/app/shared/search/search-results/search-results.component.ts
+++ b/src/app/shared/search/search-results/search-results.component.ts
@@ -127,6 +127,16 @@ export class SearchResultsComponent {
   @Input() disableHeader = false;
 
   /**
+   * Heading level to render the results header at.
+   *
+   * On a standalone search page the results header is the page's main heading, so it must stay an
+   * h1. When the search is embedded under a page that already has its own h1 - a community or
+   * collection page, whose h1 is the comcol name - it is a subordinate section heading and has to
+   * be an h2, otherwise the page ends up with two h1s.
+   */
+  @Input() headingLevel: 1 | 2 = 1;
+
+  /**
    * A boolean representing if result entries are selectable
    */
   @Input() selectable = false;

--- a/src/app/shared/search/search-results/themed-search-results.component.ts
+++ b/src/app/shared/search/search-results/themed-search-results.component.ts
@@ -30,7 +30,7 @@ import {
 })
 export class ThemedSearchResultsComponent extends ThemedComponent<SearchResultsComponent> {
 
-  protected inAndOutputNames: (keyof SearchResultsComponent & keyof this)[] = ['linkType', 'searchResults', 'searchConfig', 'showCsvExport', 'showThumbnails', 'sortConfig', 'viewMode', 'configuration', 'disableHeader', 'selectable', 'context', 'hidePaginationDetail', 'selectionConfig', 'contentChange', 'deselectObject', 'selectObject'];
+  protected inAndOutputNames: (keyof SearchResultsComponent & keyof this)[] = ['linkType', 'searchResults', 'searchConfig', 'showCsvExport', 'showThumbnails', 'sortConfig', 'viewMode', 'configuration', 'disableHeader', 'headingLevel', 'selectable', 'context', 'hidePaginationDetail', 'selectionConfig', 'contentChange', 'deselectObject', 'selectObject'];
 
   @Input() linkType: CollectionElementLinkType;
 
@@ -49,6 +49,8 @@ export class ThemedSearchResultsComponent extends ThemedComponent<SearchResultsC
   @Input() configuration: string;
 
   @Input() disableHeader: boolean;
+
+  @Input() headingLevel: 1 | 2;
 
   @Input() selectable: boolean;
 

--- a/src/app/shared/search/search.component.html
+++ b/src/app/shared/search/search.component.html
@@ -50,6 +50,7 @@
         [searchConfig]="searchOptions$ | async"
         [configuration]="(currentConfiguration$ | async)"
         [disableHeader]="!searchEnabled"
+        [headingLevel]="headingLevel"
         [linkType]="linkType"
         [context]="(currentContext$ | async)"
         [selectable]="selectable"

--- a/src/app/shared/search/search.component.ts
+++ b/src/app/shared/search/search.component.ts
@@ -162,6 +162,12 @@ export class SearchComponent implements OnDestroy, OnInit {
   @Input() searchEnabled = true;
 
   /**
+   * Heading level for the results header, forwarded to {@link SearchResultsComponent}. Pass 2 when
+   * embedding this search under a page that already owns the h1.
+   */
+  @Input() headingLevel: 1 | 2 = 1;
+
+  /**
    * The width of the sidebar (bootstrap columns)
    */
   @Input() sideBarWidth = 3;

--- a/src/app/shared/search/themed-search.component.ts
+++ b/src/app/shared/search/themed-search.component.ts
@@ -36,6 +36,7 @@ export class ThemedSearchComponent extends ThemedComponent<SearchComponent> {
     'linkType',
     'paginationId',
     'searchEnabled',
+    'headingLevel',
     'sideBarWidth',
     'searchFormPlaceholder',
     'selectable',
@@ -75,6 +76,8 @@ export class ThemedSearchComponent extends ThemedComponent<SearchComponent> {
   @Input() paginationId: string;
 
   @Input() searchEnabled: boolean;
+
+  @Input() headingLevel: 1 | 2;
 
   @Input() sideBarWidth: number;
 


### PR DESCRIPTION
Fixes L6 from the dataquest-dev/dspace-customers#853 review.

## Problem

Community and collection pages render **two `<h1>`s**. Measured on `dev-6.pc:8593`, community
*Bakalářské práce*:

```js
document.querySelectorAll('h1')  ->  ["Bakalářské práce", "Výsledky vyhledávání"]
```

Two competing top-level headings means assistive tech gets no single answer to "what is this page
about".

## Cause

- `comcol-page-header.component.html` → `<h1>{{ name }}</h1>` — the comcol name. Correct.
- `search-results.component.html` → `<h1>{{ … 'search.results.head' … }}</h1>` — the search results
  embedded in the comcol page.

The results heading is *right* on a standalone search page, where it is the only h1. Verified before
touching anything:

```
/search  ->  h1s: ["Výsledky vyhledávání"]   h2s: []
```

So it cannot simply be dropped — that would leave `/search` with no h1 at all, trading one a11y
defect for another.

## Fix

The heading becomes level-aware instead:

- new `headingLevel: 1 | 2` input on `SearchResultsComponent`, default `1`
- threaded through `SearchComponent` and both themed wrappers
  (`ThemedSearchComponent`, `ThemedSearchResultsComponent`)
- `ComcolSearchSectionComponent` passes `[headingLevel]="2"`

Standalone search pages are unchanged; only the comcol-embedded search demotes its heading.

The JCU `custom` theme overrides `SearchComponent` and `SearchResultsComponent`, but their
`templateUrl`s point back at the base templates — the local `.html` files are 0-byte scaffolding — so
the theme picks the fix up with no duplicate edit. Worth knowing before assuming a theme copy needs
patching.

Same code is in upstream `main`, so this is not a JCU regression and is worth offering upstream.

## Verification

Local DSpace 9.3 stack built from `customer/jcu`, Czech UI.

```
BEFORE  community    h1s: ["Bakalářské práce", "Výsledky vyhledávání"]        (2)

AFTER   community    h1s: ["Jihočeská univerzita – Repozitář (Sample)"]       (1)
                     h2s: ["Procházet", "Výsledky vyhledávání"]
AFTER   collection   h1s: ["Diplomové a disertační práce (Sample)"]           (1)
                     H1 -> H2 "Procházet" -> H3 "Filtry" -> H3 "Nastavení" -> H2 "Výsledky vyhledávání"
AFTER   /search      h1s: ["Výsledky vyhledávání"]                            (1, unchanged)
```

No skipped heading levels introduced — the collection page walks H1 → H2 → H3 cleanly.

**Before** — `dev-6` community page, 2 h1s
<img width="1440" height="900" alt="M4-1-before-dev6-duplicate-podle-predmetu" src="https://github.com/user-attachments/assets/4d36ffdb-c6ae-4ab7-8070-4ed6ced7b649" />
**After** — collection page, single h1
<img width="1440" height="900" alt="L6-2-after-collection-single-h1" src="https://github.com/user-attachments/assets/2b509da2-088d-4302-b0d2-19d3ce40a808" />


(The "before" shot is shared with the M4 PR — both defects are visible on that same page.)

Tests — Node 22, ChromeHeadless:

```
src/app/shared/search   + src/app/shared/comcol   ->  159 SUCCESS
  ✔ should be an h1 by default, as the main heading of a standalone search page  (new)
  ✔ should be an h2 when embedded under a page that already owns the h1          (new)
  ✔ should render no heading at all when the header is disabled                  (new)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
