### PR TITLE
JCU/fix(i18n): stop the English UI presenting itself as DSpace

### DIFF
--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -2703,7 +2703,7 @@
   "dso-selector.set-scope.community.head": "Vyberte rozsah vyhledávání",
 
   // "dso-selector.set-scope.community.button": "Search all of DSpace",
-  "dso-selector.set-scope.community.button": "Hledat v celém DSpace",
+  "dso-selector.set-scope.community.button": "Hledat v celém repozitáři",
 
   // "dso-selector.set-scope.community.or-divider": "or",
   "dso-selector.set-scope.community.or-divider": "nebo",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1797,7 +1797,7 @@
 
   "dso-selector.set-scope.community.head": "Select a search scope",
 
-  "dso-selector.set-scope.community.button": "Search all of DSpace",
+  "dso-selector.set-scope.community.button": "Search the entire repository",
 
   "dso-selector.set-scope.community.or-divider": "or",
 
@@ -2217,7 +2217,7 @@
 
   "home.title": "Home",
 
-  "home.top-level-communities.head": "Communities in DSpace",
+  "home.top-level-communities.head": "Communities",
 
   "home.top-level-communities.help": "Select a community to browse its collections.",
 
@@ -3481,7 +3481,7 @@
 
   "menu.section.browse_community_by_title": "By Title",
 
-  "menu.section.browse_global": "All of DSpace",
+  "menu.section.browse_global": "Browse by",
 
   "menu.section.browse_global_by_author": "By Author",
 
@@ -3717,7 +3717,7 @@
 
   "notification.suggestion.please": "Please",
 
-  "nav.browse.header": "All of DSpace",
+  "nav.browse.header": "Entire repository",
 
   "nav.community-browse.header": "By Community",
 
@@ -4455,9 +4455,12 @@
 
   "repository.image.logo": "Repository logo",
 
-  "repository.title": "DSpace Repository",
+  // The repository name, which also names the legal entity in the End User Agreement and the
+  // Privacy Policy. This is a translation of the Czech "Institucionalni digitalni repozitar"
+  // already in use; replace it if JCU has an official English name.
+  "repository.title": "Institutional Digital Repository",
 
-  "repository.title.prefix": "DSpace Repository :: ",
+  "repository.title.prefix": "IDR :: ",
 
   "resource-policies.add.button": "Add",
 
@@ -4898,7 +4901,7 @@
 
   "search.form.search_dspace": "All repository",
 
-  "search.form.scope.all": "All of DSpace",
+  "search.form.scope.all": "Entire repository",
 
   "search.results.head": "Search Results",
 


### PR DESCRIPTION
Fixes **H4** from the JCU #853 audit: the English UI still presenting itself as DSpace.

## The audit's framing is only partly right — measured

I compared the two bundles key by key. **24** English values contain "DSpace". Of those:

| | count |
|---|---|
| Czech avoids "DSpace", English still leaks it — *the actual EN/CS asymmetry* | **6** |
| Both bundles say "DSpace" | **18** |

So "the English bundle stayed on defaults while Czech was customised" describes 6 keys, not the whole set. Those 6 are fixed here. The other 18 are a branding decision in **both** languages, so I have not decided them unilaterally — full list at the bottom.

## Fixed (6 keys)

| key | before | after | mirrors CS |
|---|---|---|---|
| `home.top-level-communities.head` | Communities in DSpace | Communities | "Komunity" |
| `menu.section.browse_global` | All of DSpace | Browse by | "Procházet podle" |
| `nav.browse.header` | All of DSpace | Entire repository | "Celý repozitář" |
| `search.form.scope.all` | All of DSpace | Entire repository | "Celý repozitář" |
| `repository.title` | DSpace Repository | Institutional Digital Repository | "Institucionální digitální repozitář" |
| `repository.title.prefix` | DSpace Repository :: | IDR :: | "IDR :: " |

Nothing is invented — every new English value mirrors what the Czech bundle already says.

Plus `dso-selector.set-scope.community.button` in **both** bundles ("Search all of DSpace" / "Hledat v celém DSpace" → "Search the entire repository" / "Hledat v celém repozitáři"): a scope button should name the repository, not the product, and changing one side only would move the asymmetry rather than remove it.

## `repository.title` also fixes half of M6

It is not just a page title — it is the **legal entity name** in the End User Agreement and Privacy Policy templates (`end-user-agreement-content.component.html:5`, `privacy-content.component.html:5`). Before this, `/info/end-user-agreement` read:

> These Terms of Use constitute a legally binding agreement made between you … and **DSpace Repository** ("Company", "we", "us", or "our")

and now reads "… and **Institutional Digital Repository** …". That is the mechanical half of **M6**, fixed here as a side effect.

While I was in there — **the `[a]` / `#comment-a` / `#ref-a` markers M6 calls template artifacts are not artifacts.** They are a working footnote: line 10 carries the superscript reference, line 95 is the note itself, clarifying that the DSpace *software* is open source even though the site content is not. Both anchors resolve. Removing them would delete a deliberate legal clarification. Verified in the browser.

## Verification

Local 9.3 stack, UI in English:

| | before | after |
|---|---|---|
| `<title>` on `/home` | DSpace Repository :: Home | **IDR :: Home** |
| navbar | Communities & Collections · **All of DSpace** · Statistics | Communities & Collections · **Browse by** · Statistics |
| EULA entity | DSpace Repository | **Institutional Digital Repository** |

EN/CS asymmetry: **6 → 0**. Both bundles parse; `ng lint` — *All files pass linting*.

## Two things I need from you

**1. Confirm or replace the English name.** `repository.title` is my translation of the Czech name already in use. If JCU has an official English name, it is a one-line change — there is a comment on the key saying so. Note the audit also flagged that three names are in play at once (banner "Publication Repository" / "Repozitář publikací", `repository.title`, prefix "IDR"); unifying those, and with `dspace.name` from **H3** (backend `local.cfg`, not this repo), is still open.

**2. Decide on the 18 both-leak keys.** These say "DSpace" in Czech *and* English, so they are not an EN oversight:

- Genuinely product-neutral candidates: `login.form.header` ("Please log in to DSpace"), `logout.form.header`, `register-page.registration.info`, `info.feedback.info`, `submission.import-external.page.hint`, `title` ("DSpace")
- The **MyDSpace** family — `mydspace.title`, `nav.mydspace`, `mydspace.breadcrumbs`, `mydspace.status`, `mydspace.search-form.placeholder`, `submission.import-external.back-to-my-dspace`. "MyDSpace" is a feature name users may recognise; renaming it is a product decision, not a branding cleanup.
- Should **stay** as-is: `footer.link.dspace` ("DSpace software" — correct attribution), `item.edit.relationships.no-entity-type` (names the literal metadata field `dspace.entity.type`), `error-page.orcid.generic-error`, `admin.registries.metadata.description`, `quality-assurance.event.accept.description`

Say which group you want and it is a quick follow-up.
