### PR TITLE
JCU/fix(docker): keep /dspace/log between container recreates

### DIFF
--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -59,6 +59,12 @@ services:
     volumes:
     # Keep DSpace assetstore directory between reboots
     - assetstore:/dspace/assetstore
+    # Keep DSpace log directory between reboots, so that dspace.log (see log4j2-container.xml)
+    # survives a container recreate instead of being wiped with the writable layer.
+    # A named volume is used on purpose: it inherits the ownership of /dspace/log from the image,
+    # so the container's "dspace" user (uid 1100) can write to it. A bind mount to a fresh host
+    # directory would be owned by root and silently unwritable.
+    - dspacelogs:/dspace/log
     # Ensure that the database is ready BEFORE starting tomcat
     # 1. While a TCP connection to dspacedb port 5432 is not available, continue to sleep
     # 2. Then, run database migration to init database tables
@@ -141,5 +147,6 @@ services:
       runuser -u solr -- env SOLR_HEAP="${SOLR_HEAP:-4g}" solr-foreground
 volumes:
   assetstore:
+  dspacelogs:
   pgdata:
   solr_data:


### PR DESCRIPTION
## Problem

`/dspace/log` lives in the backend container's **writable layer**. It is wiped on every `docker compose up -d --force-recreate` and on every image update — that is, precisely when you go looking for the logs after an incident or a bad deploy.

This already bites today for `dspace-cli.log` and `checker.log`, which `log4j2-cli.xml` writes into that directory on every start (the entrypoint runs `dspace database migrate force`). It matters much more once `dspace.log` is written there too — see the companion PR in `dataquest-dev/DSpace` `customer/jcu`, which fixes the container log4j2 config so DSpace stops logging only to container stdout.

## Fix

Mount `/dspace/log` as a named volume, alongside the existing `assetstore` one.

```yaml
    volumes:
    - assetstore:/dspace/assetstore
    - dspacelogs:/dspace/log
```

**Why a named volume and not a bind mount.** The backend image creates a `dspace` user with a fixed uid 1100 and runs as that user (`Dockerfile`: `useradd -u 1100 ... && chown -Rv dspace: /dspace`, `USER dspace`). Docker seeds a fresh *named* volume from the image contents, ownership included, so uid 1100 keeps write access. A bind mount to a new host directory would come up **root-owned**, log4j would fail to open the file, and we would be back to console-only logging — with the added charm of it looking like the fix simply did not work.

If someone does want the logs directly on the host, the bind mount has to be prepared first:

```bash
mkdir -p /var/log/dspace && chown 1100:1100 /var/log/dspace
```

and then `- /var/log/dspace:/dspace/log` instead. Otherwise, read them with:

```bash
docker compose exec dspace tail -f /dspace/log/dspace.log
```

## Verification

`docker compose -f docker/docker-compose-rest.yml config` renders cleanly, with the mount attached to the `dspace` service and the volume declared:

```yaml
      - type: volume
        source: dspacelogs
        target: /dspace/log
```

## Notes

- Existing deployments are unaffected on the way in — the first `up` creates an empty volume and starts filling it. No data migration, nothing to back up first.
- This is one half of the fix. Without the companion `dataquest-dev/DSpace` PR the volume will only ever hold `dspace-cli.log` / `checker.log`; without this PR `dspace.log` exists but does not survive a recreate. Merging both is what actually gives JCU a persistent `dspace.log`.
- If the deploy overlay on the JCU host (`/opt/dspace-envs/443`) redefines the `dspace` service's `volumes:`, note that compose **replaces** sequences rather than merging them — the overlay would need `dspacelogs:/dspace/log` repeated there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
