### PR TITLE
JCU/fix(ssr): answer HEAD requests with the same status as GET

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -225,7 +225,12 @@ export function app() {
  * The callback function to serve server side angular
  */
 function ngApp(req, res, next) {
-  if (environment.ssr.enabled && req.method === 'GET' && (req.path === '/' || !isExcludedFromSsr(req.path, environment.ssr.excludePathPatterns))) {
+  // HEAD is handled exactly like GET: Express dispatches HEAD requests to GET handlers, and RFC 9110
+  // requires a HEAD response to carry the same status and headers as the equivalent GET. Since the
+  // status code of a page is only known once Angular has rendered it (ServerResponseService sets 404
+  // on the not-found page), skipping SSR for HEAD would answer every URL with 200 and the empty CSR
+  // shell. Express drops the body of a HEAD response for us, so nothing extra is sent to the client.
+  if (environment.ssr.enabled && (req.method === 'GET' || req.method === 'HEAD') && (req.path === '/' || !isExcludedFromSsr(req.path, environment.ssr.excludePathPatterns))) {
     // Render the page to user via SSR (server side rendering)
     serverSideRender(req, res, next);
   } else {

--- a/server.ts
+++ b/server.ts
@@ -225,11 +225,6 @@ export function app() {
  * The callback function to serve server side angular
  */
 function ngApp(req, res, next) {
-  // HEAD is handled exactly like GET: Express dispatches HEAD requests to GET handlers, and RFC 9110
-  // requires a HEAD response to carry the same status and headers as the equivalent GET. Since the
-  // status code of a page is only known once Angular has rendered it (ServerResponseService sets 404
-  // on the not-found page), skipping SSR for HEAD would answer every URL with 200 and the empty CSR
-  // shell. Express drops the body of a HEAD response for us, so nothing extra is sent to the client.
   if (environment.ssr.enabled && (req.method === 'GET' || req.method === 'HEAD') && (req.path === '/' || !isExcludedFromSsr(req.path, environment.ssr.excludePathPatterns))) {
     // Render the page to user via SSR (server side rendering)
     serverSideRender(req, res, next);


### PR DESCRIPTION
Fixes **L2** from the dataquest-dev/dspace-customers#853 review.

## The reported symptom no longer reproduces — but the underlying bug does

The review says `/this-page-does-not-exist-123` and `/items/00000000-…` render the 404 page with
HTTP **200**. Measured again on production today, plain `GET` is already correct:

```
GET  https://dspace-new.jcu.cz/this-page-does-not-exist-123            404   386 038 B
GET  https://dspace-new.jcu.cz/items/00000000-0000-0000-0000-000000000000   404   386 723 B
GET  https://dspace-new.jcu.cz/collections/00000000-…                  404   386 736 B
GET  https://dspace-new.jcu.cz/handle/20.500.14390/999999              404   386 498 B
```

That part was fixed upstream by [DSpace/dspace-angular#4227](https://github.com/DSpace/dspace-angular/pull/4227)
(which closed both [#4132](https://github.com/DSpace/dspace-angular/issues/4132) "Error pages return
HTTP 200" and [#4042](https://github.com/DSpace/dspace-angular/issues/4042)), and it is in the 9.x
line we run.

**`HEAD` was never fixed**, and on the same URLs it still answers 200:

```
HEAD https://dspace-new.jcu.cz/home                            200   1 113 B
HEAD https://dspace-new.jcu.cz/this-page-does-not-exist-123    200   1 113 B
HEAD https://dspace-new.jcu.cz/items/00000000-…                200   1 113 B
HEAD https://dspace-new.jcu.cz/404                             200   1 113 B
```

Those 1 113 bytes are the empty SPA shell. So a `HEAD` request gets a soft 404 *and* no rendered
content, on every URL in the repository — which is also where the "**source HTML is just an empty
1 113 B SPA shell**" observation in **M8** comes from. It is one bug, visible two ways.

## Cause

`ngApp()` in `server.ts` decides whether to render server-side:

```ts
if (environment.ssr.enabled && req.method === 'GET' && (req.path === '/' || !isExcludedFromSsr(…)))
```

Express dispatches `HEAD` requests to `GET` handlers (`Route._handles_method()` falls back to `get`
when no `head` handler is registered), so `router.get('*', cacheCheck, ngApp)` does run for `HEAD` —
but the `req.method === 'GET'` test then fails and the request is served by `clientSideRender()`,
which sends the static `index.html` with the default status 200.

The status of a DSpace page is only known *after* Angular has rendered it: `PageNotFoundComponent`,
`ForbiddenComponent`, `ObjectNotFoundComponent` and `PageInternalServerErrorComponent` set it through
`ServerResponseService` in their constructors. Skipping SSR is therefore the same as answering 200.

RFC 9110 §9.3.2 is explicit that this is wrong:

> The server SHOULD send the same header fields in response to a HEAD request as it would have sent
> if the request method had been GET. However, a server MAY omit header fields for which a value is
> determined only while generating the content.

## Fix

```diff
-  if (environment.ssr.enabled && req.method === 'GET' && (req.path === '/' || …))
+  if (environment.ssr.enabled && (req.method === 'GET' || req.method === 'HEAD') && (req.path === '/' || …))
```

Express strips the body of a `HEAD` response by itself, so the rendered HTML never reaches the wire —
verified below on a raw socket, 0 body bytes. The existing bot/anonymous page cache is unchanged and
still refuses to store non-2xx responses (`saveToCache()` → `hasNotSucceeded()`), so a 404 is never
cached and replayed as a 200.

**Cost:** a `HEAD` crawl now renders a page instead of returning a static file. For bot user agents
the SSR page cache (`cache.serverSide.botCache`, already enabled here since #1424) absorbs the repeat
hits, and the paths that are expensive to render are already listed in `ssr.excludePathPatterns`.
The alternative — keep answering 200 to every HEAD — is worse for exactly the SEO reasons this review
was written about.

## Verified

Production build (`npm run build:prod`) of this branch, run against the local Docker 9.3 backend.

Before:

```
METHOD PATH                                             STATUS   BYTES
GET    /home                                            200      451282
HEAD   /home                                            200      1115      <-- shell
GET    /this-page-does-not-exist-123                    404      385020
HEAD   /this-page-does-not-exist-123                    200      1115      <-- soft 404
GET    /items/00000000-0000-0000-0000-000000000000      404      385697
HEAD   /items/00000000-0000-0000-0000-000000000000      200      1115      <-- soft 404
GET    /404                                             404      384945
HEAD   /404                                             200      1115      <-- soft 404
GET    /handle/123456789/999999                         404      385447
HEAD   /handle/123456789/999999                         200      1115      <-- soft 404
```

After:

```
METHOD PATH                                             STATUS   BYTES
GET    /home                                            200      451282
HEAD   /home                                            200      451282
GET    /this-page-does-not-exist-123                    404      385020
HEAD   /this-page-does-not-exist-123                    404      385020
GET    /items/00000000-0000-0000-0000-000000000000      404      385697
HEAD   /items/00000000-0000-0000-0000-000000000000      404      385697
GET    /404                                             404      384945
HEAD   /404                                             404      384945
GET    /handle/123456789/999999                         404      385447
HEAD   /handle/123456789/999999                         404      385447
```

`BYTES` is `Content-Length`; nothing is actually transmitted for `HEAD`. Raw socket check:

```
HEAD /this-page-does-not-exist-123 HTTP/1.1

HTTP/1.1 404 Not found
Content-Type: text/html; charset=utf-8
Content-Length: 385020
--- body bytes after headers: 0
```

Browsing the app is unaffected (home renders, the 404 page renders, `npm run lint` reports 0 errors).

## What this does *not* fix

Paths listed in `ssr.excludePathPatterns` are served client-side by design and still answer 200 —
e.g. `/browse/nonexistent-index`. `/search`, `/admin/*`, `/submit`, `/profile`, `/processes`,
`/workspaceitems` and `/workflowitems` are `Disallow`ed in `robots.txt`, but `/browse/` is not, so
`/browse/<unknown-index>` remains a crawlable soft 404. Making it correct means rendering those pages server-side, which is precisely what #1424
turned off for load reasons — so it is a config trade-off, not a code fix, and I left it alone.

## Upstream

`server.ts` here is byte-for-byte identical to `upstream/dspace-9_x`, and the `req.method === 'GET'`
guard is identical in `dspace-9_x`, `dspace-10_x` and `main` — **this is still live upstream**. It
was introduced by "Restrict SSR to paths in the sitemap" and survived the #4227 rewrite untouched.
Confirmed on the upstream demo instance:

```
GET  https://demo.dspace.org/handle/foo/bar   404   (462 637 B of rendered 404 page)
HEAD https://demo.dspace.org/handle/foo/bar   200
```

Note that #4042 was *specifically* a HEAD-request bug ("HEAD requests via the HANDLE urls return 200
instead of 301") and was closed as fixed by #4227 — the GET path was fixed, the HEAD path was not, so
the ticket is arguably still open. This patch is a one-liner and worth offering upstream.

Across our own customer branches, none of `customer/{jcu,mendelu,TUL,sav,lindat,uk,vsb-tuo,zcu-pub,zcu-data}`
carries this guard's fix, so they are all affected in principle. In practice `dspace.zcu.cz` answers
`HEAD /this-page-does-not-exist-123` with a rendered `404` (336 400 B), i.e. its deployed build
predates the guard; JCU and the upstream demo are the ones reproducing today.

## Evidence

Screenshots:

- `L2-1-before-head-returns-200-for-every-url.png`
<img width="1105" height="820" alt="L2-1-before-head-returns-200-for-every-url" src="https://github.com/user-attachments/assets/13791528-ced9-449b-8ad0-6c42de9478c2" />

- `L2-2-after-head-mirrors-get-status.png`
<img width="1105" height="820" alt="L2-2-after-head-mirrors-get-status" src="https://github.com/user-attachments/assets/b6ce6f55-c803-418f-a080-577065c1eaf9" />

- `L2-3-after-local-404-page-still-renders.png`
<img width="929" height="869" alt="L2-3-after-local-404-page-still-renders" src="https://github.com/user-attachments/assets/6aef5a51-f6c9-4ab2-939c-809471f43a66" />

- `L2-4-after-local-home-renders-normally.png`
<img width="929" height="869" alt="L2-4-after-local-home-renders-normally" src="https://github.com/user-attachments/assets/81355f02-c4ad-4a68-9d7f-b5c3557f22e0" />
