### PR TITLE
JCU/fix(gdpr): do not load the CitacePRO iframe before cookie consent

### DIFF
--- a/src/app/item-page/simple/field-components/specific-field/citation/item-page-citation.component.html
+++ b/src/app/item-page/simple/field-components/specific-field/citation/item-page-citation.component.html
@@ -1,12 +1,25 @@
 @if ((citaceProStatus$ | async) && (citaceProURL$ | async); as citaceProURL) {
   <div class="mb-2">
-    <iframe
-      class="d-block"
-      title="{{ 'item.page.citace-pro.title' | translate }}"
-      height="150px"
-      width="100%"
-      style="border: none;"
-      [src]="citaceProURL"
-    ></iframe>
+    @if (hasConsent$ | async) {
+      <iframe
+        class="d-block"
+        title="{{ 'item.page.citace-pro.title' | translate }}"
+        height="150px"
+        width="100%"
+        style="border: none;"
+        loading="lazy"
+        sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
+        [src]="citaceProURL"
+      ></iframe>
+    } @else {
+      <div class="citace-pro-consent alert alert-info d-flex flex-column flex-sm-row align-items-sm-center gap-2 mb-0"
+           role="region" [attr.aria-label]="'item.page.citace-pro.title' | translate">
+        <span class="flex-grow-1">{{ 'item.page.citace-pro.consent.required' | translate }}</span>
+        <button type="button" class="btn btn-sm btn-outline-primary text-nowrap"
+                (click)="showCookieSettings()">
+          {{ 'item.page.citace-pro.consent.button' | translate }}
+        </button>
+      </div>
+    }
   </div>
 }

--- a/src/app/item-page/simple/field-components/specific-field/citation/item-page-citation.component.spec.ts
+++ b/src/app/item-page/simple/field-components/specific-field/citation/item-page-citation.component.spec.ts
@@ -15,9 +15,16 @@ import {
   TranslateLoader,
   TranslateModule,
 } from '@ngx-translate/core';
+import {
+  BehaviorSubject,
+  of,
+} from 'rxjs';
 
 import { ConfigurationDataService } from '../../../../../core/data/configuration-data.service';
+import { CookieService } from '../../../../../core/services/cookie.service';
 import { ConfigurationProperty } from '../../../../../core/shared/configuration-property.model';
+import { OrejimeService } from '../../../../../shared/cookies/orejime.service';
+import { CITACE_PRO_OREJIME_KEY } from '../../../../../shared/cookies/orejime-configuration';
 import { TranslateLoaderMock } from '../../../../../shared/mocks/translate-loader.mock';
 import { createSuccessfulRemoteDataObject$ } from '../../../../../shared/remote-data.utils';
 import { ItemPageCitationFieldComponent } from './item-page-citation.component';
@@ -25,9 +32,33 @@ import { ItemPageCitationFieldComponent } from './item-page-citation.component';
 const CITACE_PRO_URL = 'https://www.citacepro.com/api/dspace/citace/oai';
 const CITACE_PRO_UNIVERSITY = 'dspace.jcu.cz';
 
+/**
+ * Consent doubles that let a test flip the stored preference at runtime, the way accepting in the
+ * consent dialog does. Factories rather than classes: max-classes-per-file allows only one.
+ */
+const orejimeServiceStub = (consented: boolean) => {
+  const preferences = new BehaviorSubject<any>({ [CITACE_PRO_OREJIME_KEY]: consented });
+
+  return {
+    preferences,
+    initialize: () => undefined,
+    showSettings: jasmine.createSpy('showSettings'),
+    getSavedPreferences: () => preferences.asObservable(),
+  };
+};
+
+const cookieServiceStub = () => ({
+  cookies$: of({}),
+  get: () => undefined,
+  getAll: () => ({}),
+  set: () => undefined,
+  remove: () => undefined,
+});
+
 describe('ItemPageCitationFieldComponent', () => {
   let component: ItemPageCitationFieldComponent;
   let fixture: ComponentFixture<ItemPageCitationFieldComponent>;
+  let orejime: ReturnType<typeof orejimeServiceStub>;
   const mockHandle = '123456789/3';
 
   function mockConfigurationDataService(allowed: string) {
@@ -43,7 +74,9 @@ describe('ItemPageCitationFieldComponent', () => {
     };
   }
 
-  async function init(allowed: string): Promise<void> {
+  async function init(allowed: string, consented = true): Promise<void> {
+    orejime = orejimeServiceStub(consented);
+
     await TestBed.configureTestingModule({
       imports: [
         ItemPageCitationFieldComponent,
@@ -53,6 +86,8 @@ describe('ItemPageCitationFieldComponent', () => {
       ],
       providers: [
         { provide: ConfigurationDataService, useValue: mockConfigurationDataService(allowed) },
+        { provide: OrejimeService, useValue: orejime },
+        { provide: CookieService, useValue: cookieServiceStub() },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     })
@@ -99,6 +134,42 @@ describe('ItemPageCitationFieldComponent', () => {
     it('should keep the widget hidden', () => {
       expect(component.citaceProStatus$.getValue()).toBeFalse();
       expect(fixture.debugElement.query(By.css('iframe'))).toBeNull();
+    });
+  });
+
+  describe('cookie consent', () => {
+    it('should not put the third-party iframe in the DOM before consent', async () => {
+      await init('true', false);
+
+      expect(fixture.debugElement.query(By.css('iframe'))).toBeNull();
+    });
+
+    it('should offer the cookie settings instead of the widget before consent', async () => {
+      await init('true', false);
+
+      const button = fixture.debugElement.query(By.css('.citace-pro-consent button'));
+      expect(button).not.toBeNull();
+
+      button.nativeElement.click();
+      expect(orejime.showSettings).toHaveBeenCalled();
+    });
+
+    it('should reveal the iframe once consent is granted, without a reload', async () => {
+      await init('true', false);
+      expect(fixture.debugElement.query(By.css('iframe'))).toBeNull();
+
+      orejime.preferences.next({ [CITACE_PRO_OREJIME_KEY]: true });
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css('iframe'))).not.toBeNull();
+    });
+
+    it('should sandbox the iframe and defer its load', async () => {
+      await init('true', true);
+
+      const iframe = fixture.debugElement.query(By.css('iframe')).nativeElement;
+      expect(iframe.getAttribute('loading')).toBe('lazy');
+      expect(iframe.getAttribute('sandbox')).toBe('allow-scripts allow-popups allow-popups-to-escape-sandbox');
     });
   });
 

--- a/src/app/item-page/simple/field-components/specific-field/citation/item-page-citation.component.ts
+++ b/src/app/item-page/simple/field-components/specific-field/citation/item-page-citation.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   Input,
   OnInit,
+  Optional,
 } from '@angular/core';
 import {
   DomSanitizer,
@@ -12,15 +13,22 @@ import { TranslateModule } from '@ngx-translate/core';
 import {
   BehaviorSubject,
   combineLatest,
+  Observable,
   of,
 } from 'rxjs';
 import {
   catchError,
+  map,
+  startWith,
+  switchMap,
   take,
 } from 'rxjs/operators';
 
 import { ConfigurationDataService } from '../../../../../core/data/configuration-data.service';
+import { CookieService } from '../../../../../core/services/cookie.service';
 import { getFirstCompletedRemoteData } from '../../../../../core/shared/operators';
+import { OrejimeService } from '../../../../../shared/cookies/orejime.service';
+import { CITACE_PRO_OREJIME_KEY } from '../../../../../shared/cookies/orejime-configuration';
 
 @Component({
   selector: 'ds-item-page-citation-field',
@@ -36,9 +44,18 @@ export class ItemPageCitationFieldComponent implements OnInit {
   citaceProStatus$ = new BehaviorSubject<boolean>(false);
   citaceProURL$ = new BehaviorSubject<SafeResourceUrl | null>(null);
 
+  /**
+   * Whether the visitor has consented to loading the third-party CitacePRO iframe.
+   * Until they have, the widget must not be rendered at all — an iframe in the DOM is already
+   * a request to citacepro.com.
+   */
+  hasConsent$: Observable<boolean>;
+
   constructor(
     private sanitizer: DomSanitizer,
     private configService: ConfigurationDataService,
+    @Optional() private orejimeService: OrejimeService,
+    @Optional() private cookieService: CookieService,
   ) {}
 
 
@@ -56,6 +73,8 @@ export class ItemPageCitationFieldComponent implements OnInit {
       catchError(() => of(null)),
     );
 
+    this.hasConsent$ = this.watchConsent();
+
     combineLatest([citaceProUrl$, universityUsingDspace$, citaceProAllowed$]).pipe(
       take(1),
     ).subscribe(([citaceProUrlData, universityData, citaceProAllowedData]) => {
@@ -68,6 +87,13 @@ export class ItemPageCitationFieldComponent implements OnInit {
     });
   }
 
+  /**
+   * Opens the cookie preferences dialog so the visitor can grant consent from where the widget
+   * would have been, instead of having to hunt for the link in the footer.
+   */
+  showCookieSettings(): void {
+    this.orejimeService?.showSettings();
+  }
 
   makeCitaceProURL(
     citaceProBaseUrl: string,
@@ -83,5 +109,25 @@ export class ItemPageCitationFieldComponent implements OnInit {
     }
     const url = `${citaceProBaseUrl}:${universityUsingDspace}:${this.handle}`;
     return this.sanitizer.bypassSecurityTrustResourceUrl(url);
+  }
+
+  /**
+   * Re-reads the stored consent whenever a cookie changes, so accepting in the consent dialog
+   * reveals the widget without a page reload. Without the OrejimeService (server-side rendering)
+   * we cannot know the visitor's choice, so we withhold consent.
+   */
+  private watchConsent(): Observable<boolean> {
+    if (!this.orejimeService) {
+      return of(false);
+    }
+
+    const cookieChanges$ = this.cookieService?.cookies$ ?? of(null);
+
+    return cookieChanges$.pipe(
+      startWith(null),
+      switchMap(() => this.orejimeService.getSavedPreferences()),
+      map((preferences: any) => preferences?.[CITACE_PRO_OREJIME_KEY] === true),
+      catchError(() => of(false)),
+    );
   }
 }

--- a/src/app/shared/cookies/orejime-configuration.ts
+++ b/src/app/shared/cookies/orejime-configuration.ts
@@ -29,6 +29,13 @@ export const CORRELATION_ID_OREJIME_KEY = 'correlation-id';
 export const CORRELATION_ID_COOKIE = 'CORRELATION-ID';
 
 /**
+ * Consent gate for the CitacePRO citation widget on the item page. The widget is a third-party
+ * iframe, so loading it transfers the visitor's IP address to citacepro.com (and, through the
+ * stylesheet that iframe pulls in, to Google Fonts). That may not happen before consent.
+ */
+export const CITACE_PRO_OREJIME_KEY = 'citace-pro';
+
+/**
  * Orejime configuration
  * For more information see https://github.com/empreinte-digitale/orejime
  */
@@ -228,6 +235,20 @@ export function getOrejimeConfiguration(_window: NativeWindowRef): any {
         purposes: ['functional'],
         required: false,
         cookies: [ACCESSIBILITY_COOKIE],
+        onlyOnce: false,
+      },
+      {
+        // No `cookies` to list: this app gates an embedded third-party iframe rather than a
+        // cookie of our own, and cookies set on citacepro.com cannot be removed from here
+        // anyway. Its own purpose category keeps the third-party transfer visible to the user
+        // instead of hiding it among the functional cookies the site needs to work.
+        name: CITACE_PRO_OREJIME_KEY,
+        purposes: ['third-party-content'],
+        required: false,
+        // Consent to a third-party transfer must be an affirmative act, so the toggle starts off
+        // rather than pre-ticked.
+        default: false,
+        cookies: [],
         onlyOnce: false,
       },
     ],

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -2548,6 +2548,15 @@
   // "cookies.consent.purpose.sharing": "Sharing",
   "cookies.consent.purpose.sharing": "Sdílení",
 
+  // "cookies.consent.purpose.third-party-content": "Third-party content",
+  "cookies.consent.purpose.third-party-content": "Obsah třetích stran",
+
+  // "cookies.consent.app.title.citace-pro": "Citace PRO",
+  "cookies.consent.app.title.citace-pro": "Citace PRO",
+
+  // "cookies.consent.app.description.citace-pro": "Shows a ready-made citation of this record. The widget is loaded from citacepro.com, which receives your IP address.",
+  "cookies.consent.app.description.citace-pro": "Zobrazuje hotovou citaci tohoto záznamu. Widget se načítá z citacepro.com, které tím získá vaši IP adresu.",
+
   // "curation-task.task.citationpage.label": "Generate Citation Page",
   "curation-task.task.citationpage.label": "Vytvořit stránku s citacemi",
 
@@ -4391,6 +4400,12 @@
 
   // "item.page.citace-pro.title": "Citace PRO",
   "item.page.citace-pro.title": "Citace PRO",
+
+  // "item.page.citace-pro.consent.required": "The Citace PRO citation is loaded from a third-party service. To display it, allow third-party content in your cookie preferences.",
+  "item.page.citace-pro.consent.required": "Citace z Citace PRO se načítá ze služby třetí strany. Pro zobrazení povolte obsah třetích stran v nastavení cookies.",
+
+  // "item.page.citace-pro.consent.button": "Cookie preferences",
+  "item.page.citace-pro.consent.button": "Nastavení cookies",
 
   // "item.page.citation": "Citation",
   "item.page.citation": "Citace",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1695,6 +1695,12 @@
 
   "cookies.consent.purpose.sharing": "Sharing",
 
+  "cookies.consent.purpose.third-party-content": "Third-party content",
+
+  "cookies.consent.app.title.citace-pro": "Citace PRO",
+
+  "cookies.consent.app.description.citace-pro": "Shows a ready-made citation of this record. The widget is loaded from citacepro.com, which receives your IP address.",
+
   "curation-task.task.citationpage.label": "Generate Citation Page",
 
   "curation-task.task.checklinks.label": "Check Links in Metadata",
@@ -2914,6 +2920,10 @@
   "item.page.authors": "Authors",
 
   "item.page.citace-pro.title": "Citace PRO",
+
+  "item.page.citace-pro.consent.required": "The Citace PRO citation is loaded from a third-party service. To display it, allow third-party content in your cookie preferences.",
+
+  "item.page.citace-pro.consent.button": "Cookie preferences",
 
   "item.page.citation": "Citation",
 


### PR DESCRIPTION
Fixes **H6** from the JCU #853 audit: third-party requests fired before the visitor answered the cookie banner.

## What actually happens (and where the audit's diagnosis was off)

The audit listed three offending hosts and said Google Fonts was loaded on *every page* from our own stylesheet. Measured on production with a fresh profile, it is narrower than that but the finding itself is real:

| Page | Third-party requests before consent |
|---|---|
| `/home` | **none** |
| `/items/{uuid}` | `www.citacepro.com` (iframe + `style2.css`), `fonts.googleapis.com`, `fonts.gstatic.com` (2 woff2) |

All five requests originate from the **CitacePRO iframe** — `style2.css`, served by citacepro.com *inside* the iframe, is what pulls in Open Sans from Google. Our own fonts (Clara Sans, FontAwesome) are already self-hosted under `/assets/fonts/`, and the only `fonts.googleapis.com` import left in the repo is in `src/themes/dspace/styles/`, a bundle JCU never loads (`inject: false`, active theme is `custom`).

So there is nothing to self-host, and one fix removes all three hosts: **don't load the iframe until consent exists**.

Confirmed the banner was up and unanswered at the time — only `XSRF-TOKEN` was set, no `orejime-*` cookie.

## Changes

**`orejime-configuration.ts`** — new `citace-pro` app:
- its own `third-party-content` purpose rather than folding it into `functional`, so the visitor sees that data leaves the site instead of it hiding among cookies the site needs to work
- `default: false` — consent to a third-party transfer has to be an affirmative act, not a pre-ticked box. Existing apps keep their current defaults.
- no `cookies` to list: this gates an embed, and cookies set on citacepro.com can't be cleared from here anyway

**`item-page-citation.component.ts`** — `hasConsent$` reads the stored preference and re-reads it on every `CookieService.cookies$` emission, so accepting in the dialog reveals the widget with no reload. `OrejimeService`/`CookieService` are `@Optional()`; without them (SSR) consent is withheld.

**`item-page-citation.component.html`** — the iframe is behind `@if` (an iframe in the DOM *is* the request, so hiding it with CSS would not do), plus `sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"` and `loading="lazy"`. Where the widget would be, a short explanation and a button that opens the consent dialog.

**`cs.json5` / `en.json5`** — 5 new keys (purpose label, app title + description, placeholder text + button).

## Verification

Local 9.3 docker stack, `citace.pro.url` / `.university` / `.allowed` identical to production.

| | before consent | after granting |
|---|---|---|
| third-party requests | **0** | the 3 hosts, as expected |
| iframe in DOM | no | yes, `sandbox` + `loading="lazy"` |
| widget usable | — | yes, renders its "Uložit do Citace PRO" button inside the sandbox |

Granting consent revealed the widget **without a page reload**.

Also checked the upgrade path: a visitor whose `orejime-*` cookie predates this change has no `citace-pro` key, so they get the placeholder rather than a silent third-party load.

`ng lint` 0 errors · citation specs **10/10** (4 new: nothing in the DOM before consent, settings button opens the dialog, reveal-on-consent without reload, sandbox/lazy attributes) · cookies specs **21/21**.

## Left out on purpose

- **OAI prefix `oai:dspace.jcu.cz:…`** in the widget URL is still the old domain. That comes from `citace.pro.university` in `local.cfg`, not from this repo, and per **L5** the target domain needs confirming before anything is changed. Flagged there, not touched here.
- The sandbox is verified to let the widget render and open popups. Worth one manual click of "Uložit do Citace PRO" against a real JCU handle before merge — the local stack's handles aren't in CitacePRO's database.
- Pre-ticked defaults on the *existing* optional apps (`accessibility`, `correlation-id`) are untouched — pre-existing DSpace behaviour, out of scope here.

## Evidence

Screenshots attached below: production before (banner up, widget loaded), local after (placeholder), the consent dialog showing the new "Obsah třetích stran" section with the toggle off, and local after granting consent.
<img width="1280" height="801" alt="H6-1-before-prod-item-page-consent-banner-and-citacepro" src="https://github.com/user-attachments/assets/fe2eb5b8-ba4e-422f-8e00-89bcfb60f46d" />
<img width="1265" height="801" alt="H6-2-after-local-no-consent-placeholder-instead-of-iframe" src="https://github.com/user-attachments/assets/62d98ea0-5a23-4c90-a9e0-b5eacde38952" />
