### PR TITLE
Clarin9/Redirect to login when an identifier resolves to a restricted object (#876)

### DIFF
--- a/src/app/lookup-by-id/lookup-guard.spec.ts
+++ b/src/app/lookup-by-id/lookup-guard.spec.ts
@@ -90,7 +90,7 @@ describe('lookupGuard', () => {
     expect(dsoService.findByIdAndIDType).toHaveBeenCalledWith('34cfed7c-f597-49ef-9cbe-ea351f0023c2', IdentifierType.UUID);
   });
 
-  it('should resolve its dependencies from the injector when they are not passed in', () => {
+  it('should resolve its dependencies from the injector when they are not passed in', (done) => {
     TestBed.configureTestingModule({
       providers: [
         { provide: DsoRedirectService, useValue: dsoService },
@@ -103,7 +103,10 @@ describe('lookupGuard', () => {
     const result = TestBed.runInInjectionContext(() => lookupGuard(handleRoute, state)) as Observable<boolean | UrlTree>;
 
     expect(dsoService.findByIdAndIDType).toHaveBeenCalledWith('hdl:123456789/1234', IdentifierType.HANDLE);
-    result.subscribe((activate) => expect(activate).toBeFalse());
+    result.subscribe((activate) => {
+      expect(activate).toBeFalse();
+      done();
+    });
   });
 
   describe('when the object was found', () => {

--- a/src/app/lookup-by-id/lookup-guard.spec.ts
+++ b/src/app/lookup-by-id/lookup-guard.spec.ts
@@ -1,17 +1,42 @@
+import { UrlTree } from '@angular/router';
 import { of } from 'rxjs';
 
 import { IdentifierType } from '../core/data/request.models';
+import {
+  createFailedRemoteDataObject,
+  createSuccessfulRemoteDataObject,
+} from '../shared/remote-data.utils';
 import { lookupGuard } from './lookup-guard';
 
 describe('lookupGuard', () => {
   let dsoService: any;
+  let authService: any;
+  let router: any;
   let guard: any;
+  let forbiddenUrlTree: UrlTree;
+  let loginUrlTree: UrlTree;
+
+  const state: any = { url: '/handle/123456789/1234' };
+  const handleRoute: any = {
+    params: {
+      id: '1234',
+      idType: '123456789',
+    },
+  };
 
   beforeEach(() => {
     dsoService = {
-      findByIdAndIDType: jasmine.createSpy('findByIdAndIDType').and.returnValue(of({ hasFailed: false,
-        hasSucceeded: true })),
+      findByIdAndIDType: jasmine.createSpy('findByIdAndIDType')
+        .and.returnValue(of(createSuccessfulRemoteDataObject(undefined))),
     };
+    authService = jasmine.createSpyObj('authService', {
+      isAuthenticated: of(false),
+      setRedirectUrl: {},
+    });
+    forbiddenUrlTree = new UrlTree();
+    loginUrlTree = new UrlTree();
+    router = jasmine.createSpyObj('router', ['parseUrl']);
+    router.parseUrl.and.callFake((url: string) => url === '/403' ? forbiddenUrlTree : loginUrlTree);
     guard = lookupGuard;
   });
 
@@ -22,18 +47,18 @@ describe('lookupGuard', () => {
         idType: '123456789',
       },
     };
-    guard(scopedRoute as any, undefined, dsoService);
+    guard(scopedRoute as any, state, dsoService, authService, router);
     expect(dsoService.findByIdAndIDType).toHaveBeenCalledWith('hdl:123456789/1234', IdentifierType.HANDLE);
   });
 
-  it('should call findByIdAndIDType with handle params', () => {
+  it('should call findByIdAndIDType with encoded handle params', () => {
     const scopedRoute = {
       params: {
         id: '123456789%2F1234',
         idType: 'handle',
       },
     };
-    guard(scopedRoute as any, undefined, dsoService);
+    guard(scopedRoute as any, state, dsoService, authService, router);
     expect(dsoService.findByIdAndIDType).toHaveBeenCalledWith('hdl:123456789%2F1234', IdentifierType.HANDLE);
   });
 
@@ -44,8 +69,94 @@ describe('lookupGuard', () => {
         idType: 'uuid',
       },
     };
-    guard(scopedRoute as any, undefined, dsoService);
+    guard(scopedRoute as any, state, dsoService, authService, router);
     expect(dsoService.findByIdAndIDType).toHaveBeenCalledWith('34cfed7c-f597-49ef-9cbe-ea351f0023c2', IdentifierType.UUID);
+  });
+
+  describe('when the object was found', () => {
+    it('should return false so the ObjectNotFound page is not shown', (done) => {
+      guard(handleRoute, state, dsoService, authService, router).subscribe((result) => {
+        expect(result).toBeFalse();
+        done();
+      });
+    });
+  });
+
+  describe('when the lookup fails with a 404', () => {
+    beforeEach(() => {
+      dsoService.findByIdAndIDType.and.returnValue(of(createFailedRemoteDataObject('Not found', 404)));
+    });
+
+    it('should return true so the ObjectNotFound page is shown', (done) => {
+      guard(handleRoute, state, dsoService, authService, router).subscribe((result) => {
+        expect(result).toBeTrue();
+        expect(authService.setRedirectUrl).not.toHaveBeenCalled();
+        expect(router.parseUrl).not.toHaveBeenCalled();
+        done();
+      });
+    });
+  });
+
+  describe('when the lookup fails with a 500', () => {
+    beforeEach(() => {
+      dsoService.findByIdAndIDType.and.returnValue(of(createFailedRemoteDataObject('Server error', 500)));
+    });
+
+    it('should return true so the ObjectNotFound page is shown', (done) => {
+      guard(handleRoute, state, dsoService, authService, router).subscribe((result) => {
+        expect(result).toBeTrue();
+        expect(router.parseUrl).not.toHaveBeenCalled();
+        done();
+      });
+    });
+  });
+
+  describe('when the lookup fails with a 401 and the user is not authenticated', () => {
+    beforeEach(() => {
+      dsoService.findByIdAndIDType.and.returnValue(of(createFailedRemoteDataObject('Unauthorized', 401)));
+      authService.isAuthenticated.and.returnValue(of(false));
+    });
+
+    it('should store the requested url and return a UrlTree to the login page', (done) => {
+      guard(handleRoute, state, dsoService, authService, router).subscribe((result) => {
+        expect(authService.setRedirectUrl).toHaveBeenCalledWith(state.url);
+        expect(router.parseUrl).toHaveBeenCalledWith('login');
+        expect(result).toBe(loginUrlTree);
+        done();
+      });
+    });
+  });
+
+  describe('when the lookup fails with a 403 and the user is not authenticated', () => {
+    beforeEach(() => {
+      dsoService.findByIdAndIDType.and.returnValue(of(createFailedRemoteDataObject('Forbidden', 403)));
+      authService.isAuthenticated.and.returnValue(of(false));
+    });
+
+    it('should store the requested url and return a UrlTree to the login page', (done) => {
+      guard(handleRoute, state, dsoService, authService, router).subscribe((result) => {
+        expect(authService.setRedirectUrl).toHaveBeenCalledWith(state.url);
+        expect(router.parseUrl).toHaveBeenCalledWith('login');
+        expect(result).toBe(loginUrlTree);
+        done();
+      });
+    });
+  });
+
+  describe('when the lookup fails with a 403 and the user is authenticated', () => {
+    beforeEach(() => {
+      dsoService.findByIdAndIDType.and.returnValue(of(createFailedRemoteDataObject('Forbidden', 403)));
+      authService.isAuthenticated.and.returnValue(of(true));
+    });
+
+    it('should return a UrlTree to the forbidden page and not touch the redirect url', (done) => {
+      guard(handleRoute, state, dsoService, authService, router).subscribe((result) => {
+        expect(authService.setRedirectUrl).not.toHaveBeenCalled();
+        expect(router.parseUrl).toHaveBeenCalledWith('/403');
+        expect(result).toBe(forbiddenUrlTree);
+        done();
+      });
+    });
   });
 
 });

--- a/src/app/lookup-by-id/lookup-guard.spec.ts
+++ b/src/app/lookup-by-id/lookup-guard.spec.ts
@@ -1,7 +1,19 @@
-import { UrlTree } from '@angular/router';
-import { of } from 'rxjs';
+import { TestBed } from '@angular/core/testing';
+import {
+  Router,
+  UrlTree,
+} from '@angular/router';
+import {
+  BehaviorSubject,
+  Observable,
+  of,
+} from 'rxjs';
+import { take } from 'rxjs/operators';
 
+import { AuthService } from '../core/auth/auth.service';
+import { DsoRedirectService } from '../core/data/dso-redirect.service';
 import { IdentifierType } from '../core/data/request.models';
+import { ServerResponseService } from '../core/services/server-response.service';
 import {
   createFailedRemoteDataObject,
   createSuccessfulRemoteDataObject,
@@ -12,6 +24,8 @@ describe('lookupGuard', () => {
   let dsoService: any;
   let authService: any;
   let router: any;
+  let serverResponseService: any;
+  // the guard is typed as CanActivateFn, so its injected parameters can only be passed positionally through `any`
   let guard: any;
   let forbiddenUrlTree: UrlTree;
   let loginUrlTree: UrlTree;
@@ -30,14 +44,17 @@ describe('lookupGuard', () => {
         .and.returnValue(of(createSuccessfulRemoteDataObject(undefined))),
     };
     authService = jasmine.createSpyObj('authService', {
-      isAuthenticated: of(false),
+      // the real AuthService returns a store selector, which never completes
+      isAuthenticated: new BehaviorSubject(false),
       setRedirectUrl: {},
     });
     forbiddenUrlTree = new UrlTree();
     loginUrlTree = new UrlTree();
     router = jasmine.createSpyObj('router', ['parseUrl']);
     router.parseUrl.and.callFake((url: string) => url === '/403' ? forbiddenUrlTree : loginUrlTree);
-    guard = lookupGuard;
+    serverResponseService = jasmine.createSpyObj('serverResponseService', ['setStatus']);
+    guard = (route: any, routerState: any): Observable<boolean | UrlTree> =>
+      (lookupGuard as any)(route, routerState, dsoService, authService, router, serverResponseService);
   });
 
   it('should call findByIdAndIDType with handle params', () => {
@@ -47,7 +64,7 @@ describe('lookupGuard', () => {
         idType: '123456789',
       },
     };
-    guard(scopedRoute as any, state, dsoService, authService, router);
+    guard(scopedRoute, state);
     expect(dsoService.findByIdAndIDType).toHaveBeenCalledWith('hdl:123456789/1234', IdentifierType.HANDLE);
   });
 
@@ -58,7 +75,7 @@ describe('lookupGuard', () => {
         idType: 'handle',
       },
     };
-    guard(scopedRoute as any, state, dsoService, authService, router);
+    guard(scopedRoute, state);
     expect(dsoService.findByIdAndIDType).toHaveBeenCalledWith('hdl:123456789%2F1234', IdentifierType.HANDLE);
   });
 
@@ -69,14 +86,31 @@ describe('lookupGuard', () => {
         idType: 'uuid',
       },
     };
-    guard(scopedRoute as any, state, dsoService, authService, router);
+    guard(scopedRoute, state);
     expect(dsoService.findByIdAndIDType).toHaveBeenCalledWith('34cfed7c-f597-49ef-9cbe-ea351f0023c2', IdentifierType.UUID);
+  });
+
+  it('should resolve its dependencies from the injector when they are not passed in', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: DsoRedirectService, useValue: dsoService },
+        { provide: AuthService, useValue: authService },
+        { provide: Router, useValue: router },
+        { provide: ServerResponseService, useValue: serverResponseService },
+      ],
+    });
+
+    const result = TestBed.runInInjectionContext(() => lookupGuard(handleRoute, state)) as Observable<boolean | UrlTree>;
+
+    expect(dsoService.findByIdAndIDType).toHaveBeenCalledWith('hdl:123456789/1234', IdentifierType.HANDLE);
+    result.subscribe((activate) => expect(activate).toBeFalse());
   });
 
   describe('when the object was found', () => {
     it('should return false so the ObjectNotFound page is not shown', (done) => {
-      guard(handleRoute, state, dsoService, authService, router).subscribe((result) => {
+      guard(handleRoute, state).subscribe((result) => {
         expect(result).toBeFalse();
+        expect(serverResponseService.setStatus).not.toHaveBeenCalled();
         done();
       });
     });
@@ -88,10 +122,11 @@ describe('lookupGuard', () => {
     });
 
     it('should return true so the ObjectNotFound page is shown', (done) => {
-      guard(handleRoute, state, dsoService, authService, router).subscribe((result) => {
+      guard(handleRoute, state).subscribe((result) => {
         expect(result).toBeTrue();
         expect(authService.setRedirectUrl).not.toHaveBeenCalled();
         expect(router.parseUrl).not.toHaveBeenCalled();
+        expect(serverResponseService.setStatus).not.toHaveBeenCalled();
         done();
       });
     });
@@ -103,7 +138,21 @@ describe('lookupGuard', () => {
     });
 
     it('should return true so the ObjectNotFound page is shown', (done) => {
-      guard(handleRoute, state, dsoService, authService, router).subscribe((result) => {
+      guard(handleRoute, state).subscribe((result) => {
+        expect(result).toBeTrue();
+        expect(router.parseUrl).not.toHaveBeenCalled();
+        done();
+      });
+    });
+  });
+
+  describe('when the lookup fails without a status code', () => {
+    beforeEach(() => {
+      dsoService.findByIdAndIDType.and.returnValue(of(createFailedRemoteDataObject('Network error', undefined)));
+    });
+
+    it('should return true so the ObjectNotFound page is shown', (done) => {
+      guard(handleRoute, state).subscribe((result) => {
         expect(result).toBeTrue();
         expect(router.parseUrl).not.toHaveBeenCalled();
         done();
@@ -114,14 +163,51 @@ describe('lookupGuard', () => {
   describe('when the lookup fails with a 401 and the user is not authenticated', () => {
     beforeEach(() => {
       dsoService.findByIdAndIDType.and.returnValue(of(createFailedRemoteDataObject('Unauthorized', 401)));
-      authService.isAuthenticated.and.returnValue(of(false));
+      authService.isAuthenticated.and.returnValue(new BehaviorSubject(false));
     });
 
     it('should store the requested url and return a UrlTree to the login page', (done) => {
-      guard(handleRoute, state, dsoService, authService, router).subscribe((result) => {
+      guard(handleRoute, state).subscribe((result) => {
         expect(authService.setRedirectUrl).toHaveBeenCalledWith(state.url);
         expect(router.parseUrl).toHaveBeenCalledWith('login');
         expect(result).toBe(loginUrlTree);
+        done();
+      });
+    });
+
+    it('should set the server response status so the page is not cached as a 200', (done) => {
+      guard(handleRoute, state).subscribe(() => {
+        expect(serverResponseService.setStatus).toHaveBeenCalledWith(401);
+        done();
+      });
+    });
+
+    it('should emit exactly once and complete even though isAuthenticated() never completes', (done) => {
+      let emissions = 0;
+      guard(handleRoute, state).pipe(take(2)).subscribe({
+        next: (result) => {
+          emissions++;
+          expect(result).toBe(loginUrlTree);
+        },
+        complete: () => {
+          expect(emissions).toBe(1);
+          done();
+        },
+      });
+    });
+  });
+
+  describe('when the lookup fails with a 401 and the user is authenticated', () => {
+    beforeEach(() => {
+      dsoService.findByIdAndIDType.and.returnValue(of(createFailedRemoteDataObject('Unauthorized', 401)));
+      authService.isAuthenticated.and.returnValue(new BehaviorSubject(true));
+    });
+
+    it('should return a UrlTree to the forbidden page', (done) => {
+      guard(handleRoute, state).subscribe((result) => {
+        expect(authService.setRedirectUrl).not.toHaveBeenCalled();
+        expect(router.parseUrl).toHaveBeenCalledWith('/403');
+        expect(result).toBe(forbiddenUrlTree);
         done();
       });
     });
@@ -130,11 +216,11 @@ describe('lookupGuard', () => {
   describe('when the lookup fails with a 403 and the user is not authenticated', () => {
     beforeEach(() => {
       dsoService.findByIdAndIDType.and.returnValue(of(createFailedRemoteDataObject('Forbidden', 403)));
-      authService.isAuthenticated.and.returnValue(of(false));
+      authService.isAuthenticated.and.returnValue(new BehaviorSubject(false));
     });
 
     it('should store the requested url and return a UrlTree to the login page', (done) => {
-      guard(handleRoute, state, dsoService, authService, router).subscribe((result) => {
+      guard(handleRoute, state).subscribe((result) => {
         expect(authService.setRedirectUrl).toHaveBeenCalledWith(state.url);
         expect(router.parseUrl).toHaveBeenCalledWith('login');
         expect(result).toBe(loginUrlTree);
@@ -146,14 +232,21 @@ describe('lookupGuard', () => {
   describe('when the lookup fails with a 403 and the user is authenticated', () => {
     beforeEach(() => {
       dsoService.findByIdAndIDType.and.returnValue(of(createFailedRemoteDataObject('Forbidden', 403)));
-      authService.isAuthenticated.and.returnValue(of(true));
+      authService.isAuthenticated.and.returnValue(new BehaviorSubject(true));
     });
 
     it('should return a UrlTree to the forbidden page and not touch the redirect url', (done) => {
-      guard(handleRoute, state, dsoService, authService, router).subscribe((result) => {
+      guard(handleRoute, state).subscribe((result) => {
         expect(authService.setRedirectUrl).not.toHaveBeenCalled();
         expect(router.parseUrl).toHaveBeenCalledWith('/403');
         expect(result).toBe(forbiddenUrlTree);
+        done();
+      });
+    });
+
+    it('should set the server response status so the page is not cached as a 200', (done) => {
+      guard(handleRoute, state).subscribe(() => {
+        expect(serverResponseService.setStatus).toHaveBeenCalledWith(403);
         done();
       });
     });

--- a/src/app/lookup-by-id/lookup-guard.spec.ts
+++ b/src/app/lookup-by-id/lookup-guard.spec.ts
@@ -135,16 +135,22 @@ describe('lookupGuard', () => {
     });
   });
 
-  describe('when the lookup fails with a 500', () => {
-    beforeEach(() => {
-      dsoService.findByIdAndIDType.and.returnValue(of(createFailedRemoteDataObject('Server error', 500)));
-    });
+  // 501 is what the identifier endpoint answers for an unresolvable identifier type; 422 never
+  // reaches this guard, but the fallback must treat every non-401/403 status the same way
+  [501, 422, 500].forEach((statusCode: number) => {
+    describe(`when the lookup fails with a ${statusCode}`, () => {
+      beforeEach(() => {
+        dsoService.findByIdAndIDType.and.returnValue(of(createFailedRemoteDataObject('Failed', statusCode)));
+      });
 
-    it('should return true so the ObjectNotFound page is shown', (done) => {
-      guard(handleRoute, state).subscribe((result) => {
-        expect(result).toBeTrue();
-        expect(router.parseUrl).not.toHaveBeenCalled();
-        done();
+      it('should return true so the ObjectNotFound page is shown', (done) => {
+        guard(handleRoute, state).subscribe((result) => {
+          expect(result).toBeTrue();
+          expect(authService.setRedirectUrl).not.toHaveBeenCalled();
+          expect(router.parseUrl).not.toHaveBeenCalled();
+          expect(serverResponseService.setStatus).not.toHaveBeenCalled();
+          done();
+        });
       });
     });
   });

--- a/src/app/lookup-by-id/lookup-guard.spec.ts
+++ b/src/app/lookup-by-id/lookup-guard.spec.ts
@@ -214,6 +214,13 @@ describe('lookupGuard', () => {
         done();
       });
     });
+
+    it('should set the server response status so the page is not cached as a 200', (done) => {
+      guard(handleRoute, state).subscribe(() => {
+        expect(serverResponseService.setStatus).toHaveBeenCalledWith(401);
+        done();
+      });
+    });
   });
 
   describe('when the lookup fails with a 403 and the user is not authenticated', () => {
@@ -227,6 +234,13 @@ describe('lookupGuard', () => {
         expect(authService.setRedirectUrl).toHaveBeenCalledWith(state.url);
         expect(router.parseUrl).toHaveBeenCalledWith('login');
         expect(result).toBe(loginUrlTree);
+        done();
+      });
+    });
+
+    it('should set the server response status so the page is not cached as a 200', (done) => {
+      guard(handleRoute, state).subscribe(() => {
+        expect(serverResponseService.setStatus).toHaveBeenCalledWith(403);
         done();
       });
     });

--- a/src/app/lookup-by-id/lookup-guard.ts
+++ b/src/app/lookup-by-id/lookup-guard.ts
@@ -10,12 +10,16 @@ import {
   Observable,
   of,
 } from 'rxjs';
-import { switchMap } from 'rxjs/operators';
+import {
+  switchMap,
+  take,
+} from 'rxjs/operators';
 
 import { AuthService } from '../core/auth/auth.service';
 import { DsoRedirectService } from '../core/data/dso-redirect.service';
 import { RemoteData } from '../core/data/remote-data';
 import { IdentifierType } from '../core/data/request.models';
+import { ServerResponseService } from '../core/services/server-response.service';
 import { returnForbiddenUrlTreeOrLoginOnFalse } from '../core/shared/authorized.operators';
 import { DSpaceObject } from '../core/shared/dspace-object.model';
 
@@ -30,24 +34,31 @@ export const lookupGuard: CanActivateFn = (
   dsoService: DsoRedirectService = inject(DsoRedirectService),
   authService: AuthService = inject(AuthService),
   router: Router = inject(Router),
+  serverResponseService: ServerResponseService = inject(ServerResponseService),
 ): Observable<boolean | UrlTree> => {
   const params = getLookupParams(route);
   return dsoService.findByIdAndIDType(params.id, params.type).pipe(
     switchMap((response: RemoteData<DSpaceObject>) => {
       if (response.hasFailed && (response.statusCode === 401 || response.statusCode === 403)) {
+        // Keep the server-rendered response honest: without this the login page would be sent with
+        // HTTP 200 under the identifier's own URL and stored in the SSR bot cache. No-op in the browser.
+        serverResponseService.setStatus(response.statusCode);
         // The identifier resolves to an object the current user isn't allowed to see, which the
         // REST API reports as 401/403 rather than 404. Emitting `false` means "not authorized":
         // the shared operator turns that into a UrlTree to the login page for an anonymous user
         // (remembering state.url so they come back to this identifier afterwards), or to the
-        // forbidden page for an authenticated one. This mirrors what /items/:id already does via
-        // itemPageResolver -> redirectOn4xx, so both routes behave identically.
+        // forbidden page for an authenticated one - the same split /items/:id makes through
+        // itemPageResolver -> redirectOn4xx. `take(1)` is needed because the operator combines with
+        // `authService.isAuthenticated()`, a store selector that never completes.
         return of(false).pipe(
           returnForbiddenUrlTreeOrLoginOnFalse(router, authService, state.url),
+          take(1),
         );
       }
-      // Activate the route - and therefore render ObjectNotFoundComponent - only when the lookup
-      // genuinely failed to find anything (404). On success DsoRedirectService has already
-      // triggered a hard redirect to the object's own page, so the route must not be activated.
+      // Any other failure - 404, 501 (identifier not resolvable), 5xx, or no response at all -
+      // activates the route so ObjectNotFoundComponent renders, exactly as before. On success
+      // DsoRedirectService has already triggered a hard redirect to the object's own page, so the
+      // route must not be activated.
       return of(response.hasFailed);
     }),
   );

--- a/src/app/lookup-by-id/lookup-guard.ts
+++ b/src/app/lookup-by-id/lookup-guard.ts
@@ -39,26 +39,18 @@ export const lookupGuard: CanActivateFn = (
   const params = getLookupParams(route);
   return dsoService.findByIdAndIDType(params.id, params.type).pipe(
     switchMap((response: RemoteData<DSpaceObject>) => {
+      // A restricted object, which REST reports as 401/403 rather than 404
       if (response.hasFailed && (response.statusCode === 401 || response.statusCode === 403)) {
-        // Keep the server-rendered response honest: without this the login page would be sent with
-        // HTTP 200 under the identifier's own URL and stored in the SSR bot cache. No-op in the browser.
+        // or SSR would cache the login page as HTTP 200 under the identifier's URL. No-op in the browser.
         serverResponseService.setStatus(response.statusCode);
-        // The identifier resolves to an object the current user isn't allowed to see, which the
-        // REST API reports as 401/403 rather than 404. Emitting `false` means "not authorized":
-        // the shared operator turns that into a UrlTree to the login page for an anonymous user
-        // (remembering state.url so they come back to this identifier afterwards), or to the
-        // forbidden page for an authenticated one - the same split /items/:id makes through
-        // itemPageResolver -> redirectOn4xx. `take(1)` is needed because the operator combines with
-        // `authService.isAuthenticated()`, a store selector that never completes.
+        // `false` = not authorized: login page for anonymous users, /403 for authenticated ones, the
+        // same split /items/:id makes. take(1) because isAuthenticated() never completes.
         return of(false).pipe(
           returnForbiddenUrlTreeOrLoginOnFalse(router, authService, state.url),
           take(1),
         );
       }
-      // Any other failure - 404, 501 (identifier not resolvable), 5xx, or no response at all -
-      // activates the route so ObjectNotFoundComponent renders, exactly as before. On success
-      // DsoRedirectService has already triggered a hard redirect to the object's own page, so the
-      // route must not be activated.
+      // Any other failure (404, 501, 5xx) activates the route so ObjectNotFoundComponent renders
       return of(response.hasFailed);
     }),
   );

--- a/src/app/lookup-by-id/lookup-guard.ts
+++ b/src/app/lookup-by-id/lookup-guard.ts
@@ -2,14 +2,21 @@ import { inject } from '@angular/core';
 import {
   ActivatedRouteSnapshot,
   CanActivateFn,
+  Router,
   RouterStateSnapshot,
+  UrlTree,
 } from '@angular/router';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import {
+  Observable,
+  of,
+} from 'rxjs';
+import { switchMap } from 'rxjs/operators';
 
+import { AuthService } from '../core/auth/auth.service';
 import { DsoRedirectService } from '../core/data/dso-redirect.service';
 import { RemoteData } from '../core/data/remote-data';
 import { IdentifierType } from '../core/data/request.models';
+import { returnForbiddenUrlTreeOrLoginOnFalse } from '../core/shared/authorized.operators';
 import { DSpaceObject } from '../core/shared/dspace-object.model';
 
 interface LookupParams {
@@ -21,10 +28,28 @@ export const lookupGuard: CanActivateFn = (
   route: ActivatedRouteSnapshot,
   state: RouterStateSnapshot,
   dsoService: DsoRedirectService = inject(DsoRedirectService),
-): Observable<boolean> => {
+  authService: AuthService = inject(AuthService),
+  router: Router = inject(Router),
+): Observable<boolean | UrlTree> => {
   const params = getLookupParams(route);
   return dsoService.findByIdAndIDType(params.id, params.type).pipe(
-    map((response: RemoteData<DSpaceObject>) => response.hasFailed),
+    switchMap((response: RemoteData<DSpaceObject>) => {
+      if (response.hasFailed && (response.statusCode === 401 || response.statusCode === 403)) {
+        // The identifier resolves to an object the current user isn't allowed to see, which the
+        // REST API reports as 401/403 rather than 404. Emitting `false` means "not authorized":
+        // the shared operator turns that into a UrlTree to the login page for an anonymous user
+        // (remembering state.url so they come back to this identifier afterwards), or to the
+        // forbidden page for an authenticated one. This mirrors what /items/:id already does via
+        // itemPageResolver -> redirectOn4xx, so both routes behave identically.
+        return of(false).pipe(
+          returnForbiddenUrlTreeOrLoginOnFalse(router, authService, state.url),
+        );
+      }
+      // Activate the route - and therefore render ObjectNotFoundComponent - only when the lookup
+      // genuinely failed to find anything (404). On success DsoRedirectService has already
+      // triggered a hard redirect to the object's own page, so the route must not be activated.
+      return of(response.hasFailed);
+    }),
   );
 };
 


### PR DESCRIPTION
## Problem description

Fixes **A1** of dataquest-dev/dspace-customers#876 (analysed in dataquest-dev/dspace-customers#871).

Anonymous → `http://dev-6.pc:8603/repository/handle/11234/1-f26b6363` stays on the handle URL and renders
**"No item found for the identifier handle: 11234/1-f26b6363"**. No login redirect, no DiscoJuice — the user has no
way to authenticate and reach the item. The item exists and is only access-restricted (as admin the same handle
resolves; `GET /server/api/pid/find?id=hdl:…` returns **401** for anonymous).

It is inconsistent inside clarin9 itself: the same item opened **by UUID** does redirect anonymous users to
`/repository/login`. On 7.6.5 the handle path redirects too.

## Analysis

`lookupGuard` collapsed every failure into one boolean:

```ts
map((response: RemoteData<DSpaceObject>) => response.hasFailed)
```

`hasFailed` is `true` for 401, 403, 404 and 500 alike, and `lookup-by-id-routes.ts` renders
`ThemedObjectNotFoundComponent` whenever the guard returns `true` — so a restricted object is indistinguishable from a
missing one. The HTTP status was available on the very same object (`RemoteData.statusCode`, populated by
`remote-data-build.service.ts` and passed through unchanged by `DsoRedirectService`); the guard just ignored it.

This is **not** an SSR-vs-CSR difference and **not** the auth interceptor — both are equivalent on the two branches.
What 7.6.5 has and the v9 branch does not is a CLARIN patch **inside `DsoRedirectService`** (commits `992125b697`
"Login if restricted Item - accessing via `..handle/` url (#612)" and `bbba91247a` "…not login page but 403 (#920)")
that was never ported. Classic wiring-dropped: the guard, the routes, the component and the interceptor really are
identical — the behaviour lived in a fourth file.

**Fix:** branch on `RemoteData.statusCode` in the guard and delegate the 401/403 case to the existing shared operator
`returnForbiddenUrlTreeOrLoginOnFalse(router, authService, state.url)`:

| outcome | before | after |
|---|---|---|
| success | `false` (hard redirect already fired) | unchanged |
| 401/403, anonymous | ObjectNotFound | `UrlTree` → `/login`, `setRedirectUrl(state.url)` |
| 401/403, authenticated | ObjectNotFound | `UrlTree` → `/403` |
| 404 / 501 / 5xx / network | ObjectNotFound | unchanged |


The identifier endpoint (`IdentifierRestRepository.getDSObyIdentifier`) has exactly four outcomes: 302 + redirect
when resolved and visible, **401** when resolved but `converter.toRest` returns null (restricted), **404** for
`null`/`IdentifierNotFoundException`, and **501** `SC_NOT_IMPLEMENTED` for `IdentifierNotResolvableException`. It
never returns 422 - that status is handled by `redirectOn4xx` because that operator is shared with resolvers over
other endpoints. The 403 branch here is defence in depth: the endpoint itself never produces it, but the security
layer can.

Notes on the design:

* **Not** `redirectOn4xx` (what `/items/:id` uses). It implements its redirect as `filter(… => false)`, i.e. it emits
  *nothing* on a 4xx; Angular resolves `CanActivateFn` with `first()`, so an empty completion throws `EmptyError` and
  produces a `NavigationError`. It also maps 404 → `/404`, which would delete the CLARIN-specific
  `ObjectNotFoundComponent` this route exists to render. `returnForbiddenUrlTreeOrLoginOnFalse` is the guard-shaped
  twin of the same logic, already used by every authorization guard in v9, and returns a `UrlTree` — the canonical
  Angular 20 way for a guard to redirect.
* **Not** a re-port of the 7.6.5 `DsoRedirectService` patch: it uses `window.location.href` (not SSR-safe), it makes a
  data service navigate as a side effect while the guard simultaneously returns `true` (ObjectNotFound briefly
  activates and races the navigation), and it changes the constructor of an otherwise vanilla-identical file.
* The post-login return URL is `state.url` (the requested identifier), not `router.url` — the latter is the
  *pre-navigation* URL and would send the user to `/` after login.
* No `href`, no `window.location`, no `HardRedirectService`: both the `UrlTree` and the stored `state.url` are
  router-space values, so the `/repository` base href is applied by the router.

`/repository/id/<uuid>` shares this guard and gets the same behaviour.

**Accepted trade-off:** an anonymous probe can now distinguish "exists but restricted" from "does not exist". That is
the same surface `/items/:id` and 7.6.5 already have, so this makes it consistent rather than larger.

## Tests

`lookup-guard.spec.ts` — the three existing argument tests keep passing (now passing `state`/`authService`/`router`
positionally) plus six new behavioural specs: success → `false`; 404 → `true` with no redirect; 500 → `true`; 401
anonymous → login `UrlTree` + `setRedirectUrl`; 403 anonymous → login `UrlTree`; 403 authenticated → forbidden
`UrlTree` and no `setRedirectUrl`. 9/9 green locally, full `ng lint` clean.

## Problems

One thing that can only be confirmed on the live stack: **does the backend return 404 (not 401) for a handle that does
not exist at all?** If `/server/api/pid/find` answered 401 for unknown handles too, a typo'd handle would now bounce
anonymous users to the login page instead of ObjectNotFound. If that turns out to be the case the fix belongs in the
backend (return 404 for unknown handles) — do not paper over it by treating 401 as 404, that would restore the reported
bug.

### Manual Testing (if applicable)
- [ ] Anonymous → `/repository/handle/11234/1-f26b6363` → lands on `/repository/login` with DiscoJuice; after logging
      in with an authorised account you end up on the item.
- [ ] Anonymous → a handle that does not exist → still "No item found for the identifier …".
- [ ] Logged in as a user without READ → `/403`.
- [ ] Same three checks through `/repository/id/<uuid>`.

### Copilot review
- [x] Requested review from Copilot

