### PR TITLE
JCU/fix(docker): keep Solr logs between container recreates

### DIFF
--- a/docker/docker-compose-rest.yml
+++ b/docker/docker-compose-rest.yml
@@ -116,6 +116,9 @@ services:
     volumes:
     # Keep Solr data directory between reboots
     - solr_data:/var/solr/data
+    # Keep Solr's own logs between reboots. Solr rotates solr.log itself
+    # (size-based, bounded); this only stops them dying with the container.
+    - solr_logs:/var/solr/logs
     # NOTE: We are not running Solr as "root", but we need root permissions to copy our cores to the mounted
     # /var/solr/data directory. Then we start Solr as the "solr" user.
     user: root
@@ -150,3 +153,4 @@ volumes:
   dspacelogs:
   pgdata:
   solr_data:
+  solr_logs:


### PR DESCRIPTION
## Problem

Same problem as `/dspace/log`, one container over. Solr writes `solr.log` into `/var/solr/logs`, which lives in the container's **writable layer** — so it is wiped on every `docker compose up -d --force-recreate` and on every image update.

`customer/vsb-tuo` already mounts `solr_logs:/var/solr/logs`. This branch did not.

## Changes

```yaml
    volumes:
    - solr_data:/var/solr/data
    - solr_logs:/var/solr/logs
```

plus the matching `solr_logs:` declaration.

## What this does *not* change

Solr's log rotation is untouched, and deliberately so. Solr rotates `solr.log` itself — size-based and bounded (`DefaultRolloverStrategy max="9"`) — using the log4j2 config baked into the official Solr image. That config is not in this repo and not in the DSpace fork either: `dspace-solr` is the stock `docker.io/solr` image plus DSpace's configsets, nothing more. So the `.gz` compression applied to the DSpace logs does not reach Solr, and nobody in the fleet compresses Solr logs. This PR is purely about the logs surviving a recreate.

## Safety

The `dspacesolr` service runs as `user: root` and its entrypoint does `chown -R solr:solr /var/solr` before starting Solr as the `solr` user, so a freshly seeded named volume ends up with the right ownership. No permission workaround needed.

## Verification

`docker compose config` renders cleanly, with the mount attached to `dspacesolr` and the volume declared:

```yaml
        source: solr_logs
        target: /var/solr/logs
```

## Why a separate PR

This was meant to ride along with #1433, but that PR was merged before this commit landed on its branch — so `dspacelogs:/dspace/log` is on `customer/jcu` and this half is not. Cut fresh from the current branch head. The equivalent change for `customer/mendelu` is in #1434, which is still open and already carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
