### PR TITLE
JCU/feat(item-page): show the translated abstract and thesis metadata

### DIFF
--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -4383,6 +4383,24 @@
   // "item.page.abstract": "Abstract",
   "item.page.abstract": "Abstrakt",
 
+  // "item.page.abstract-translated": "Abstract (English)",
+  "item.page.abstract-translated": "Abstrakt (anglicky)",
+
+  // "item.page.type": "Document type",
+  "item.page.type": "Typ dokumentu",
+
+  // "item.page.thesis.degree-name": "Degree",
+  "item.page.thesis.degree-name": "Akademický titul",
+
+  // "item.page.thesis.degree-program": "Study programme",
+  "item.page.thesis.degree-program": "Studijní program",
+
+  // "item.page.thesis.degree-discipline": "Field of study",
+  "item.page.thesis.degree-discipline": "Studijní obor",
+
+  // "item.page.thesis.degree-grantor": "Awarding institution",
+  "item.page.thesis.degree-grantor": "Udělující instituce",
+
   // "item.page.author": "Author",
   "item.page.author": "Autor",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -2909,6 +2909,21 @@
 
   "item.page.abstract": "Abstract",
 
+  // JCU: dc.description.abstract-translated is tagged eng throughout the repository, so the label
+  // names English rather than saying "translated". If a non-English translation ever appears, this
+  // should switch to reading the value's own language tag.
+  "item.page.abstract-translated": "Abstract (English)",
+
+  "item.page.type": "Document type",
+
+  "item.page.thesis.degree-name": "Degree",
+
+  "item.page.thesis.degree-program": "Study programme",
+
+  "item.page.thesis.degree-discipline": "Field of study",
+
+  "item.page.thesis.degree-grantor": "Awarding institution",
+
   "item.page.author": "Author",
 
   "item.page.authors": "Authors",

--- a/src/themes/custom/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/themes/custom/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -1,0 +1,144 @@
+@if (showBackButton$ | async) {
+  <ds-results-back-button [back]="back"></ds-results-back-button>
+}
+@if (iiifEnabled) {
+  <div class="row">
+    <div class="col-12">
+      <ds-mirador-viewer id="iiif-viewer"
+        [object]="object"
+        [searchable]="iiifSearchEnabled"
+        [query]="iiifQuery$ | async">
+      </ds-mirador-viewer>
+    </div>
+  </div>
+}
+
+<div class="d-flex flex-row">
+  <ds-item-page-title-field [item]="object" class="me-auto">
+  </ds-item-page-title-field>
+  <ds-dso-edit-menu></ds-dso-edit-menu>
+</div>
+<div class="row">
+  <div class="col-12 col-md-4">
+    @if (!(mediaViewer.image || mediaViewer.video)) {
+      <ds-metadata-field-wrapper [hideIfNoTextContent]="false">
+        <ds-thumbnail [thumbnail]="object?.thumbnail | async"></ds-thumbnail>
+      </ds-metadata-field-wrapper>
+    }
+    @if (mediaViewer.image || mediaViewer.video) {
+      <div class="mb-2">
+        <ds-media-viewer [item]="object"></ds-media-viewer>
+      </div>
+    }
+    <ds-item-page-file-section [item]="object"></ds-item-page-file-section>
+    <ds-item-page-date-field [item]="object"></ds-item-page-date-field>
+    <ds-metadata-representation-list class="ds-item-page-mixed-author-field"
+      [parentItem]="object"
+      [itemType]="'Person'"
+      [metadataFields]="['dc.contributor.author', 'dc.creator']"
+      [label]="'item.page.authors' | translate">
+    </ds-metadata-representation-list>
+    <ds-generic-item-page-field [item]="object"
+      [fields]="['journal.title']"
+      [label]="'item.page.journal-title'">
+    </ds-generic-item-page-field>
+    <ds-generic-item-page-field [item]="object"
+      [fields]="['journal.identifier.issn']"
+      [label]="'item.page.journal-issn'">
+    </ds-generic-item-page-field>
+    <ds-generic-item-page-field [item]="object"
+      [fields]="['journalvolume.identifier.name']"
+      [label]="'item.page.volume-title'">
+    </ds-generic-item-page-field>
+    <ds-generic-item-page-field [item]="object"
+      [fields]="['dc.publisher']"
+      [label]="'item.page.publisher'">
+    </ds-generic-item-page-field>
+    <!-- JCU is a repository of theses, so the document type and the degree the work was submitted
+         for are primary information. Upstream only exposes them on the full item page. -->
+    <ds-generic-item-page-field [item]="object"
+      [fields]="['dc.type']"
+      [separator]="', '"
+      [label]="'item.page.type'">
+    </ds-generic-item-page-field>
+    <ds-generic-item-page-field [item]="object"
+      [fields]="['dc.thesis.degree-name']"
+      [label]="'item.page.thesis.degree-name'">
+    </ds-generic-item-page-field>
+    <ds-generic-item-page-field [item]="object"
+      [fields]="['dc.thesis.degree-program']"
+      [label]="'item.page.thesis.degree-program'">
+    </ds-generic-item-page-field>
+    <ds-generic-item-page-field [item]="object"
+      [fields]="['dc.thesis.degree-discipline']"
+      [label]="'item.page.thesis.degree-discipline'">
+    </ds-generic-item-page-field>
+    <ds-generic-item-page-field [item]="object"
+      [fields]="['dc.thesis.degree-grantor']"
+      [label]="'item.page.thesis.degree-grantor'">
+    </ds-generic-item-page-field>
+  </div>
+  <div class="col-12 col-md-6">
+    <ds-item-page-citation-field [handle]="object?.handle"></ds-item-page-citation-field>
+    <ds-item-page-abstract-field [item]="object"></ds-item-page-abstract-field>
+    <!-- The translated abstract is shown next to the original rather than swapped in by UI
+         language, so neither version is ever hidden from a reader. enableMarkdown matches
+         ds-item-page-abstract-field, which renders dc.description.abstract the same way. -->
+    <ds-generic-item-page-field [item]="object"
+      [fields]="['dc.description.abstract-translated']"
+      [enableMarkdown]="true"
+      [label]="'item.page.abstract-translated'">
+    </ds-generic-item-page-field>
+    <ds-generic-item-page-field [item]="object"
+      [fields]="['dc.description']"
+      [label]="'item.page.description'">
+    </ds-generic-item-page-field>
+
+    <ds-generic-item-page-field [item]="object"
+      [fields]="['dc.subject']"
+      [separator]="', '"
+      [label]="'item.page.subject'">
+    </ds-generic-item-page-field>
+    <ds-generic-item-page-field [item]="object"
+      [fields]="['dc.identifier.citation']"
+      [label]="'item.page.citation'">
+    </ds-generic-item-page-field>
+    @if (geospatialItemPageFieldsEnabled) {
+      <ds-geospatial-item-page-field [item]="object"
+                                     [label]="'item.page.places'"
+                                     [pointFields]="['dcterms.spatial']"
+                                     [bboxFields]="['dcterms.spatial']"
+                                     [cluster]="true"
+      >
+      </ds-geospatial-item-page-field>
+    }
+    <ds-item-page-uri-field [item]="object"
+      [fields]="['dc.identifier.uri']"
+      [label]="'item.page.uri'">
+    </ds-item-page-uri-field>
+    <ds-item-page-collections [item]="object"></ds-item-page-collections>
+    <ds-item-page-uri-field [item]="object"
+      [fields]="['coar.notify.endorsedBy']"
+      [label]="'item.page.endorsement'">
+    </ds-item-page-uri-field>
+    <ds-item-page-uri-field [item]="object"
+      [fields]="['datacite.relation.isReviewedBy']"
+      [label]="'item.page.review'">
+    </ds-item-page-uri-field>
+    <ds-item-page-uri-field [item]="object"
+      [fields]="['datacite.relation.isSupplementedBy']"
+      [label]="'item.page.supplemented'">
+    </ds-item-page-uri-field>
+    <ds-item-page-uri-field [item]="object"
+      [fields]="['datacite.relation.isReferencedBy']"
+      [label]="'item.page.referenced'">
+    </ds-item-page-uri-field>
+    <ds-item-page-cc-license-field [item]="object" [variant]="'full'">
+    </ds-item-page-cc-license-field>
+    <div>
+      <a class="btn btn-outline-primary" [routerLink]="[itemPageRoute + '/full']" role="button" role="button" tabindex="0">
+        <i class="fas fa-info-circle"></i> {{"item.page.link.full" | translate}}
+      </a>
+    </div>
+  </div>
+</div>

--- a/src/themes/custom/app/item-page/simple/item-types/untyped-item/untyped-item.component.spec.ts
+++ b/src/themes/custom/app/item-page/simple/item-types/untyped-item/untyped-item.component.spec.ts
@@ -1,0 +1,206 @@
+import { HttpClient } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  NO_ERRORS_SCHEMA,
+} from '@angular/core';
+import {
+  ComponentFixture,
+  TestBed,
+  waitForAsync,
+} from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Store } from '@ngrx/store';
+import {
+  TranslateLoader,
+  TranslateModule,
+} from '@ngx-translate/core';
+import {
+  Observable,
+  of,
+} from 'rxjs';
+
+import { BrowseDefinitionDataService } from '../../../../../../../app/core/browse/browse-definition-data.service';
+import { RemoteDataBuildService } from '../../../../../../../app/core/cache/builders/remote-data-build.service';
+import { ObjectCacheService } from '../../../../../../../app/core/cache/object-cache.service';
+import { BitstreamDataService } from '../../../../../../../app/core/data/bitstream-data.service';
+import { CommunityDataService } from '../../../../../../../app/core/data/community-data.service';
+import { ConfigurationDataService } from '../../../../../../../app/core/data/configuration-data.service';
+import { DefaultChangeAnalyzer } from '../../../../../../../app/core/data/default-change-analyzer.service';
+import { DSOChangeAnalyzer } from '../../../../../../../app/core/data/dso-change-analyzer.service';
+import { ItemDataService } from '../../../../../../../app/core/data/item-data.service';
+import { RelationshipDataService } from '../../../../../../../app/core/data/relationship-data.service';
+import { RemoteData } from '../../../../../../../app/core/data/remote-data';
+import { VersionDataService } from '../../../../../../../app/core/data/version-data.service';
+import { VersionHistoryDataService } from '../../../../../../../app/core/data/version-history-data.service';
+import { RouteService } from '../../../../../../../app/core/services/route.service';
+import { Bitstream } from '../../../../../../../app/core/shared/bitstream.model';
+import { HALEndpointService } from '../../../../../../../app/core/shared/hal-endpoint.service';
+import { Item } from '../../../../../../../app/core/shared/item.model';
+import { MetadataMap } from '../../../../../../../app/core/shared/metadata.models';
+import { SearchService } from '../../../../../../../app/core/shared/search/search.service';
+import { UUIDService } from '../../../../../../../app/core/shared/uuid.service';
+import { WorkspaceitemDataService } from '../../../../../../../app/core/submission/workspaceitem-data.service';
+import { CollectionsComponent } from '../../../../../../../app/item-page/field-components/collections/collections.component';
+import { ThemedMediaViewerComponent } from '../../../../../../../app/item-page/media-viewer/themed-media-viewer.component';
+import { MiradorViewerComponent } from '../../../../../../../app/item-page/mirador-viewer/mirador-viewer.component';
+import { ThemedFileSectionComponent } from '../../../../../../../app/item-page/simple/field-components/file-section/themed-file-section.component';
+import { ItemPageAbstractFieldComponent } from '../../../../../../../app/item-page/simple/field-components/specific-field/abstract/item-page-abstract-field.component';
+import { ItemPageCcLicenseFieldComponent } from '../../../../../../../app/item-page/simple/field-components/specific-field/cc-license/item-page-cc-license-field.component';
+import { ItemPageCitationFieldComponent } from '../../../../../../../app/item-page/simple/field-components/specific-field/citation/item-page-citation.component';
+import { ItemPageDateFieldComponent } from '../../../../../../../app/item-page/simple/field-components/specific-field/date/item-page-date-field.component';
+import { GenericItemPageFieldComponent } from '../../../../../../../app/item-page/simple/field-components/specific-field/generic/generic-item-page-field.component';
+import { GeospatialItemPageFieldComponent } from '../../../../../../../app/item-page/simple/field-components/specific-field/geospatial/geospatial-item-page-field.component';
+import { ThemedItemPageTitleFieldComponent } from '../../../../../../../app/item-page/simple/field-components/specific-field/title/themed-item-page-field.component';
+import { ItemPageUriFieldComponent } from '../../../../../../../app/item-page/simple/field-components/specific-field/uri/item-page-uri-field.component';
+import { mockRouteService } from '../../../../../../../app/item-page/simple/item-types/shared/item.component.spec';
+import { ThemedMetadataRepresentationListComponent } from '../../../../../../../app/item-page/simple/metadata-representation-list/themed-metadata-representation-list.component';
+import { ItemVersionsSharedService } from '../../../../../../../app/item-page/versions/item-versions-shared.service';
+import { DsoEditMenuComponent } from '../../../../../../../app/shared/dso-page/dso-edit-menu/dso-edit-menu.component';
+import { MetadataFieldWrapperComponent } from '../../../../../../../app/shared/metadata-field-wrapper/metadata-field-wrapper.component';
+import { mockTruncatableService } from '../../../../../../../app/shared/mocks/mock-trucatable.service';
+import { TranslateLoaderMock } from '../../../../../../../app/shared/mocks/translate-loader.mock';
+import { NotificationsService } from '../../../../../../../app/shared/notifications/notifications.service';
+import { createSuccessfulRemoteDataObject$ } from '../../../../../../../app/shared/remote-data.utils';
+import { ThemedResultsBackButtonComponent } from '../../../../../../../app/shared/results-back-button/themed-results-back-button.component';
+import { BrowseDefinitionDataServiceStub } from '../../../../../../../app/shared/testing/browse-definition-data-service.stub';
+import { ConfigurationDataServiceStub } from '../../../../../../../app/shared/testing/configuration-data.service.stub';
+import { createPaginatedList } from '../../../../../../../app/shared/testing/utils.test';
+import { TruncatableService } from '../../../../../../../app/shared/truncatable/truncatable.service';
+import { ThemedThumbnailComponent } from '../../../../../../../app/thumbnail/themed-thumbnail.component';
+import {
+  APP_CONFIG,
+  APP_DATA_SERVICES_MAP,
+} from '../../../../../../../config/app-config.interface';
+import { environment } from '../../../../../../../environments/environment.test';
+import { UntypedItemComponent } from './untyped-item.component';
+
+/**
+ * The JCU theme owns this template so it can surface thesis metadata and the translated abstract
+ * on the simple item page. These tests pin the field list down: upstream only exposes those values
+ * on the full item page, and a future theme rebase must not silently drop them again.
+ */
+describe('UntypedItemComponent (custom theme)', () => {
+  let comp: UntypedItemComponent;
+  let fixture: ComponentFixture<UntypedItemComponent>;
+
+  /**
+   * Reads the `fields` input off every rendered ds-generic-item-page-field instance, which is what
+   * actually decides which metadata the page shows.
+   */
+  const declaredGenericFields = (): string[] =>
+    fixture.debugElement.queryAll(By.directive(GenericItemPageFieldComponent))
+      .map((el) => (el.componentInstance as GenericItemPageFieldComponent).fields)
+      .filter(Boolean)
+      .reduce((acc: string[], fields: string[]) => acc.concat(fields), []);
+
+  beforeEach(waitForAsync(() => {
+    const mockBitstreamDataService = {
+      getThumbnailFor(item: Item): Observable<RemoteData<Bitstream>> {
+        return createSuccessfulRemoteDataObject$(new Bitstream());
+      },
+    };
+
+    TestBed.configureTestingModule({
+      imports: [
+        TranslateModule.forRoot({
+          loader: { provide: TranslateLoader, useClass: TranslateLoaderMock },
+        }),
+        RouterTestingModule,
+        UntypedItemComponent,
+      ],
+      providers: [
+        { provide: ItemDataService, useValue: {} },
+        { provide: TruncatableService, useValue: mockTruncatableService },
+        { provide: RelationshipDataService, useValue: {} },
+        { provide: ObjectCacheService, useValue: {} },
+        { provide: UUIDService, useValue: {} },
+        { provide: Store, useValue: jasmine.createSpyObj('store', { dispatch: undefined, select: undefined, pipe: of(true) }) },
+        { provide: RemoteDataBuildService, useValue: {} },
+        { provide: CommunityDataService, useValue: {} },
+        { provide: HALEndpointService, useValue: {} },
+        { provide: NotificationsService, useValue: {} },
+        { provide: HttpClient, useValue: {} },
+        { provide: DSOChangeAnalyzer, useValue: {} },
+        { provide: DefaultChangeAnalyzer, useValue: {} },
+        { provide: VersionHistoryDataService, useValue: {} },
+        { provide: VersionDataService, useValue: {} },
+        { provide: BitstreamDataService, useValue: mockBitstreamDataService },
+        { provide: WorkspaceitemDataService, useValue: {} },
+        { provide: SearchService, useValue: {} },
+        { provide: ItemVersionsSharedService, useValue: {} },
+        { provide: RouteService, useValue: mockRouteService },
+        { provide: BrowseDefinitionDataService, useValue: BrowseDefinitionDataServiceStub },
+        { provide: ConfigurationDataService, useValue: new ConfigurationDataServiceStub() },
+        { provide: APP_CONFIG, useValue: environment },
+        { provide: APP_DATA_SERVICES_MAP, useValue: {} },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).overrideComponent(UntypedItemComponent, {
+      add: { changeDetection: ChangeDetectionStrategy.Default },
+      // Everything except ds-generic-item-page-field is stubbed out by NO_ERRORS_SCHEMA: these
+      // tests are about which fields the template declares, not about rendering each one.
+      remove: {
+        imports: [
+          ThemedResultsBackButtonComponent,
+          MiradorViewerComponent,
+          ThemedItemPageTitleFieldComponent,
+          DsoEditMenuComponent,
+          MetadataFieldWrapperComponent,
+          ThemedThumbnailComponent,
+          ThemedMediaViewerComponent,
+          ThemedFileSectionComponent,
+          ItemPageDateFieldComponent,
+          ThemedMetadataRepresentationListComponent,
+          ItemPageAbstractFieldComponent,
+          ItemPageCcLicenseFieldComponent,
+          ItemPageCitationFieldComponent,
+          ItemPageUriFieldComponent,
+          GeospatialItemPageFieldComponent,
+          CollectionsComponent,
+        ],
+      },
+    });
+  }));
+
+  beforeEach(waitForAsync(() => {
+    TestBed.compileComponents();
+    fixture = TestBed.createComponent(UntypedItemComponent);
+    comp = fixture.componentInstance;
+    comp.object = Object.assign(new Item(), {
+      bundles: createSuccessfulRemoteDataObject$(createPaginatedList([])),
+      metadata: new MetadataMap(),
+      relationships: of([]),
+    });
+    fixture.detectChanges();
+  }));
+
+  it('should render the translated abstract next to the original', () => {
+    expect(declaredGenericFields()).toContain('dc.description.abstract-translated');
+    // The original abstract keeps its own dedicated component, so both are shown.
+    expect(fixture.debugElement.queryAll(By.css('ds-item-page-abstract-field')).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should render the document type', () => {
+    expect(declaredGenericFields()).toContain('dc.type');
+  });
+
+  it('should render every thesis field', () => {
+    const declared = declaredGenericFields();
+
+    [
+      'dc.thesis.degree-name',
+      'dc.thesis.degree-program',
+      'dc.thesis.degree-discipline',
+      'dc.thesis.degree-grantor',
+    ].forEach((field) => expect(declared).toContain(field));
+  });
+
+  it('should keep the upstream fields it inherited', () => {
+    const declared = declaredGenericFields();
+
+    ['dc.publisher', 'dc.subject', 'dc.description'].forEach((field) => expect(declared).toContain(field));
+    expect(fixture.debugElement.queryAll(By.css('ds-item-page-uri-field')).length).toBeGreaterThanOrEqual(1);
+    expect(fixture.debugElement.queryAll(By.css('ds-item-page-collections')).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/themes/custom/app/item-page/simple/item-types/untyped-item/untyped-item.component.ts
+++ b/src/themes/custom/app/item-page/simple/item-types/untyped-item/untyped-item.component.ts
@@ -36,8 +36,9 @@ import { ThemedThumbnailComponent } from '../../../../../../../app/thumbnail/the
   styleUrls: [
     '../../../../../../../app/item-page/simple/item-types/untyped-item/untyped-item.component.scss',
   ],
-  // templateUrl: './untyped-item.component.html',
-  templateUrl: '../../../../../../../app/item-page/simple/item-types/untyped-item/untyped-item.component.html',
+  // The theme now owns this template: it adds the JCU thesis fields and the translated abstract
+  // on top of the upstream layout, so it can no longer reuse the base template.
+  templateUrl: './untyped-item.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     AsyncPipe,


### PR DESCRIPTION
Fixes **M9** from the JCU #853 audit: the English abstract and the thesis metadata never reached the item page.

## Reproduced on production

Item [`261a145d`](https://dspace-new.jcu.cz/items/261a145d-b059-4e51-9ff4-c494ec0f0db4) carries:

```
dc.description.abstract              [cze] Tato diplomová práce spojuje téma rozšířené reality…
dc.description.abstract-translated   [eng] This thesis combines topic of augmented reality with tourism…
dc.type                              [cze] diplomová práce
dc.thesis.degree-name                [-]   Ing.
dc.thesis.degree-program             [cze] Ekonomika a management
dc.thesis.degree-discipline          [cze] Obchodní podnikání
dc.thesis.degree-grantor             [cze] Jihočeská univerzita. Ekonomická fakulta
```

With the UI in **English**, the page showed the **Czech** abstract under "Abstract", no English abstract, and none of `dc.type` or `dc.thesis.*`. In a repository of qualification theses, the degree, programme, field of study and awarding faculty were reachable only through "Full item page".

## Why it had to go in the theme

JCU items render through `ds-untyped-item` (no entity type). The theme *already had* an `UntypedItemComponent` override registered in `eager-theme.module.ts`, but its `templateUrl` pointed back at the upstream template with the local file left as 0-byte scaffolding — so there was nowhere to add anything.

The theme now owns the template. Core is untouched, which matters: `dc.thesis.*` is not an upstream schema and does not belong in `src/app/`.

## Layout

- **Left column**, after Publisher: Document type, Degree, Study programme, Field of study, Awarding institution — grouped with the other "about the work" metadata.
- **Right column**, directly under the existing abstract: the translated abstract.

Both abstracts are shown **side by side** rather than swapped by UI language, which is what the audit recommended — nothing is ever hidden from a reader, and it avoids using the `-translated` suffix as control flow. The translated field gets `[enableMarkdown]="true"` to match how `ds-item-page-abstract-field` renders the original.

## On the "(English)" label

`dc.description.abstract-translated` is tagged `eng` in **13/13** values sampled on production, against `cze` / `cs_CZ` / untagged on the original. So the label names the language, because that is far more useful to the reader this fix exists for. If a non-English translation ever shows up, the label should be driven by the value's own language tag — there is a comment on the key saying so.

## Verification

Local 9.3 stack, item seeded with all six values (fields registered in the local registry first — they were absent from the sample dataset):

**before**
<img width="1265" height="956" alt="M9-1-before-prod-item-page-cs-no-en-abstract-no-thesis" src="https://github.com/user-attachments/assets/d7990e6e-064f-4e23-8d44-41218f2a42e8" />

| CS UI | Abstrakt + **Abstrakt (anglicky)**, Typ dokumentu, Akademický titul, Studijní program, Studijní obor, Udělující instituce |
<img width="1265" height="1013" alt="M9-3-after-local-cs-en-abstract-and-thesis-fields" src="https://github.com/user-attachments/assets/f10f995f-df7b-4b9f-ae5e-5e4857ad33cf" />
| EN UI | Abstract + **Abstract (English)**, Document type, Degree, Study programme, Field of study, Awarding institution |
| item with none of the fields | only Document type (it has `dc.type`); `ds-metadata-field-wrapper` hides the rest — **no empty labels** |
<img width="1265" height="1013" alt="M9-4-after-local-en-ui-abstract-and-thesis-fields" src="https://github.com/user-attachments/assets/38a9b798-d463-46b1-9fd7-8e3de1c881e0" />

`ng lint` 0 errors · specs **38/38**, 4 new. The new tests read the `fields` input off each rendered `ds-generic-item-page-field`, so a future theme rebase that drops a field fails the build rather than silently regressing.

## Worth a look from you

- **Czech labels** — "Akademický titul", "Studijní program", "Studijní obor", "Udělující instituce". These are my wording; if JCU has house terms, they are one-line changes in `cs.json5`.
- **`dc.description.department` and `dc.description.grade`** also exist in the data ("Přírodovědecká fakulta", "Dokončená práce s úspěšnou obhajobou"). Not in the audit's scope, so not added — say the word and they are two more blocks.
- **`dc.type` is free text** (`bakalářská práce`, `diplomová práce`, … plus 3 English `article`). Now that it is visible, the inconsistency is visible too. That is **L8**, and it needs a controlled vocabulary decision from the customer.
