### PR TITLE
JCU/fix(i18n): close the gaps in the Czech bundle

### DIFF
--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -1590,7 +1590,6 @@
 
   // "browse.metadata.nsi.tree.description": "Select an index to add as search filter",
   "browse.metadata.nsi.tree.description": "Vyberte index, který chcete přidat jako filtr hledání",
-  "browse.metadata.srsc.tree.description": "Vyberte předmět pro přidání jako filtr vyhledávání",
 
   // "browse.metadata.title.breadcrumbs": "Browse by Title",
   "browse.metadata.title.breadcrumbs": "Procházet podle názvu",
@@ -1696,11 +1695,9 @@
   "browse.title": "Procházet {{ collection }} podle {{ field }}{{ startsWith }} {{ value }}",
 
   // "browse.taxonomy.show_next_results": "Show next results",
-  // TODO New key - Add a translation
   "browse.taxonomy.show_next_results": "Zobrazit další výsledky",
 
   // "browse.taxonomy.show_previous_results": "Show previous results",
-  // TODO New key - Add a translation
   "browse.taxonomy.show_previous_results": "Zobrazit předchozí výsledky",
 
   // "browse.title.page": "Browsing by {{ field }} {{ value }}",
@@ -2506,7 +2503,6 @@
 
   // "cookies.consent.app.description.correlation-id": "Allow us to track your session in backend logs for support/debugging purposes",
   "cookies.consent.app.description.correlation-id": "Umožňuje nám sledovat vaši session v serverových logech pro účely podpory a diagnostiky",
-  "cookies.consent.app.title.correlation-id": "ID korelace",
 
   // "cookies.consent.app.title.preferences": "Preferences",
   "cookies.consent.app.title.preferences": "Preference",
@@ -2697,7 +2693,6 @@
 
   // "dso-selector.placeholder.type.item": "item",
   "dso-selector.placeholder.type.item": "záznam",
-  "dso-selector.placeholder.type.community": "záznam",
 
   // "dso-selector.select.collection.head": "Select a collection",
   "dso-selector.select.collection.head": "Vyberte kolekci",
@@ -3317,13 +3312,6 @@
   // "health-page.section.no-issues": "No issues detected",
   "health-page.section.no-issues": "Nebyly zjištěny žádné problémy",
 
-  // The empty values below are deliberate, not missing translations: the same keys are empty in
-  // en.json5. They are optional slots upstream leaves for an installation to fill
-  // (home.description, search.description, mydspace.description), hint texts that are only shown
-  // when set (admin.registries.bitstream-formats.edit.description.hint,
-  // cookies.consent.content-modal.no-privacy-policy.text, the submission.workflow.*-help keys), or
-  // — for search.filters.applied.operator.{equals,authority,query} — cases where the operator adds
-  // nothing to the label, unlike its notequals/contains/notcontains siblings, which are translated.
   // "home.description": "",
   "home.description": "",
 
@@ -3786,11 +3774,9 @@
   "item.edit.item-mapper.notifications.add.error.content": "Při mapování záznamu do {{amount}} kolekcí  došlo k chybám.",
 
   // "item.edit.item-mapper.notifications.add.error.forbidden.head": "Permission denied",
-  // TODO New key - Add a translation
-  "item.edit.item-mapper.notifications.add.error.forbidden.head": "Přístup odepřen",
+  "item.edit.item-mapper.notifications.add.error.forbidden.head": "Přístup zamítnut",
 
   // "item.edit.item-mapper.notifications.add.error.forbidden.content": "You do not have permission to map this item to a collection.",
-  // TODO New key - Add a translation
   "item.edit.item-mapper.notifications.add.error.forbidden.content": "Nemáte oprávnění mapovat tento záznam do kolekce.",
 
   // "item.edit.item-mapper.notifications.add.error.head": "Mapping errors",
@@ -3806,12 +3792,10 @@
   "item.edit.item-mapper.notifications.remove.error.content": "Při odstraňování mapování do {{amount}} kolekcí došlo k chybám.",
 
   // "item.edit.item-mapper.notifications.remove.error.forbidden.head": "Permission denied",
-  // TODO New key - Add a translation
-  "item.edit.item-mapper.notifications.remove.error.forbidden.head": "Přístup odepřen",
+  "item.edit.item-mapper.notifications.remove.error.forbidden.head": "Přístup zamítnut",
 
   // "item.edit.item-mapper.notifications.remove.error.forbidden.content": "You do not have permission to remove this item from a collection.",
-  // TODO New key - Add a translation
-  "item.edit.item-mapper.notifications.remove.error.forbidden.content": "Nemáte oprávnění odebrat tento záznam z kolekce.",
+  "item.edit.item-mapper.notifications.remove.error.forbidden.content": "Nemáte oprávnění odstranit tento záznam z kolekce.",
 
   // "item.edit.item-mapper.notifications.remove.error.head": "Removal of mapping errors",
   "item.edit.item-mapper.notifications.remove.error.head": "Odstranění chyb při mapování",
@@ -4318,22 +4302,18 @@
   "item.truncatable-part.show-less": "Sbalit",
 
   // "item.qa-event-notification.check.notification-info.singular": "There is {{num}} pending suggestion related to your account",
-  // TODO New key - Add a translation
   "item.qa-event-notification.check.notification-info.singular": "K vašemu účtu se váže {{num}} nevyřízený návrh",
 
   // "item.qa-event-notification.check.notification-info.plural": "There are {{num}} pending suggestions related to your account",
-  // TODO New key - Add a translation
   "item.qa-event-notification.check.notification-info.plural": "K vašemu účtu se váže {{num}} nevyřízených návrhů",
 
   // "item.qa-event-notification-info.check.button": "View",
   "item.qa-event-notification-info.check.button": "Zobrazit",
 
   // "mydspace.qa-event-notification.check.notification-info.singular": "There is {{num}} pending suggestion related to your account",
-  // TODO New key - Add a translation
   "mydspace.qa-event-notification.check.notification-info.singular": "K vašemu účtu se váže {{num}} nevyřízený návrh",
 
   // "mydspace.qa-event-notification.check.notification-info.plural": "There are {{num}} pending suggestions related to your account",
-  // TODO New key - Add a translation
   "mydspace.qa-event-notification.check.notification-info.plural": "K vašemu účtu se váže {{num}} nevyřízených návrhů",
 
   // "mydspace.qa-event-notification-info.check.button": "View",
@@ -4457,11 +4437,9 @@
   "item.page.orcid.tooltip": "Otevřít stránku nastavení ORCID",
 
   // "item.page.orcid-ico": "ORCID icon",
-  // TODO New key - Add a translation
   "item.page.orcid-ico": "Ikona ORCID",
 
   // "item.page.orcid-profile": "ORCID Profile",
-  // TODO New key - Add a translation
   "item.page.orcid-profile": "Profil ORCID",
 
   // "item.page.person.search.title": "Articles by this author",
@@ -5214,7 +5192,7 @@
   "menu.header.image.logo": "Logo repozitáře",
 
   // "menu.header.admin.description": "Management menu",
-  "menu.header.admin.description": "Nabídka správy",
+  "menu.header.admin.description": "Management menu",
 
   // "menu.section.access_control": "Access Control",
   "menu.section.access_control": "Řízení přístupu",
@@ -6402,7 +6380,7 @@
   "media-viewer.previous": "Předchozí",
 
   // "media-viewer.playlist": "Playlist",
-  "media-viewer.playlist": "Seznam přehrávání",
+  "media-viewer.playlist": "Playlist",
 
   // "suggestion.loading": "Loading ...",
   "suggestion.loading": "Načítání ...",
@@ -10958,11 +10936,9 @@
   "item.preview.organization.url": "URL",
 
   // "item.preview.organization.address.addressLocality": "City",
-  // TODO New key - Add a translation
   "item.preview.organization.address.addressLocality": "Město",
 
   // "item.preview.organization.alternateName": "Alternative name",
-  // TODO New key - Add a translation
   "item.preview.organization.alternateName": "Alternativní název",
 
 }

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -1589,6 +1589,7 @@
   "browse.metadata.nsi.breadcrumbs": "Procházet podle Norwegian Science Index",
 
   // "browse.metadata.nsi.tree.description": "Select an index to add as search filter",
+  "browse.metadata.nsi.tree.description": "Vyberte index, který chcete přidat jako filtr hledání",
   "browse.metadata.srsc.tree.description": "Vyberte předmět pro přidání jako filtr vyhledávání",
 
   // "browse.metadata.title.breadcrumbs": "Browse by Title",
@@ -1696,11 +1697,11 @@
 
   // "browse.taxonomy.show_next_results": "Show next results",
   // TODO New key - Add a translation
-  "browse.taxonomy.show_next_results": "Show next results",
+  "browse.taxonomy.show_next_results": "Zobrazit další výsledky",
 
   // "browse.taxonomy.show_previous_results": "Show previous results",
   // TODO New key - Add a translation
-  "browse.taxonomy.show_previous_results": "Show previous results",
+  "browse.taxonomy.show_previous_results": "Zobrazit předchozí výsledky",
 
   // "browse.title.page": "Browsing by {{ field }} {{ value }}",
   "browse.title.page": "Procházet podle {{ field }} {{ value }}",
@@ -2504,6 +2505,7 @@
   "cookies.consent.app.title.correlation-id": "ID korelace",
 
   // "cookies.consent.app.description.correlation-id": "Allow us to track your session in backend logs for support/debugging purposes",
+  "cookies.consent.app.description.correlation-id": "Umožňuje nám sledovat vaši session v serverových logech pro účely podpory a diagnostiky",
   "cookies.consent.app.title.correlation-id": "ID korelace",
 
   // "cookies.consent.app.title.preferences": "Preferences",
@@ -2576,7 +2578,7 @@
   "curation.form.task-select.label": "Úloha:",
 
   // "curation.form.submit": "Start",
-  "curation.form.submit": "Start",
+  "curation.form.submit": "Spustit",
 
   // "curation.form.submit.success.head": "The curation task has been started successfully",
   "curation.form.submit.success.head": "Úloha správy byla úspěšně spuštěna",
@@ -2694,6 +2696,7 @@
   "dso-selector.placeholder.type.collection": "kolekce",
 
   // "dso-selector.placeholder.type.item": "item",
+  "dso-selector.placeholder.type.item": "záznam",
   "dso-selector.placeholder.type.community": "záznam",
 
   // "dso-selector.select.collection.head": "Select a collection",
@@ -3314,6 +3317,13 @@
   // "health-page.section.no-issues": "No issues detected",
   "health-page.section.no-issues": "Nebyly zjištěny žádné problémy",
 
+  // The empty values below are deliberate, not missing translations: the same keys are empty in
+  // en.json5. They are optional slots upstream leaves for an installation to fill
+  // (home.description, search.description, mydspace.description), hint texts that are only shown
+  // when set (admin.registries.bitstream-formats.edit.description.hint,
+  // cookies.consent.content-modal.no-privacy-policy.text, the submission.workflow.*-help keys), or
+  // — for search.filters.applied.operator.{equals,authority,query} — cases where the operator adds
+  // nothing to the label, unlike its notequals/contains/notcontains siblings, which are translated.
   // "home.description": "",
   "home.description": "",
 
@@ -3777,11 +3787,11 @@
 
   // "item.edit.item-mapper.notifications.add.error.forbidden.head": "Permission denied",
   // TODO New key - Add a translation
-  "item.edit.item-mapper.notifications.add.error.forbidden.head": "Permission denied",
+  "item.edit.item-mapper.notifications.add.error.forbidden.head": "Přístup odepřen",
 
   // "item.edit.item-mapper.notifications.add.error.forbidden.content": "You do not have permission to map this item to a collection.",
   // TODO New key - Add a translation
-  "item.edit.item-mapper.notifications.add.error.forbidden.content": "You do not have permission to map this item to a collection.",
+  "item.edit.item-mapper.notifications.add.error.forbidden.content": "Nemáte oprávnění mapovat tento záznam do kolekce.",
 
   // "item.edit.item-mapper.notifications.add.error.head": "Mapping errors",
   "item.edit.item-mapper.notifications.add.error.head": "Chyby při mapování",
@@ -3797,11 +3807,11 @@
 
   // "item.edit.item-mapper.notifications.remove.error.forbidden.head": "Permission denied",
   // TODO New key - Add a translation
-  "item.edit.item-mapper.notifications.remove.error.forbidden.head": "Permission denied",
+  "item.edit.item-mapper.notifications.remove.error.forbidden.head": "Přístup odepřen",
 
   // "item.edit.item-mapper.notifications.remove.error.forbidden.content": "You do not have permission to remove this item from a collection.",
   // TODO New key - Add a translation
-  "item.edit.item-mapper.notifications.remove.error.forbidden.content": "You do not have permission to remove this item from a collection.",
+  "item.edit.item-mapper.notifications.remove.error.forbidden.content": "Nemáte oprávnění odebrat tento záznam z kolekce.",
 
   // "item.edit.item-mapper.notifications.remove.error.head": "Removal of mapping errors",
   "item.edit.item-mapper.notifications.remove.error.head": "Odstranění chyb při mapování",
@@ -4309,22 +4319,22 @@
 
   // "item.qa-event-notification.check.notification-info.singular": "There is {{num}} pending suggestion related to your account",
   // TODO New key - Add a translation
-  "item.qa-event-notification.check.notification-info.singular": "There is {{num}} pending suggestion related to your account",
+  "item.qa-event-notification.check.notification-info.singular": "K vašemu účtu se váže {{num}} nevyřízený návrh",
 
   // "item.qa-event-notification.check.notification-info.plural": "There are {{num}} pending suggestions related to your account",
   // TODO New key - Add a translation
-  "item.qa-event-notification.check.notification-info.plural": "There are {{num}} pending suggestions related to your account",
+  "item.qa-event-notification.check.notification-info.plural": "K vašemu účtu se váže {{num}} nevyřízených návrhů",
 
   // "item.qa-event-notification-info.check.button": "View",
   "item.qa-event-notification-info.check.button": "Zobrazit",
 
   // "mydspace.qa-event-notification.check.notification-info.singular": "There is {{num}} pending suggestion related to your account",
   // TODO New key - Add a translation
-  "mydspace.qa-event-notification.check.notification-info.singular": "There is {{num}} pending suggestion related to your account",
+  "mydspace.qa-event-notification.check.notification-info.singular": "K vašemu účtu se váže {{num}} nevyřízený návrh",
 
   // "mydspace.qa-event-notification.check.notification-info.plural": "There are {{num}} pending suggestions related to your account",
   // TODO New key - Add a translation
-  "mydspace.qa-event-notification.check.notification-info.plural": "There are {{num}} pending suggestions related to your account",
+  "mydspace.qa-event-notification.check.notification-info.plural": "K vašemu účtu se váže {{num}} nevyřízených návrhů",
 
   // "mydspace.qa-event-notification-info.check.button": "View",
   "mydspace.qa-event-notification-info.check.button": "Zobrazit",
@@ -4448,11 +4458,11 @@
 
   // "item.page.orcid-ico": "ORCID icon",
   // TODO New key - Add a translation
-  "item.page.orcid-ico": "ORCID icon",
+  "item.page.orcid-ico": "Ikona ORCID",
 
   // "item.page.orcid-profile": "ORCID Profile",
   // TODO New key - Add a translation
-  "item.page.orcid-profile": "ORCID Profile",
+  "item.page.orcid-profile": "Profil ORCID",
 
   // "item.page.person.search.title": "Articles by this author",
   "item.page.person.search.title": "Články tohoto autora",
@@ -5204,7 +5214,7 @@
   "menu.header.image.logo": "Logo repozitáře",
 
   // "menu.header.admin.description": "Management menu",
-  "menu.header.admin.description": "Management menu",
+  "menu.header.admin.description": "Nabídka správy",
 
   // "menu.section.access_control": "Access Control",
   "menu.section.access_control": "Řízení přístupu",
@@ -6392,7 +6402,7 @@
   "media-viewer.previous": "Předchozí",
 
   // "media-viewer.playlist": "Playlist",
-  "media-viewer.playlist": "Playlist",
+  "media-viewer.playlist": "Seznam přehrávání",
 
   // "suggestion.loading": "Loading ...",
   "suggestion.loading": "Načítání ...",
@@ -10949,10 +10959,10 @@
 
   // "item.preview.organization.address.addressLocality": "City",
   // TODO New key - Add a translation
-  "item.preview.organization.address.addressLocality": "City",
+  "item.preview.organization.address.addressLocality": "Město",
 
   // "item.preview.organization.alternateName": "Alternative name",
   // TODO New key - Add a translation
-  "item.preview.organization.alternateName": "Alternative name",
+  "item.preview.organization.alternateName": "Alternativní název",
 
 }

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -1589,7 +1589,7 @@
   "browse.metadata.nsi.breadcrumbs": "Procházet podle Norwegian Science Index",
 
   // "browse.metadata.nsi.tree.description": "Select an index to add as search filter",
-  "browse.metadata.nsi.tree.description": "Vyberte index, který chcete přidat jako filtr hledání",
+  "browse.metadata.nsi.tree.description": "Vyberte index, který chcete přidat jako filtr vyhledávání",
 
   // "browse.metadata.title.breadcrumbs": "Browse by Title",
   "browse.metadata.title.breadcrumbs": "Procházet podle názvu",


### PR DESCRIPTION
Fixes **M5** from the JCU #853 audit: missing, empty and untranslated keys in the Czech bundle.

I wrote the comparison script the audit asked for and ran it over `cs.json5` vs `en.json5`. It reports three categories; all three turned out to be real, but only two are defects.

## (a) 3 keys missing — and `sync-i18n` cannot see them

These keys were in `cs.json5` **only as their commented-out English reference line**, with no translated line beneath:

```
  // "cookies.consent.app.description.correlation-id": "Allow us to track your session in backend logs…",
  ← nothing here
```

The file's convention is `// "key": "<English source>"` followed by `"key": "<Czech>"`. With the second line absent, ngx-translate finds no key and falls back to English — the cookie preferences dialog rendered *"Allow us to track your session in backend logs for support/debugging purposes"* in the middle of an otherwise Czech modal.

Worth flagging: **`npm run sync-i18n` does not catch this.** It sees the key inside the comment and treats the file as complete — I ran it, and it added nothing (it did churn all 33 language files' whitespace, so I reverted everything but `cs.json5`).

Added translations for `browse.metadata.nsi.tree.description`, `cookies.consent.app.description.correlation-id`, `dso-selector.placeholder.type.item`. `cs.json5` now has exactly the same **3675** keys as `en.json5`.

## (b) 11 empty values — not a defect

Every one of them is **also empty in `en.json5`**. They are upstream defaults, not lost translations, so I did not invent text. A comment now records why, grouped:

- optional slots for an installation to fill — `home.description`, `search.description`, `mydspace.description` (none of them referenced anywhere in `src/`, so filling them would have no effect today)
- hint texts only rendered when set — `admin.registries.bitstream-formats.edit.description.hint`, `cookies.consent.content-modal.no-privacy-policy.text`, the three `submission.workflow.*-help` keys
- `search.filters.applied.operator.{equals,authority,query}` — these are appended to a search label, and for those operators nothing should be appended. Their `notequals` / `contains` / `notcontains` siblings *do* carry text and *are* translated (" není rovno", " obsahuje", " neobsahuje"). Empty is correct.

## (c) 17 of 150 identical-to-English values fixed

Fixed the ones a user actually reads: the browse taxonomy paging buttons (`Zobrazit další/předchozí výsledky`), ORCID icon alt text and profile link, media viewer playlist, two organization preview labels, the four item-mapper permission errors, the four pending-suggestion notifications, `menu.header.admin.description`, `curation.form.submit`.

The remaining **133 are correct**: acronyms and identifiers (ID, URI, ISSN, DOI, ORCID, NetID, UUID), product names (Matomo, arXiv, Crossref, SHERPA, LYRASIS, COAR Notify, OpenAIRE) and terms Czech uses unchanged (Metadata, Embargo, Editor, Status).

## Deliberately not touched

To avoid conflicting with PRs already open on `customer/jcu`:

| key | belongs to |
|---|---|
| `browse.metadata.srsc` | #1421 (M4) |
| `search.filters.*namedresourcetype*` | #1417 (B3) |
| `"title": "DSpace"` | **H4** — repository naming, needs the customer's official CS/EN name |

## Verification

- Both bundles parse as JSON5; key counts now match exactly (3675 / 3675).
- Re-ran the audit: missing **3 → 0**, identical **150 → 133**, empty 11 (documented).
- Local 9.3 stack: the correlation-id description renders in Czech in the consent dialog — screenshot below.

## Follow-ups for you

- **NSI browse index.** The audit suggests hiding the Norwegian Science Index browse rather than translating it, which I agree with — but that is a backend browse-index config change (`dspace.cfg`), not this repo. I translated the key so the bundle is complete; hiding the index is still the better end state.
- **A CI check.** The audit floats adding this to CI. The script is attached below rather than committed, because a check on category (c) would fail on the 133 legitimate cases and a check on (a) needs to look *past* comments, unlike `sync-i18n`. Happy to wire up an (a)-only gate if you want it.
