### PR TITLE
JCU/perf(ssr): exclude crawler-heavy routes from SSR and size the bot page cache

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -38,3 +38,40 @@ themes:
         attributes:
           rel: manifest
           href: assets/custom/images/favicons/manifest.webmanifest
+
+ssr:
+  excludePathPatterns:
+    - pattern: "^/communities/[a-f0-9-]{36}/browse(/.*)?$"
+      flag: "i"
+    - pattern: "^/collections/[a-f0-9-]{36}/browse(/.*)?$"
+      flag: "i"
+    - pattern: "^/browse/"
+    - pattern: "^/search"
+    - pattern: "^/community-list$"
+    - pattern: "^/statistics/?"
+    - pattern: "^/admin/"
+    - pattern: "^/processes/?"
+    - pattern: "^/notifications/"
+    - pattern: "^/access-control/"
+    - pattern: "^/health$"
+    - pattern: "^/collections/[a-f0-9-]{36}/search"
+      flag: "i"
+    - pattern: "^/communities/[a-f0-9-]{36}/search"
+      flag: "i"
+    - pattern: "^/(items|entities/[^/]+)/[a-f0-9-]{36}/full/?$"
+      flag: "i"
+    - pattern: "^/(mydspace|submit|import-external|workspaceitems|workflowitems)(/|$)"
+    - pattern: "^/(profile|subscriptions|suggestions)(/|$)"
+    - pattern: "^/(items|collections|communities|entities/[^/]+)/[a-f0-9-]{36}/(edit|delete|bitstreams/new)(/|$)"
+      flag: "i"
+    - pattern: "^/(register|forgot)(/|$)"
+
+cache:
+  serverSide:
+    debug: false
+    botCache:
+      max: 512
+      timeToLive: 21600000
+      allowStale: true
+    anonymousCache:
+      max: 0


### PR DESCRIPTION
SSR-side half of the scoped-search crawler protection; #1419 did the robots.txt half.

**`ssr.excludePathPatterns`** — the 11 runtime defaults from `src/environments/environment.production.ts`, repeated verbatim because the array is replaced wholesale (omit one and SSR is silently re-enabled for it), plus 7 additions: scoped search on collections/communities (the Mendelu 504 root cause, #1402), `/items|entities/<uuid>/full`, and auth-only routes whose renders can never be cached anyway.

Exclusion means CSR, not an error — nothing is blocked, no route returns a non-200, and no user-agent is treated differently.

**`cache.serverSide`** — `botCache.max` 1000 → 512 (each PM2 worker keeps its own copy; 8 × 1000 pages does not fit the 1024 MB heap cap) and TTL 24 h → 6 h, the only invalidation lever for withdrawn items. `anonymousCache` stays 0: `getCacheKey` is URL-only while the render language comes from the `dsLanguage` cookie, so enabling it would serve Czech pages to English visitors.

In `config.yml` rather than `config.prod.yml` so it applies even where the deployment's env config is empty.

Verified: YAML parses, all 18 regexes compile, 43-path matrix passes — item/collection/community landing pages, `/handle/*`, `/bitstreams/*/download`, `request-a-copy` and `/login` all still render server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
