### PR TITLE
Clarin9/Fix "latest version" notice link ignoring the /repository base href (#876)

### DIFF
--- a/src/app/item-page/versions/notice/item-versions-notice.component.spec.ts
+++ b/src/app/item-page/versions/notice/item-versions-notice.component.spec.ts
@@ -1,4 +1,7 @@
-import { Location } from '@angular/common';
+import {
+  APP_BASE_HREF,
+  Location,
+} from '@angular/common';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import {
   ComponentFixture,
@@ -135,13 +138,18 @@ describe('ItemVersionsNoticeComponent', () => {
     });
 
     it('should resolve the latest version item page url against the base href', () => {
+      locationStub.prepareExternalUrl.calls.reset();
+
       expect(component.getItemPage(latestItem)).toEqual('/repository/items/latest_item_id');
       // The plain router path must be what is handed to Location, otherwise the prefix would be applied twice
-      expect(locationStub.prepareExternalUrl).toHaveBeenCalledWith('/items/latest_item_id');
+      expect(locationStub.prepareExternalUrl).toHaveBeenCalledOnceWith('/items/latest_item_id');
     });
 
     it('should not resolve a url when no item is provided', () => {
+      locationStub.prepareExternalUrl.calls.reset();
+
       expect(component.getItemPage(undefined)).toBeUndefined();
+      expect(locationStub.prepareExternalUrl).not.toHaveBeenCalled();
     });
 
     it('should render the notice anchor with the base href applied', () => {
@@ -156,6 +164,55 @@ describe('ItemVersionsNoticeComponent', () => {
       expect(anchor).not.toBeNull();
       expect(anchor.nativeElement.getAttribute('href')).toEqual('/repository/items/latest_item_id');
     });
+  });
+
+  describe('getItemPage with the real Location', () => {
+    // Exercises the actual PathLocationStrategy instead of a stub, so the "no-op for the vanilla
+    // NAMESPACE=/ deployment" claim is covered rather than asserted only in a comment.
+    [
+      { baseHref: '/', expected: '/items/latest_item_id' },
+      { baseHref: '/repository/', expected: '/repository/items/latest_item_id' },
+      // the form express hands to the SSR platform injector (req.baseUrl, no trailing slash)
+      { baseHref: '/repository', expected: '/repository/items/latest_item_id' },
+    ].forEach(({ baseHref, expected }) => {
+      it(`should resolve the item page url against base href '${baseHref}'`, () => {
+        expect(createComponentWithBaseHref(baseHref).getItemPage(latestItem)).toEqual(expected);
+      });
+    });
+
+    it('should keep the entity route shape and only add the prefix', () => {
+      const entityItem = Object.assign(new Item(), {
+        id: 'entity_item_id',
+        uuid: 'entity_item_id',
+        metadata: { 'dspace.entity.type': [{ value: 'Publication' }] },
+      });
+
+      expect(createComponentWithBaseHref('/repository/').getItemPage(entityItem))
+        .toEqual('/repository/entities/publication/entity_item_id');
+    });
+
+    function createComponentWithBaseHref(baseHref: string): ItemVersionsNoticeComponent {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        // RouterTestingModule is deliberately left out: it contributes SpyLocation/MockLocationStrategy,
+        // which ignore APP_BASE_HREF. Without it the root-provided Location/PathLocationStrategy are used.
+        imports: [
+          TranslateModule.forRoot(),
+          ItemVersionsNoticeComponent,
+          NoopAnimationsModule,
+        ],
+        providers: [
+          { provide: VersionHistoryDataService, useValue: versionHistoryServiceSpy },
+          { provide: APP_BASE_HREF, useValue: baseHref },
+        ],
+        schemas: [NO_ERRORS_SCHEMA],
+      });
+
+      const realLocationFixture = TestBed.createComponent(ItemVersionsNoticeComponent);
+      realLocationFixture.componentInstance.item = firstItem;
+      realLocationFixture.detectChanges();
+      return realLocationFixture.componentInstance;
+    }
   });
 
   function initComponentWithItem(item: Item) {

--- a/src/app/item-page/versions/notice/item-versions-notice.component.spec.ts
+++ b/src/app/item-page/versions/notice/item-versions-notice.component.spec.ts
@@ -167,8 +167,7 @@ describe('ItemVersionsNoticeComponent', () => {
   });
 
   describe('getItemPage with the real Location', () => {
-    // Exercises the actual PathLocationStrategy instead of a stub, so the "no-op for the vanilla
-    // NAMESPACE=/ deployment" claim is covered rather than asserted only in a comment.
+    // the real PathLocationStrategy, so the "no-op for NAMESPACE=/" claim is actually covered
     [
       { baseHref: '/', expected: '/items/latest_item_id' },
       { baseHref: '/repository/', expected: '/repository/items/latest_item_id' },
@@ -194,8 +193,7 @@ describe('ItemVersionsNoticeComponent', () => {
     function createComponentWithBaseHref(baseHref: string): ItemVersionsNoticeComponent {
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({
-        // RouterTestingModule is deliberately left out: it contributes SpyLocation/MockLocationStrategy,
-        // which ignore APP_BASE_HREF. Without it the root-provided Location/PathLocationStrategy are used.
+        // no RouterTestingModule on purpose: its SpyLocation/MockLocationStrategy ignore APP_BASE_HREF
         imports: [
           TranslateModule.forRoot(),
           ItemVersionsNoticeComponent,

--- a/src/app/item-page/versions/notice/item-versions-notice.component.spec.ts
+++ b/src/app/item-page/versions/notice/item-versions-notice.component.spec.ts
@@ -1,3 +1,4 @@
+import { Location } from '@angular/common';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import {
   ComponentFixture,
@@ -7,7 +8,10 @@ import {
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
-import { TranslateModule } from '@ngx-translate/core';
+import {
+  TranslateModule,
+  TranslateService,
+} from '@ngx-translate/core';
 import { of } from 'rxjs';
 import { take } from 'rxjs/operators';
 
@@ -61,6 +65,7 @@ describe('ItemVersionsNoticeComponent', () => {
   const versionHistoryServiceSpy = jasmine.createSpyObj('versionHistoryService',
     ['getVersions', 'getLatestVersionFromHistory$', 'isLatest$' ],
   );
+  const locationStub = jasmine.createSpyObj('location', ['prepareExternalUrl']);
 
   beforeEach(waitForAsync(() => {
 
@@ -73,6 +78,7 @@ describe('ItemVersionsNoticeComponent', () => {
       ],
       providers: [
         { provide: VersionHistoryDataService, useValue: versionHistoryServiceSpy },
+        { provide: Location, useValue: locationStub },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
@@ -84,6 +90,8 @@ describe('ItemVersionsNoticeComponent', () => {
     versionHistoryServiceSpy.getVersions.and.returnValue(createSuccessfulRemoteDataObject$(createPaginatedList(versions)));
     versionHistoryServiceSpy.getLatestVersionFromHistory$.and.returnValue(of(latestVersion));
     versionHistoryServiceSpy.isLatest$.and.callFake(isLatestFcn);
+    // Simulate a UI deployed under a sub-path namespace, i.e. <base href="/repository/">
+    locationStub.prepareExternalUrl.and.callFake((url: string) => `/repository${url}`);
   }));
 
   describe('when the item is the latest version', () => {
@@ -118,6 +126,35 @@ describe('ItemVersionsNoticeComponent', () => {
       versionHistoryService.isLatest$(latestVersion).pipe(take(1)).subscribe((res) => {
         expect(res).toBeTrue();
       });
+    });
+  });
+
+  describe('getItemPage', () => {
+    beforeEach(() => {
+      initComponentWithItem(firstItem);
+    });
+
+    it('should resolve the latest version item page url against the base href', () => {
+      expect(component.getItemPage(latestItem)).toEqual('/repository/items/latest_item_id');
+      // The plain router path must be what is handed to Location, otherwise the prefix would be applied twice
+      expect(locationStub.prepareExternalUrl).toHaveBeenCalledWith('/items/latest_item_id');
+    });
+
+    it('should not resolve a url when no item is provided', () => {
+      expect(component.getItemPage(undefined)).toBeUndefined();
+    });
+
+    it('should render the notice anchor with the base href applied', () => {
+      const translate = TestBed.inject(TranslateService);
+      translate.setTranslation('en', {
+        'item.version.notice': 'The latest version can be found <a href=\'{{destination}}\'>here</a>.',
+      }, true);
+      translate.use('en');
+      fixture.detectChanges();
+
+      const anchor = fixture.debugElement.query(By.css('ds-alert a'));
+      expect(anchor).not.toBeNull();
+      expect(anchor.nativeElement.getAttribute('href')).toEqual('/repository/items/latest_item_id');
     });
   });
 

--- a/src/app/item-page/versions/notice/item-versions-notice.component.ts
+++ b/src/app/item-page/versions/notice/item-versions-notice.component.ts
@@ -144,9 +144,12 @@ export class ItemVersionsNoticeComponent implements OnInit {
    * `Location.prepareExternalUrl` applies the exact same transformation `RouterLink`
    * applies to its `href`, and is a no-op when the base href is `/`.
    *
+   * The template calls this while the latest version is still loading, so `item` - and therefore
+   * the returned url - may be undefined.
+   *
    * @param item The item for which the url is requested
    */
-  getItemPage(item: Item): string {
+  getItemPage(item: Item | undefined): string | undefined {
     if (hasValue(item)) {
       return this.location.prepareExternalUrl(getItemPageRoute(item));
     }

--- a/src/app/item-page/versions/notice/item-versions-notice.component.ts
+++ b/src/app/item-page/versions/notice/item-versions-notice.component.ts
@@ -1,4 +1,7 @@
-import { AsyncPipe } from '@angular/common';
+import {
+  AsyncPipe,
+  Location,
+} from '@angular/common';
 import {
   Component,
   Input,
@@ -84,7 +87,10 @@ export class ItemVersionsNoticeComponent implements OnInit {
    */
   public AlertTypeEnum = AlertType;
 
-  constructor(private versionHistoryService: VersionHistoryDataService) {
+  constructor(
+    private versionHistoryService: VersionHistoryDataService,
+    private location: Location,
+  ) {
   }
 
   /**
@@ -128,12 +134,21 @@ export class ItemVersionsNoticeComponent implements OnInit {
   }
 
   /**
-   * Get the item page url
+   * Get the item page url, resolved against the application's base href.
+   *
+   * The url is interpolated into the raw `<a href='{{destination}}'>` anchor of the
+   * `item.version.notice` translation, which the alert renders through `[innerHTML]`.
+   * It is therefore resolved by the browser and not by the Angular router, so a
+   * root-relative router path such as `/items/<uuid>` would ignore `<base href>` and
+   * break every deployment served from a sub-path (e.g. `<base href="/repository/">`).
+   * `Location.prepareExternalUrl` applies the exact same transformation `RouterLink`
+   * applies to its `href`, and is a no-op when the base href is `/`.
+   *
    * @param item The item for which the url is requested
    */
   getItemPage(item: Item): string {
     if (hasValue(item)) {
-      return getItemPageRoute(item);
+      return this.location.prepareExternalUrl(getItemPageRoute(item));
     }
   }
 }

--- a/src/app/item-page/versions/notice/item-versions-notice.component.ts
+++ b/src/app/item-page/versions/notice/item-versions-notice.component.ts
@@ -134,18 +134,11 @@ export class ItemVersionsNoticeComponent implements OnInit {
   }
 
   /**
-   * Get the item page url, resolved against the application's base href.
+   * Get the item page url, resolved against the base href. The url lands in the raw `<a href>` of the
+   * `item.version.notice` translation, so the browser resolves it and not the router - a plain
+   * `/items/<uuid>` would ignore `<base href="/repository/">`. No-op when the base href is `/`.
    *
-   * The url is interpolated into the raw `<a href='{{destination}}'>` anchor of the
-   * `item.version.notice` translation, which the alert renders through `[innerHTML]`.
-   * It is therefore resolved by the browser and not by the Angular router, so a
-   * root-relative router path such as `/items/<uuid>` would ignore `<base href>` and
-   * break every deployment served from a sub-path (e.g. `<base href="/repository/">`).
-   * `Location.prepareExternalUrl` applies the exact same transformation `RouterLink`
-   * applies to its `href`, and is a no-op when the base href is `/`.
-   *
-   * The template calls this while the latest version is still loading, so `item` - and therefore
-   * the returned url - may be undefined.
+   * Undefined while the latest version is still loading.
    *
    * @param item The item for which the url is requested
    */


### PR DESCRIPTION
## Problem description

Fixes **A2** of dataquest-dev/dspace-customers#876 (analysed in dataquest-dev/dspace-customers#871).

Anonymous → `http://dev-6.pc:8603/repository/handle/11858/00-097C-0000-0023-9551-4` (HamleDT 2.0, version 1 of 2).
The notice *"This is not the latest version of this item. The latest version can be found here."* renders fine, but the
anchor is `href="/items/ff7c3631-…"` — **without the `/repository` prefix** — so clicking it hits nginx and 404s.
It is the only root-relative link on the page without the prefix; the version-history links
(`/repository/items/version/250`) are correct. On 7.6.5 the same link is correct.

## Analysis

The `item.version.notice` translation embeds a **raw HTML anchor**:

```
"item.version.notice": "This is not the latest version of this item. The latest version can be found <a href='{{destination}}'>here</a>.",
```

and `ds-alert` renders it through `[innerHTML]` (`shared/alert/alert.component.html:4`). So `{{destination}}` becomes a
literal browser-resolved `href`, **not** an Angular `routerLink`. `getItemPage()` fed it the bare router path
`getItemPageRoute(item)` → `/items/<uuid>`, and `<base href>` only applies to *relative* URLs — root-relative ones
always resolve against the origin. Every other link on the page uses `[routerLink]`, and `RouterLink` renders its
`href` through `LocationStrategy.prepareExternalUrl()`, which is exactly why only this one anchor is broken.

The file is byte-identical to upstream DSpace 9.x here — 7.6.5 carried a LINDAT-only `destinationUrl$` derived from
`document.location.pathname` that the v9 port dropped. This is an upstream bug that only shows up when
`ui.nameSpace !== '/'`.

**Fix:** run the route through `Location.prepareExternalUrl()` — the same transform `RouterLink` applies — which is a
strict no-op when the base href is `/`, so vanilla deployments are unaffected.

Re-porting the 7.6.5 hack was rejected: it slices the *current* pathname, so on the **full** item page
(`/repository/items/<uuid>/full`, where the notice also renders) it would produce
`/repository/items/<uuid>/<latestUuid>` → 404, it ignores entity-type routing (`/entities/publication/<uuid>`), and
`document.location` is not meaningful under SSR.

## Tests

* `item-versions-notice.component.spec.ts` — 3 new specs: the url is resolved against the base href, the *unprefixed*
  router path is what gets handed to `Location` (guards against a future double-prefix), the `hasValue` guard still
  short-circuits, and a DOM-level assertion that the rendered `<a>` really carries `/repository/items/<uuid>`.
* Verified locally: this spec 7/7, `item-page/full` + `item-page/simple` specs 55/55, full `ng lint` clean.

## Out of scope (follow-ups, same defect, different features)

Three other places interpolate a root-relative router path into a raw-anchor translation and have the identical bug:
`group-form.component` (`admin.access-control.groups.form.alert.workflowGroup`),
`grant-deny-request-copy.component` (`grant-deny-request-copy.intro1`) and
`suggestions-page.component` (`suggestion.approveAndImport.success`). Each needs the same one-liner; kept out of this
PR to keep it reviewable.

### Sync verification
No translation files were changed — the fix is entirely on the value side of `{{destination}}`.

### Manual Testing (if applicable)
- [ ] Anonymous, on a `/repository` deployment: open version 1 of a versioned item, inspect the notice anchor →
      `href="/repository/items/<latest-uuid>"`, and clicking it loads the latest version instead of a 404.
- [ ] Same on `/repository/items/<uuid>/full`.
- [ ] On a `NAMESPACE=/` instance the anchor is unchanged (`/items/<uuid>`).

### Copilot review
- [x] Requested review from Copilot
