### PR TITLE
JCU/perf(api): stop asking the API questions an anonymous user cannot answer

### DIFF
--- a/src/app/item-page/simple/notify-requests-status/notify-requests-status-component/notify-requests-status.component.spec.ts
+++ b/src/app/item-page/simple/notify-requests-status/notify-requests-status-component/notify-requests-status.component.spec.ts
@@ -6,8 +6,10 @@ import {
   waitForAsync,
 } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
 import { NotifyRequestsStatusDataService } from 'src/app/core/data/notify-services-status-data.service';
 
+import { NotifyInfoService } from '../../../../core/coar-notify/notify-info/notify-info.service';
 import { createSuccessfulRemoteDataObject$ } from '../../../../shared/remote-data.utils';
 import { NotifyRequestsStatus } from '../notify-requests-status.model';
 import { RequestStatusEnum } from '../notify-status.enum';
@@ -18,6 +20,7 @@ describe('NotifyRequestsStatusComponent', () => {
   let component: NotifyRequestsStatusComponent;
   let fixture: ComponentFixture<NotifyRequestsStatusComponent>;
   let notifyInfoServiceSpy;
+  let notifyInfoSpy;
 
   const mock: NotifyRequestsStatus = Object.assign(new NotifyRequestsStatus(), {
     notifyStatus: [],
@@ -28,10 +31,14 @@ describe('NotifyRequestsStatusComponent', () => {
     notifyInfoServiceSpy = {
       getNotifyRequestsStatus:() => createSuccessfulRemoteDataObject$(mock),
     };
+    notifyInfoSpy = {
+      isCoarConfigEnabled: () => of(true),
+    };
     TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot(), NotifyRequestsStatusComponent],
       providers: [
         { provide: NotifyRequestsStatusDataService, useValue: notifyInfoServiceSpy },
+        { provide: NotifyInfoService, useValue: notifyInfoSpy },
       ],
     }).overrideComponent(NotifyRequestsStatusComponent, {
       remove: {
@@ -64,6 +71,18 @@ describe('NotifyRequestsStatusComponent', () => {
     component.requestMap$.subscribe((map) => {
       expect(map.size).toBe(0);
     });
+  }));
+
+  it('should not ask the backend for the request status when COAR Notify is disabled', fakeAsync(() => {
+    spyOn(notifyInfoSpy, 'isCoarConfigEnabled').and.returnValue(of(false));
+    spyOn(notifyInfoServiceSpy, 'getNotifyRequestsStatus').and.callThrough();
+
+    component.itemUuid = 'testUuid';
+    component.ngOnInit();
+    component.requestMap$.subscribe();
+    tick();
+
+    expect(notifyInfoServiceSpy.getNotifyRequestsStatus).not.toHaveBeenCalled();
   }));
 
   it('should group data by status', () => {

--- a/src/app/item-page/simple/notify-requests-status/notify-requests-status-component/notify-requests-status.component.ts
+++ b/src/app/item-page/simple/notify-requests-status/notify-requests-status-component/notify-requests-status.component.ts
@@ -9,11 +9,14 @@ import {
   OnInit,
 } from '@angular/core';
 import {
+  EMPTY,
   filter,
   map,
   Observable,
+  switchMap,
 } from 'rxjs';
 
+import { NotifyInfoService } from '../../../../core/coar-notify/notify-info/notify-info.service';
 import { NotifyRequestsStatusDataService } from '../../../../core/data/notify-services-status-data.service';
 import {
   getFirstCompletedRemoteData,
@@ -55,20 +58,30 @@ export class NotifyRequestsStatusComponent implements OnInit {
    */
   requestMap$: Observable<Map<RequestStatusEnum, NotifyStatuses[]>>;
 
-  constructor(private notifyInfoService: NotifyRequestsStatusDataService) { }
+  constructor(
+    private notifyRequestsStatusDataService: NotifyRequestsStatusDataService,
+    private notifyInfoService: NotifyInfoService,
+  ) { }
 
   ngOnInit(): void {
-    this.requestMap$ = this.notifyInfoService
-      .getNotifyRequestsStatus(this.itemUuid)
-      .pipe(
-        getFirstCompletedRemoteData(),
-        filter((data) => hasValue(data)),
-        getRemoteDataPayload(),
-        filter((data: NotifyRequestsStatus) => hasValue(data)),
-        map((data: NotifyRequestsStatus) => {
-          return this.groupDataByStatus(data);
-        }),
-      );
+    // /api/ldn/notifyrequests/<uuid> answers 401 unless COAR Notify is both enabled and visible to
+    // the current user, so this was a guaranteed error on every item page for anonymous visitors.
+    // The same feature flag already gates the COAR links built by ItemPageComponent.
+    this.requestMap$ = this.notifyInfoService.isCoarConfigEnabled().pipe(
+      switchMap((coarEnabled: boolean) => coarEnabled
+        ? this.notifyRequestsStatusDataService
+          .getNotifyRequestsStatus(this.itemUuid)
+          .pipe(
+            getFirstCompletedRemoteData(),
+            filter((data) => hasValue(data)),
+            getRemoteDataPayload(),
+            filter((data: NotifyRequestsStatus) => hasValue(data)),
+            map((data: NotifyRequestsStatus) => {
+              return this.groupDataByStatus(data);
+            }),
+          )
+        : EMPTY),
+    );
   }
 
   /**

--- a/src/app/item-page/simple/qa-event-notification/qa-event-notification.component.spec.ts
+++ b/src/app/item-page/simple/qa-event-notification/qa-event-notification.component.spec.ts
@@ -13,6 +13,8 @@ import { SplitPipe } from 'src/app/shared/utils/split.pipe';
 import { APP_DATA_SERVICES_MAP } from '../../../../config/app-config.interface';
 import { RemoteDataBuildService } from '../../../core/cache/builders/remote-data-build.service';
 import { ObjectCacheService } from '../../../core/cache/object-cache.service';
+import { AuthorizationDataService } from '../../../core/data/feature-authorization/authorization-data.service';
+import { FeatureID } from '../../../core/data/feature-authorization/feature-id';
 import { RequestService } from '../../../core/data/request.service';
 import { QualityAssuranceSourceObject } from '../../../core/notifications/qa/models/quality-assurance-source.model';
 import { QualityAssuranceSourceDataService } from '../../../core/notifications/qa/source/quality-assurance-source-data.service';
@@ -28,6 +30,7 @@ describe('QaEventNotificationComponent', () => {
   let component: QaEventNotificationComponent;
   let fixture: ComponentFixture<QaEventNotificationComponent>;
   let qualityAssuranceSourceDataServiceStub: any;
+  let authorizationServiceStub: any;
 
   const obj = Object.assign(new QualityAssuranceSourceObject(), {
     id: 'sourceName:target',
@@ -43,12 +46,16 @@ describe('QaEventNotificationComponent', () => {
     qualityAssuranceSourceDataServiceStub = {
       getSourcesByTarget: () => objPL,
     };
+    authorizationServiceStub = {
+      isAuthorized: () => of(true),
+    };
     await TestBed.configureTestingModule({
       imports: [CommonModule, TranslateModule.forRoot(), QaEventNotificationComponent, SplitPipe],
       providers: [
         { provide: APP_DATA_SERVICES_MAP, useValue: {} },
         { provide: ActivatedRoute, useValue: new ActivatedRouteStub() },
         { provide: QualityAssuranceSourceDataService, useValue: qualityAssuranceSourceDataServiceStub },
+        { provide: AuthorizationDataService, useValue: authorizationServiceStub },
         { provide: RequestService, useValue: {} },
         { provide: NotificationsService, useValue: {} },
         { provide: HALEndpointService, useValue: new HALEndpointServiceStub('test') },
@@ -77,5 +84,31 @@ describe('QaEventNotificationComponent', () => {
   it('should return the quality assurance route when getQualityAssuranceRoute is called', () => {
     const route = component.getQualityAssuranceRoute();
     expect(route).toBe('/notifications/quality-assurance');
+  });
+
+  it('should ask for the sources when the user is allowed to see QA events', (done) => {
+    // the data service is provided by the component itself, so spy on the instance it actually uses
+    const sourceService = fixture.debugElement.injector.get(QualityAssuranceSourceDataService);
+    spyOn(sourceService, 'getSourcesByTarget').and.returnValue(objPL);
+    spyOn(authorizationServiceStub, 'isAuthorized').and.returnValue(of(true));
+
+    component.getQualityAssuranceSources$().subscribe((sources) => {
+      expect(authorizationServiceStub.isAuthorized).toHaveBeenCalledWith(FeatureID.CanSeeQA);
+      expect(sourceService.getSourcesByTarget).toHaveBeenCalled();
+      expect(sources).toEqual([obj]);
+      done();
+    });
+  });
+
+  it('should not ask for the sources when the user cannot see QA events', (done) => {
+    const sourceService = fixture.debugElement.injector.get(QualityAssuranceSourceDataService);
+    spyOn(sourceService, 'getSourcesByTarget').and.returnValue(objPL);
+    spyOn(authorizationServiceStub, 'isAuthorized').and.returnValue(of(false));
+
+    component.getQualityAssuranceSources$().subscribe((sources) => {
+      expect(sourceService.getSourcesByTarget).not.toHaveBeenCalled();
+      expect(sources).toEqual([]);
+      done();
+    });
   });
 });

--- a/src/app/item-page/simple/qa-event-notification/qa-event-notification.component.ts
+++ b/src/app/item-page/simple/qa-event-notification/qa-event-notification.component.ts
@@ -8,14 +8,20 @@ import {
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
-import { Observable } from 'rxjs';
+import {
+  Observable,
+  of,
+} from 'rxjs';
 import {
   catchError,
   map,
+  switchMap,
 } from 'rxjs/operators';
 
 import { getNotificatioQualityAssuranceRoute } from '../../../admin/admin-routing-paths';
 import { RequestParam } from '../../../core/cache/models/request-param.model';
+import { AuthorizationDataService } from '../../../core/data/feature-authorization/authorization-data.service';
+import { FeatureID } from '../../../core/data/feature-authorization/feature-id';
 import { FindListOptions } from '../../../core/data/find-list-options.model';
 import { PaginatedList } from '../../../core/data/paginated-list.model';
 import { RemoteData } from '../../../core/data/remote-data';
@@ -54,6 +60,7 @@ export class QaEventNotificationComponent implements OnChanges {
 
   constructor(
     private qualityAssuranceSourceDataService: QualityAssuranceSourceDataService,
+    private authorizationService: AuthorizationDataService,
   ) {}
 
   /**
@@ -73,17 +80,24 @@ export class QaEventNotificationComponent implements OnChanges {
     const findListTopicOptions: FindListOptions = {
       searchParams: [new RequestParam('target', this.item.uuid)],
     };
-    return this.qualityAssuranceSourceDataService.getSourcesByTarget(findListTopicOptions, false)
-      .pipe(
-        getFirstCompletedRemoteData(),
-        map((data: RemoteData<PaginatedList<QualityAssuranceSourceObject>>) => {
-          if (data.hasSucceeded) {
-            return data.payload.page;
-          }
-          return [];
-        }),
-        catchError(() => []),
-      );
+    // /api/integration/qualityassurancesources/search/byTarget answers 401 to anyone who is not
+    // allowed to see quality assurance events, so asking for it without checking the feature first
+    // produced a guaranteed error on every item page for every anonymous visitor. The notification
+    // this component renders is only actionable by a user who has that permission anyway.
+    return this.authorizationService.isAuthorized(FeatureID.CanSeeQA).pipe(
+      switchMap((canSeeQA: boolean) => canSeeQA
+        ? this.qualityAssuranceSourceDataService.getSourcesByTarget(findListTopicOptions, false).pipe(
+          getFirstCompletedRemoteData(),
+          map((data: RemoteData<PaginatedList<QualityAssuranceSourceObject>>) => {
+            if (data.hasSucceeded) {
+              return data.payload.page;
+            }
+            return [];
+          }),
+          catchError(() => of([])),
+        )
+        : of([])),
+    );
   }
 
   /**

--- a/src/app/shared/menu/providers/create-report.menu.spec.ts
+++ b/src/app/shared/menu/providers/create-report.menu.spec.ts
@@ -97,4 +97,15 @@ describe('CreateReportMenuProvider', () => {
       done();
     });
   });
+
+  it('should not read contentreport.enable when the user is not a site administrator', (done) => {
+    (authorizationServiceStub.isAuthorized as jasmine.Spy).and.returnValue(of(false));
+    (configurationDataService.findByPropertyName as jasmine.Spy).calls.reset();
+
+    provider.getTopSection().subscribe((section) => {
+      expect(configurationDataService.findByPropertyName).not.toHaveBeenCalled();
+      expect(section.visible).toBeFalse();
+      done();
+    });
+  });
 });

--- a/src/app/shared/menu/providers/create-report.menu.ts
+++ b/src/app/shared/menu/providers/create-report.menu.ts
@@ -8,10 +8,13 @@
 
 import { Injectable } from '@angular/core';
 import {
-  combineLatest as observableCombineLatest,
   Observable,
+  of,
 } from 'rxjs';
-import { map } from 'rxjs/operators';
+import {
+  map,
+  switchMap,
+} from 'rxjs/operators';
 
 import { ConfigurationDataService } from '../../../core/data/configuration-data.service';
 import { AuthorizationDataService } from '../../../core/data/feature-authorization/authorization-data.service';
@@ -37,19 +40,33 @@ export class CreateReportMenuProvider extends AbstractExpandableMenuProvider {
     super();
   }
 
+  /**
+   * Whether the Reports menu should be shown at all: the user is a site administrator *and* the
+   * content report feature is switched on in the backend.
+   *
+   * The order matters. The authorization is checked first and the configuration is only fetched for
+   * an administrator, because /api/config/properties/contentreport.enable answers 404 whenever the
+   * property is not set — which is the default — and that request used to be fired on every page
+   * load for every visitor, including anonymous ones who can never see this menu.
+   */
+  private isReportMenuAvailable(): Observable<boolean> {
+    return this.authorizationService.isAuthorized(FeatureID.AdministratorOf).pipe(
+      switchMap((isSiteAdmin: boolean) => isSiteAdmin
+        ? this.configurationDataService.findByPropertyName('contentreport.enable').pipe(
+          getFirstCompletedRemoteData(),
+          map((res: RemoteData<ConfigurationProperty>) => res.hasSucceeded && res.payload && res.payload.values[0] === 'true'),
+        )
+        : of(false)),
+    );
+  }
+
   getSubSections(): Observable<PartialMenuSection[]> {
-    return observableCombineLatest([
-      this.configurationDataService.findByPropertyName('contentreport.enable').pipe(
-        getFirstCompletedRemoteData(),
-        map((res: RemoteData<ConfigurationProperty>) => res.hasSucceeded && res.payload && res.payload.values[0] === 'true'),
-      ),
-      this.authorizationService.isAuthorized(FeatureID.AdministratorOf),
-    ]).pipe(
-      map(([reportEnabled, isSiteAdmin]: [boolean, boolean]) => {
+    return this.isReportMenuAvailable().pipe(
+      map((available: boolean) => {
         return [
           /* Collections Report */
           {
-            visible: isSiteAdmin && reportEnabled,
+            visible: available,
             model: {
               type: MenuItemType.LINK,
               text: 'menu.section.reports.collections',
@@ -59,7 +76,7 @@ export class CreateReportMenuProvider extends AbstractExpandableMenuProvider {
           },
           /* Queries Report */
           {
-            visible: isSiteAdmin && reportEnabled,
+            visible: available,
             model: {
               type: MenuItemType.LINK,
               text: 'menu.section.reports.queries',
@@ -72,16 +89,10 @@ export class CreateReportMenuProvider extends AbstractExpandableMenuProvider {
   }
 
   getTopSection(): Observable<PartialMenuSection> {
-    return observableCombineLatest([
-      this.configurationDataService.findByPropertyName('contentreport.enable').pipe(
-        getFirstCompletedRemoteData(),
-        map((res: RemoteData<ConfigurationProperty>) => res.hasSucceeded && res.payload && res.payload.values[0] === 'true'),
-      ),
-      this.authorizationService.isAuthorized(FeatureID.AdministratorOf),
-    ]).pipe(
-      map(([reportEnabled, isSiteAdmin]: [boolean, boolean]) => {
+    return this.isReportMenuAvailable().pipe(
+      map((available: boolean) => {
         return {
-          visible: isSiteAdmin && reportEnabled,
+          visible: available,
           model: {
             type: MenuItemType.TEXT,
             text: 'menu.section.reports',

--- a/src/app/shared/menu/providers/export.menu.spec.ts
+++ b/src/app/shared/menu/providers/export.menu.spec.ts
@@ -49,17 +49,19 @@ describe('ExportMenuProvider', () => {
 
   let provider: ExportMenuProvider;
   let authorizationServiceStub = new AuthorizationDataServiceStub();
+  let scriptServiceStub: ScriptServiceStub;
 
   beforeEach(() => {
     spyOn(authorizationServiceStub, 'isAuthorized').and.returnValue(
       of(true),
     );
+    scriptServiceStub = new ScriptServiceStub();
 
     TestBed.configureTestingModule({
       providers: [
         ExportMenuProvider,
         { provide: AuthorizationDataService, useValue: authorizationServiceStub },
-        { provide: ScriptDataService, useClass: ScriptServiceStub },
+        { provide: ScriptDataService, useValue: scriptServiceStub },
       ],
     });
     provider = TestBed.inject(ExportMenuProvider);
@@ -79,6 +81,17 @@ describe('ExportMenuProvider', () => {
   it('getSubSections should return expected menu sections', (done) => {
     provider.getSubSections().subscribe((sections) => {
       expect(sections).toEqual(expectedSubSections);
+      done();
+    });
+  });
+
+  it('getSubSections should not query the script endpoint when the user is not an administrator', (done) => {
+    (authorizationServiceStub.isAuthorized as jasmine.Spy).and.returnValue(of(false));
+    spyOn(scriptServiceStub, 'scriptWithNameExistsAndCanExecute').and.callThrough();
+
+    provider.getSubSections().subscribe((sections) => {
+      expect(scriptServiceStub.scriptWithNameExistsAndCanExecute).not.toHaveBeenCalled();
+      expect(sections.every((section) => section.visible === false)).toBeTrue();
       done();
     });
   });

--- a/src/app/shared/menu/providers/export.menu.ts
+++ b/src/app/shared/menu/providers/export.menu.ts
@@ -9,10 +9,10 @@
 import { Injectable } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import {
-  combineLatest as observableCombineLatest,
   map,
   Observable,
   of,
+  switchMap,
 } from 'rxjs';
 
 import { AuthorizationDataService } from '../../../core/data/feature-authorization/authorization-data.service';
@@ -55,14 +55,17 @@ export class ExportMenuProvider extends AbstractExpandableMenuProvider {
   }
 
   public getSubSections(): Observable<PartialMenuSection[]> {
-    return observableCombineLatest([
-      this.authorizationService.isAuthorized(FeatureID.AdministratorOf),
-      this.scriptDataService.scriptWithNameExistsAndCanExecute(METADATA_EXPORT_SCRIPT_NAME),
-    ]).pipe(
-      map(([authorized, metadataExportScriptExists]: [boolean, boolean]) => {
+    return this.authorizationService.isAuthorized(FeatureID.AdministratorOf).pipe(
+      // Ask about the script only once we know the user may run it. /api/system/scripts/<name>
+      // answers 401 to anyone who cannot execute it, so for an anonymous visitor this request was
+      // a guaranteed error on every single page load.
+      switchMap((authorized: boolean) => authorized
+        ? this.scriptDataService.scriptWithNameExistsAndCanExecute(METADATA_EXPORT_SCRIPT_NAME)
+        : of(false)),
+      map((canExportMetadata: boolean) => {
         return [
           {
-            visible: authorized && metadataExportScriptExists,
+            visible: canExportMetadata,
             model: {
               type: MenuItemType.ONCLICK,
               text: 'menu.section.export_metadata',
@@ -72,7 +75,7 @@ export class ExportMenuProvider extends AbstractExpandableMenuProvider {
             },
           },
           {
-            visible: authorized && metadataExportScriptExists,
+            visible: canExportMetadata,
             model: {
               type: MenuItemType.ONCLICK,
               text: 'menu.section.export_batch',

--- a/src/app/shared/menu/providers/import.menu.spec.ts
+++ b/src/app/shared/menu/providers/import.menu.spec.ts
@@ -48,17 +48,19 @@ describe('ImportMenuProvider', () => {
 
   let provider: ImportMenuProvider;
   let authorizationServiceStub = new AuthorizationDataServiceStub();
+  let scriptServiceStub: ScriptServiceStub;
 
   beforeEach(() => {
     spyOn(authorizationServiceStub, 'isAuthorized').and.returnValue(
       of(true),
     );
+    scriptServiceStub = new ScriptServiceStub();
 
     TestBed.configureTestingModule({
       providers: [
         ImportMenuProvider,
         { provide: AuthorizationDataService, useValue: authorizationServiceStub },
-        { provide: ScriptDataService, useClass: ScriptServiceStub },
+        { provide: ScriptDataService, useValue: scriptServiceStub },
       ],
     });
     provider = TestBed.inject(ImportMenuProvider);
@@ -78,6 +80,17 @@ describe('ImportMenuProvider', () => {
   it('getSubSections should return expected menu sections', (done) => {
     provider.getSubSections().subscribe((sections) => {
       expect(sections).toEqual(expectedSubSections);
+      done();
+    });
+  });
+
+  it('getSubSections should not query the script endpoint when the user is not an administrator', (done) => {
+    (authorizationServiceStub.isAuthorized as jasmine.Spy).and.returnValue(of(false));
+    spyOn(scriptServiceStub, 'scriptWithNameExistsAndCanExecute').and.callThrough();
+
+    provider.getSubSections().subscribe((sections) => {
+      expect(scriptServiceStub.scriptWithNameExistsAndCanExecute).not.toHaveBeenCalled();
+      expect(sections.every((section) => section.visible === false)).toBeTrue();
       done();
     });
   });

--- a/src/app/shared/menu/providers/import.menu.ts
+++ b/src/app/shared/menu/providers/import.menu.ts
@@ -9,10 +9,10 @@
 import { Injectable } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import {
-  combineLatest as observableCombineLatest,
   map,
   Observable,
   of,
+  switchMap,
 } from 'rxjs';
 
 import { AuthorizationDataService } from '../../../core/data/feature-authorization/authorization-data.service';
@@ -52,14 +52,17 @@ export class ImportMenuProvider extends AbstractExpandableMenuProvider {
   }
 
   public getSubSections(): Observable<PartialMenuSection[]> {
-    return observableCombineLatest([
-      this.authorizationService.isAuthorized(FeatureID.AdministratorOf),
-      this.scriptDataService.scriptWithNameExistsAndCanExecute(METADATA_IMPORT_SCRIPT_NAME),
-    ]).pipe(
-      map(([authorized, metadataImportScriptExists]) => {
+    return this.authorizationService.isAuthorized(FeatureID.AdministratorOf).pipe(
+      // Ask about the script only once we know the user may run it. /api/system/scripts/<name>
+      // answers 401 to anyone who cannot execute it, so for an anonymous visitor this request was
+      // a guaranteed error on every single page load.
+      switchMap((authorized: boolean) => authorized
+        ? this.scriptDataService.scriptWithNameExistsAndCanExecute(METADATA_IMPORT_SCRIPT_NAME)
+        : of(false)),
+      map((canImportMetadata: boolean) => {
         return [
           {
-            visible: authorized && metadataImportScriptExists,
+            visible: canImportMetadata,
             model: {
               type: MenuItemType.LINK,
               text: 'menu.section.import_metadata',
@@ -67,7 +70,7 @@ export class ImportMenuProvider extends AbstractExpandableMenuProvider {
             },
           },
           {
-            visible: authorized && metadataImportScriptExists,
+            visible: canImportMetadata,
             model: {
               type: MenuItemType.LINK,
               text: 'menu.section.import_batch',

--- a/src/app/shared/menu/providers/withdrawn-reinstate-item.menu.spec.ts
+++ b/src/app/shared/menu/providers/withdrawn-reinstate-item.menu.spec.ts
@@ -1,6 +1,8 @@
 import { TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
 
+import { AuthService } from '../../../core/auth/auth.service';
 import { Item } from '../../../core/shared/item.model';
 import { ITEM } from '../../../core/shared/item.resource-type';
 import { CorrectionTypeDataService } from '../../../core/submission/correctiontype-data.service';
@@ -56,6 +58,7 @@ describe('WithdrawnReinstateItemMenuProvider', () => {
 
   let correctionTypeDataService;
   let dsoWithdrawnReinstateModalService;
+  let authService;
 
   beforeEach(() => {
     const correctionType = Object.assign(new CorrectionType(), {
@@ -69,6 +72,9 @@ describe('WithdrawnReinstateItemMenuProvider', () => {
 
     dsoWithdrawnReinstateModalService = jasmine.createSpyObj('dsoWithdrawnReinstateModalService', ['openCreateWithdrawnReinstateModal']);
 
+    authService = jasmine.createSpyObj('authService', {
+      'isAuthenticated': of(true),
+    });
 
     TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot()],
@@ -76,6 +82,7 @@ describe('WithdrawnReinstateItemMenuProvider', () => {
         WithdrawnReinstateItemMenuProvider,
         { provide: CorrectionTypeDataService, useValue: correctionTypeDataService },
         { provide: DsoWithdrawnReinstateModalService, useValue: dsoWithdrawnReinstateModalService },
+        { provide: AuthService, useValue: authService },
       ],
     });
     provider = TestBed.inject(WithdrawnReinstateItemMenuProvider);
@@ -89,6 +96,16 @@ describe('WithdrawnReinstateItemMenuProvider', () => {
     it('should return the expected sections', (done) => {
       provider.getSectionsForContext(item).subscribe((sections) => {
         expect(sections).toEqual(expectedSections);
+        done();
+      });
+    });
+
+    it('should not query the correction types for an anonymous user', (done) => {
+      authService.isAuthenticated.and.returnValue(of(false));
+
+      provider.getSectionsForContext(item).subscribe((sections) => {
+        expect(correctionTypeDataService.findByItem).not.toHaveBeenCalled();
+        expect(sections.every((section) => !section.visible)).toBeTrue();
         done();
       });
     });

--- a/src/app/shared/menu/providers/withdrawn-reinstate-item.menu.ts
+++ b/src/app/shared/menu/providers/withdrawn-reinstate-item.menu.ts
@@ -7,17 +7,23 @@
  */
 import { Injectable } from '@angular/core';
 import {
-  combineLatest,
   Observable,
+  of,
 } from 'rxjs';
-import { map } from 'rxjs/operators';
+import {
+  map,
+  switchMap,
+} from 'rxjs/operators';
 
+import { AuthService } from '../../../core/auth/auth.service';
+import { PaginatedList } from '../../../core/data/paginated-list.model';
 import { Item } from '../../../core/shared/item.model';
 import {
   getFirstCompletedRemoteData,
   getRemoteDataPayload,
 } from '../../../core/shared/operators';
 import { CorrectionTypeDataService } from '../../../core/submission/correctiontype-data.service';
+import { CorrectionType } from '../../../core/submission/models/correctiontype.model';
 import {
   DsoWithdrawnReinstateModalService,
   REQUEST_REINSTATE,
@@ -36,17 +42,22 @@ export class WithdrawnReinstateItemMenuProvider extends DSpaceObjectPageMenuProv
   constructor(
     protected dsoWithdrawnReinstateModalService: DsoWithdrawnReinstateModalService,
     protected correctionTypeDataService: CorrectionTypeDataService,
+    protected authService: AuthService,
   ) {
     super();
   }
 
   public getSectionsForContext(item: Item): Observable<PartialMenuSection[]> {
-    return combineLatest([
-      this.correctionTypeDataService.findByItem(item.uuid, true).pipe(
-        getFirstCompletedRemoteData(),
-        getRemoteDataPayload()),
-    ]).pipe(
-      map(([correction]) => {
+    // /api/config/correctiontypes/search/findByItem answers 401 to anonymous users, so this was a
+    // guaranteed error on every item page. Requesting a withdrawal or a reinstatement is only
+    // possible while logged in, so there is nothing to ask about before then.
+    return this.authService.isAuthenticated().pipe(
+      switchMap((authenticated: boolean) => authenticated
+        ? this.correctionTypeDataService.findByItem(item.uuid, true).pipe(
+          getFirstCompletedRemoteData(),
+          getRemoteDataPayload())
+        : of(null as PaginatedList<CorrectionType>)),
+      map((correction: PaginatedList<CorrectionType>) => {
         return [
           {
             visible: item.isArchived && correction?.page.some((c) => c.topic === REQUEST_WITHDRAWN),


### PR DESCRIPTION
Fixes the frontend part of **L3** from the dataquest-dev/dspace-customers#853 review.

## Reproduced

Anonymous, cold cache, local Docker DSpace 9.3 with the JCU configuration. Every request the review
lists is real, plus one it does not (`google.analytics.key`):

| Page | Request | Status |
|---|---|---|
| every page | `/api/system/scripts/metadata-export` | **401** |
| every page | `/api/system/scripts/metadata-import` | **401** |
| every page | `/api/config/properties/contentreport.enable` | **404** |
| every page | `/api/config/properties/google.analytics.key` | **404** |
| item page | `/api/config/correctiontypes/search/findByItem` | **401** |
| item page | `/api/integration/qualityassurancesources/search/byTarget` | **401** |
| item page | `/api/ldn/notifyrequests/<uuid>` | **401** |
| `/search` | `/api/config/properties/bulkedit.export.max.items` | **404** |
| `/register` | `/api/config/properties/authentication-password.domain.valid` | **404** |

That is **4 failed requests on the home page and 6 on an item page**, for every visitor, on every
page view.

## Two different causes, and the review's remedy only fits one of them

The review proposes adding the properties to `rest.properties.exposed`. That is right for exactly one
of the nine — and the split matters, because it decides which repository the fix belongs in.

**The 401s are a frontend problem.** Five call sites request something, *then* check whether the user
was allowed to ask. The permission they check is already known — in every case the corresponding
`/authz/authorizations/search/object?feature=…` request is fired anyway, for other reasons, before
these calls go out. So we already had the answer and asked anyway. `ScriptDataService` even documents
it: *"user needs to be allowed to execute script for this to not throw a 401 Unauthorized"*.

**The 404s are backend configuration**, and not the way the review describes:

**All four** of `contentreport.enable`, `bulkedit.export.max.items`,
`authentication-password.domain.valid` and `google.analytics.key` are **already** listed in
`rest.properties.exposed` in `modules/rest.cfg`. `ConfigurationRestRepository.findOne()` throws
`ResourceNotFoundException` when the property is not exposed **or** when
`!configurationService.hasProperty(property)` — and DSpace ships all four commented out. Exposing
them changes nothing; they have to be **set**. (`google.analytics.key` is a fifth 404 the review
missed.)

Those live in `local.cfg` on the server, not in this repository, so they are **not** in this PR. The
exact lines are at the bottom, together with the one that needs a decision from JCU
(`authentication-password.domain.valid` — whether registration should be restricted to `@jcu.cz`).

## What this PR changes

| File | Was | Now |
|---|---|---|
| `export.menu.ts` | `combineLatest([isAdmin$, scriptExists$])` | ask for the script only when `AdministratorOf` |
| `import.menu.ts` | same | same |
| `create-report.menu.ts` | `combineLatest([contentreportEnabled$, isAdmin$])`, duplicated in both methods | one `isReportMenuAvailable()`, config read only when `AdministratorOf` |
| `withdrawn-reinstate-item.menu.ts` | `findByItem()` on every item page | only when `isAuthenticated()` — you cannot request a withdrawal while logged out |
| `qa-event-notification.component.ts` | `getSourcesByTarget()` on every item page | only when `CanSeeQA` |
| `notify-requests-status.component.ts` | `getNotifyRequestsStatus()` on every item page | only when `isCoarConfigEnabled()` (`CoarNotifyEnabled`) |

Nothing is hidden that was visible before: in each case the item was already `visible: false` for a
user without the permission — the fix only stops asking. And no request is *added*: every
authorization used as the gate was already being fetched.

Two incidental notes:

- `notify-requests-status.component.ts` had its `NotifyRequestsStatusDataService` field named
  `notifyInfoService`, which is the name of a *different* service that I now inject next to it.
  Renamed the field to `notifyRequestsStatusDataService`.
- `qa-event-notification.component.ts` had `catchError(() => [])`. RxJS treats a bare array as a
  source that emits each element, so an empty array emits *nothing* — the intent was clearly
  `of([])`, which is what it says now. No visible difference (the template renders nothing either
  way), but it is what the code meant.

## Verified

Same measurement, same stack, on this branch:

```
                      before   after
home page              4        1
item page              6        1
```

The one remaining is `google.analytics.key`, which is the backend config item.

Logged in as a site administrator the three admin requests fire again, exactly as before, and the
menus still build — sidebar → **Export** → *Metadata*, *Batch Export (ZIP)*.

- Touched specs: **24/24**, with a new "does not call X when not authorized" test for each of the six
  call sites.
- Wider suites `src/app/shared/menu/**` + `src/app/item-page/**`: **692 passing**, 11 failing — all 11
  in `edit-relationship-list.component.spec.ts`, which fails identically on `customer/jcu` without
  this branch (verified by stashing).
- `npm run lint` → 0 errors.

## Still to do in `local.cfg` (server side, not this repo) — already verified

```properties
# L3 - all four are already in rest.properties.exposed; they 404 only because they are unset.
contentreport.enable = false
bulkedit.export.max.items = 500

# Analytics is not configured; an empty value returns 200 with no values, which is what
# GoogleAnalyticsService expects when analytics is off (it checks isEmpty(trackingId)).
google.analytics.key =

# JCU's decision, not mine. Empty = no restriction (today's behaviour);
# set to jcu.cz to only allow @jcu.cz self-registration.
authentication-password.domain.valid =
```

Applied to the local Docker stack, this turns all four 404s into 200s with nothing else regressing,
and with this PR an anonymous visitor then generates **zero 4xx REST responses** on `/home`, an item
page, `/search` and `/register`.

> ⚠ **Do not add `rest.properties.exposed` to `local.cfg`.** A value there *replaces* the whole array
> from `modules/rest.cfg` rather than appending to it. I tried it while verifying and it silently
> 404'd `registration.verification.enabled`, `matomo.enabled` and `themed.by.url`. Nothing needs
> adding anyway — every property involved is already exposed.

Full write-up, including the H3 name/e-mail change and the OAI cache purge it requires, is in
`C:\Users\MatusKasak\jcu-853-H3-L3-local-cfg-patch.md`.

## Upstream and other customers

All six files are **byte-for-byte identical to `upstream/dspace-9_x`**, and `upstream/main` still has
the same eager `combineLatest([permission$, request$])` shape — so this is upstream behaviour, not a
JCU regression, and every DSpace 7/8/9/10 instance does it. There is no upstream issue for it
(searched "401 anonymous requests", "unnecessary requests anonymous", "contentreport.enable"). The
change is small and generic and is worth offering upstream; it is a straight win for any repository
whose traffic is mostly anonymous, which is all of them.

None of our other customer branches has it either.

## Evidence

Screenshots in `C:\Users\MatusKasak\jcu-853-evidence\` (to be attached here):

- `L3-1-before-anonymous-401-404-requests.png`
- `L3-2-after-anonymous-calls-gone.png`
- `L3-3-after-local-item-page-unchanged.png`
- `L3-4-after-local-admin-export-menu-still-works.png`
