### PR TITLE
TUL/Prevent an admin from deleting their own account

### DIFF
--- a/src/app/access-control/access-control.module.ts
+++ b/src/app/access-control/access-control.module.ts
@@ -5,6 +5,7 @@ import { SharedModule } from '../shared/shared.module';
 import { AccessControlRoutingModule } from './access-control-routing.module';
 import { EPeopleRegistryComponent } from './epeople-registry/epeople-registry.component';
 import { EPersonFormComponent } from './epeople-registry/eperson-form/eperson-form.component';
+import { EPersonDeleteGuardService } from './epeople-registry/eperson-delete-guard.service';
 import { GroupFormComponent } from './group-registry/group-form/group-form.component';
 import { MembersListComponent } from './group-registry/group-form/members-list/members-list.component';
 import { SubgroupsListComponent } from './group-registry/group-form/subgroup-list/subgroups-list.component';
@@ -45,6 +46,7 @@ export const ValidateEmailErrorStateMatcher: DynamicErrorMessagesMatcher =
       provide: DYNAMIC_ERROR_MESSAGES_MATCHER,
       useValue: ValidateEmailErrorStateMatcher
     },
+    EPersonDeleteGuardService,
   ]
 })
 /**

--- a/src/app/access-control/epeople-registry/epeople-registry.component.html
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.html
@@ -77,11 +77,27 @@
                             title="{{labelPrefix + 'table.edit.buttons.edit' | translate: {name: epersonDto.eperson.name} }}">
                       <i class="fas fa-edit fa-fw"></i>
                     </button>
-                    <button [disabled]="!epersonDto.ableToDelete" (click)="deleteEPerson(epersonDto.eperson)"
-                            class="btn btn-outline-danger btn-sm access-control-deleteEPersonButton"
-                            title="{{labelPrefix + 'table.edit.buttons.remove' | translate: {name: epersonDto.eperson.name} }}">
-                      <i class="fas fa-trash-alt fa-fw"></i>
-                    </button>
+                    <ng-container *ngIf="currentAuthenticatedUserId">
+                      <span *ngIf="isCurrentUser(epersonDto.eperson); else enabledDeleteButton"
+                            tabindex="0"
+                            [ngbTooltip]="selfDeleteWarningLabel | translate"
+                            container="body">
+                        <button [disabled]="true"
+                                tabindex="-1"
+                                [attr.aria-label]="selfDeleteWarningLabel | translate"
+                                class="btn btn-outline-danger btn-sm access-control-deleteEPersonButton"
+                                type="button">
+                          <i class="fas fa-trash-alt fa-fw"></i>
+                        </button>
+                      </span>
+                    </ng-container>
+                    <ng-template #enabledDeleteButton>
+                      <button [disabled]="!epersonDto.ableToDelete" (click)="deleteEPerson(epersonDto.eperson)"
+                              class="btn btn-outline-danger btn-sm access-control-deleteEPersonButton"
+                              title="{{labelPrefix + 'table.edit.buttons.remove' | translate: {name: epersonDto.eperson.name} }}">
+                        <i class="fas fa-trash-alt fa-fw"></i>
+                      </button>
+                    </ng-template>
                   </div>
                 </td>
               </tr>

--- a/src/app/access-control/epeople-registry/epeople-registry.component.spec.ts
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.spec.ts
@@ -23,6 +23,8 @@ import { TranslateLoaderMock } from '../../shared/mocks/translate-loader.mock';
 import { NotificationsServiceStub } from '../../shared/testing/notifications-service.stub';
 import { RouterStub } from '../../shared/testing/router.stub';
 import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
+import { AuthService } from '../../core/auth/auth.service';
+import { EPersonDeleteGuardService } from './eperson-delete-guard.service';
 import { RequestService } from '../../core/data/request.service';
 import { PaginationService } from '../../core/pagination/pagination.service';
 import { PaginationServiceStub } from '../../shared/testing/pagination-service.stub';
@@ -37,6 +39,8 @@ describe('EPeopleRegistryComponent', () => {
   let mockEPeople;
   let ePersonDataServiceStub: any;
   let authorizationService: AuthorizationDataService;
+  let authService: jasmine.SpyObj<AuthService>;
+  let deleteGuard: jasmine.SpyObj<EPersonDeleteGuardService>;
   let modalService;
 
   let paginationService;
@@ -117,6 +121,12 @@ describe('EPeopleRegistryComponent', () => {
     authorizationService = jasmine.createSpyObj('authorizationService', {
       isAuthorized: observableOf(true)
     });
+    authService = jasmine.createSpyObj('authService', ['getAuthenticatedUserFromStore']);
+    authService.getAuthenticatedUserFromStore.and.returnValue(observableOf(Object.assign(new EPerson(), { id: 'different-user-id' })));
+    deleteGuard = jasmine.createSpyObj('deleteGuard', ['isCurrentUser', 'getDeleteWarningLabel', 'isSelfDeletionError', 'showSelfDeleteNotification']);
+    deleteGuard.isCurrentUser.and.callFake((ePerson: EPerson, currentId: string) => !!ePerson?.id && ePerson.id === currentId);
+    deleteGuard.getDeleteWarningLabel.and.returnValue(observableOf(undefined));
+    deleteGuard.isSelfDeletionError.and.returnValue(false);
     builderService = getMockFormBuilderService();
     translateService = getMockTranslateService();
 
@@ -135,6 +145,8 @@ describe('EPeopleRegistryComponent', () => {
         { provide: EPersonDataService, useValue: ePersonDataServiceStub },
         { provide: NotificationsService, useValue: new NotificationsServiceStub() },
         { provide: AuthorizationDataService, useValue: authorizationService },
+        { provide: AuthService, useValue: authService },
+        { provide: EPersonDeleteGuardService, useValue: deleteGuard },
         { provide: FormBuilderService, useValue: builderService },
         { provide: Router, useValue: new RouterStub() },
         { provide: RequestService, useValue: jasmine.createSpyObj('requestService', ['removeByHrefSubstring']) },
@@ -254,6 +266,25 @@ describe('EPeopleRegistryComponent', () => {
           expect(epersonElement !== ePeopleIdsFoundBeforeDelete[0].nativeElement.textContent).toBeTrue();
         });
       });
+    });
+  });
+
+  describe('when an EPerson is the currently authenticated user', () => {
+    beforeEach(() => {
+      component.currentAuthenticatedUserId = EPersonMock.id;
+      fixture.detectChanges();
+    });
+
+    it('renders the delete button for that row as disabled', () => {
+      const deleteButtons = fixture.debugElement.queryAll(By.css('.access-control-deleteEPersonButton'));
+      const disabled = deleteButtons.filter((button) => button.nativeElement.disabled);
+      expect(disabled.length).toBe(1);
+    });
+
+    it('notifies instead of opening the confirmation modal', () => {
+      component.deleteEPerson(EPersonMock);
+      expect(deleteGuard.showSelfDeleteNotification).toHaveBeenCalled();
+      expect(modalService.open).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/access-control/epeople-registry/epeople-registry.component.ts
+++ b/src/app/access-control/epeople-registry/epeople-registry.component.ts
@@ -21,6 +21,8 @@ import { RequestService } from '../../core/data/request.service';
 import { PageInfo } from '../../core/shared/page-info.model';
 import { NoContent } from '../../core/shared/NoContent.model';
 import { PaginationService } from '../../core/pagination/pagination.service';
+import { AuthService } from '../../core/auth/auth.service';
+import { EPersonDeleteGuardService, SELF_DELETE_WARNING_LABEL } from './eperson-delete-guard.service';
 
 @Component({
   selector: 'ds-epeople-registry',
@@ -33,6 +35,9 @@ import { PaginationService } from '../../core/pagination/pagination.service';
 export class EPeopleRegistryComponent implements OnInit, OnDestroy {
 
   labelPrefix = 'admin.access-control.epeople.';
+  selfDeleteWarningLabel = SELF_DELETE_WARNING_LABEL;
+
+  currentAuthenticatedUserId: string;
 
   /**
    * A list of all the current EPeople within the repository or the result of the search
@@ -89,6 +94,8 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
               private translateService: TranslateService,
               private notificationsService: NotificationsService,
               private authorizationService: AuthorizationDataService,
+              private authService: AuthService,
+              private deleteGuard: EPersonDeleteGuardService,
               private formBuilder: FormBuilder,
               private router: Router,
               private modalService: NgbModal,
@@ -113,6 +120,9 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
     this.searching$.next(true);
     this.isEPersonFormShown = false;
     this.search({scope: this.currentSearchScope, query: this.currentSearchQuery});
+    this.subs.push(this.authService.getAuthenticatedUserFromStore().subscribe((currentUser: EPerson) => {
+      this.currentAuthenticatedUserId = currentUser?.id;
+    }));
     this.subs.push(this.epersonService.getActiveEPerson().subscribe((eperson: EPerson) => {
       if (eperson != null && eperson.id) {
         this.isEPersonFormShown = true;
@@ -224,28 +234,44 @@ export class EPeopleRegistryComponent implements OnInit, OnDestroy {
    */
   deleteEPerson(ePerson: EPerson) {
     if (hasValue(ePerson.id)) {
-      const modalRef = this.modalService.open(ConfirmationModalComponent);
-      modalRef.componentInstance.dso = ePerson;
-      modalRef.componentInstance.headerLabel = 'confirmation-modal.delete-eperson.header';
-      modalRef.componentInstance.infoLabel = 'confirmation-modal.delete-eperson.info';
-      modalRef.componentInstance.cancelLabel = 'confirmation-modal.delete-eperson.cancel';
-      modalRef.componentInstance.confirmLabel = 'confirmation-modal.delete-eperson.confirm';
-      modalRef.componentInstance.brandColor = 'danger';
-      modalRef.componentInstance.confirmIcon = 'fas fa-trash';
-      modalRef.componentInstance.response.pipe(take(1)).subscribe((confirm: boolean) => {
-        if (confirm) {
-          if (hasValue(ePerson.id)) {
+      if (!hasValue(this.currentAuthenticatedUserId)) {
+        return;
+      }
+
+      if (this.isCurrentUser(ePerson)) {
+        this.deleteGuard.showSelfDeleteNotification();
+        return;
+      }
+
+      this.deleteGuard.getDeleteWarningLabel(ePerson).pipe(take(1)).subscribe((warningLabel: string | undefined) => {
+        const modalRef = this.modalService.open(ConfirmationModalComponent);
+        modalRef.componentInstance.dso = ePerson;
+        modalRef.componentInstance.headerLabel = 'confirmation-modal.delete-eperson.header';
+        modalRef.componentInstance.infoLabel = 'confirmation-modal.delete-eperson.info';
+        modalRef.componentInstance.warningLabel = warningLabel;
+        modalRef.componentInstance.cancelLabel = 'confirmation-modal.delete-eperson.cancel';
+        modalRef.componentInstance.confirmLabel = 'confirmation-modal.delete-eperson.confirm';
+        modalRef.componentInstance.brandColor = 'danger';
+        modalRef.componentInstance.confirmIcon = 'fas fa-trash';
+        modalRef.componentInstance.response.pipe(take(1)).subscribe((confirm: boolean) => {
+          if (confirm) {
             this.epersonService.deleteEPerson(ePerson).pipe(getFirstCompletedRemoteData()).subscribe((restResponse: RemoteData<NoContent>) => {
               if (restResponse.hasSucceeded) {
                 this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.deleted.success', {name: ePerson.name}));
+              } else if (this.isCurrentUser(ePerson) || this.deleteGuard.isSelfDeletionError(restResponse)) {
+                this.deleteGuard.showSelfDeleteNotification();
               } else {
                 this.notificationsService.error('Error occured when trying to delete EPerson with id: ' + ePerson.id + ' with code: ' + restResponse.statusCode + ' and message: ' + restResponse.errorMessage);
               }
             });
           }
-        }
+        });
       });
     }
+  }
+
+  isCurrentUser(ePerson: EPerson): boolean {
+    return this.deleteGuard.isCurrentUser(ePerson, this.currentAuthenticatedUserId);
   }
 
   /**

--- a/src/app/access-control/epeople-registry/eperson-delete-guard.service.spec.ts
+++ b/src/app/access-control/epeople-registry/eperson-delete-guard.service.spec.ts
@@ -1,0 +1,147 @@
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { of as observableOf, throwError as observableThrowError } from 'rxjs';
+import { TranslateService } from '@ngx-translate/core';
+import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
+import { FeatureID } from '../../core/data/feature-authorization/feature-id';
+import { buildPaginatedList } from '../../core/data/paginated-list.model';
+import { PageInfo } from '../../core/shared/page-info.model';
+import { DSpaceObject } from '../../core/shared/dspace-object.model';
+import { SearchService } from '../../core/shared/search/search.service';
+import { WorkflowItemDataService } from '../../core/submission/workflowitem-data.service';
+import { WorkspaceitemDataService } from '../../core/submission/workspaceitem-data.service';
+import { NotificationsService } from '../../shared/notifications/notifications.service';
+import { createFailedRemoteDataObject$, createSuccessfulRemoteDataObject$ } from '../../shared/remote-data.utils';
+import { SearchObjects } from '../../shared/search/models/search-objects.model';
+import { NotificationsServiceStub } from '../../shared/testing/notifications-service.stub';
+import { EPersonMock } from '../../shared/testing/eperson.mock';
+import { EPersonDeleteGuardService } from './eperson-delete-guard.service';
+
+describe('EPersonDeleteGuardService', () => {
+  let service: EPersonDeleteGuardService;
+  let authorizationService: jasmine.SpyObj<AuthorizationDataService>;
+  let workspaceItemDataService: jasmine.SpyObj<WorkspaceitemDataService>;
+  let workflowItemDataService: jasmine.SpyObj<WorkflowItemDataService>;
+  let searchService: jasmine.SpyObj<SearchService>;
+  let notificationsService: NotificationsServiceStub;
+  let translateService: jasmine.SpyObj<TranslateService>;
+
+  const remoteList = (totalElements: number) => createSuccessfulRemoteDataObject$(
+    buildPaginatedList(new PageInfo({ elementsPerPage: 1, totalElements, totalPages: 1, currentPage: 1 }), [])
+  );
+  const searchObjects = (totalElements: number) => createSuccessfulRemoteDataObject$(Object.assign(
+    new SearchObjects<DSpaceObject>(),
+    buildPaginatedList(new PageInfo({ elementsPerPage: 1, totalElements, totalPages: 1, currentPage: 1 }), [])
+  ));
+
+  beforeEach(() => {
+    authorizationService = jasmine.createSpyObj('authorizationService', ['isAuthorized']);
+    authorizationService.isAuthorized.and.returnValue(observableOf(false));
+    workspaceItemDataService = jasmine.createSpyObj('workspaceItemDataService', ['searchBy']);
+    workspaceItemDataService.searchBy.and.returnValue(remoteList(0));
+    workflowItemDataService = jasmine.createSpyObj('workflowItemDataService', ['searchBy']);
+    workflowItemDataService.searchBy.and.returnValue(remoteList(0));
+    searchService = jasmine.createSpyObj('searchService', ['search']);
+    searchService.search.and.returnValue(searchObjects(0));
+    notificationsService = new NotificationsServiceStub();
+    translateService = jasmine.createSpyObj('translateService', ['get']);
+    translateService.get.and.callFake((key: string) => observableOf(key));
+
+    TestBed.configureTestingModule({
+      providers: [
+        EPersonDeleteGuardService,
+        { provide: AuthorizationDataService, useValue: authorizationService },
+        { provide: WorkspaceitemDataService, useValue: workspaceItemDataService },
+        { provide: WorkflowItemDataService, useValue: workflowItemDataService },
+        { provide: SearchService, useValue: searchService },
+        { provide: NotificationsService, useValue: notificationsService },
+        { provide: TranslateService, useValue: translateService },
+      ],
+    });
+    service = TestBed.inject(EPersonDeleteGuardService);
+  });
+
+  describe('isCurrentUser', () => {
+    it('is true only when the ids match', () => {
+      expect(service.isCurrentUser(EPersonMock, EPersonMock.id)).toBeTrue();
+      expect(service.isCurrentUser(EPersonMock, 'someone-else')).toBeFalse();
+      expect(service.isCurrentUser(undefined, EPersonMock.id)).toBeFalsy();
+    });
+  });
+
+  describe('getDeleteWarningLabel', () => {
+    it('returns undefined when the user is neither a submitter nor an admin', fakeAsync(() => {
+      let label: string | undefined = 'unset';
+      service.getDeleteWarningLabel(EPersonMock).subscribe((value) => label = value);
+      tick();
+      expect(label).toBeUndefined();
+    }));
+
+    it('returns the submitter warning when the user has submitted items', fakeAsync(() => {
+      workspaceItemDataService.searchBy.and.returnValue(remoteList(1));
+      let label: string;
+      service.getDeleteWarningLabel(EPersonMock).subscribe((value) => label = value);
+      tick();
+      expect(label).toBe('admin.access-control.epeople.delete.warning.submitter');
+    }));
+
+    it('returns the admin warning, querying the AdministratorOf feature for the target user', fakeAsync(() => {
+      authorizationService.isAuthorized.and.returnValue(observableOf(true));
+      let label: string;
+      service.getDeleteWarningLabel(EPersonMock).subscribe((value) => label = value);
+      tick();
+      expect(authorizationService.isAuthorized).toHaveBeenCalledWith(FeatureID.AdministratorOf, undefined, EPersonMock.id);
+      expect(label).toBe('admin.access-control.epeople.delete.warning.admin');
+    }));
+
+    it('returns the combined warning when both apply', fakeAsync(() => {
+      workspaceItemDataService.searchBy.and.returnValue(remoteList(1));
+      authorizationService.isAuthorized.and.returnValue(observableOf(true));
+      let label: string;
+      service.getDeleteWarningLabel(EPersonMock).subscribe((value) => label = value);
+      tick();
+      expect(label).toBe('admin.access-control.epeople.delete.warning.submitterAndAdmin');
+    }));
+
+    it('degrades each probe to false on error so a failed lookup never blocks the delete', fakeAsync(() => {
+      workspaceItemDataService.searchBy.and.returnValue(observableThrowError(() => new Error('boom')));
+      searchService.search.and.returnValue(observableThrowError(() => new Error('boom')));
+      authorizationService.isAuthorized.and.returnValue(observableThrowError(() => new Error('boom')));
+      let emitted = false;
+      let label: string | undefined = 'unset';
+      service.getDeleteWarningLabel(EPersonMock).subscribe((value) => {
+        emitted = true;
+        label = value;
+      });
+      tick();
+      expect(emitted).toBeTrue();
+      expect(label).toBeUndefined();
+    }));
+  });
+
+  describe('isSelfDeletionError', () => {
+    it('recognises the backend self-delete rejection', fakeAsync(() => {
+      let rd;
+      createFailedRemoteDataObject$('You, as admin user, cannot delete yourself', 400).subscribe((value) => rd = value);
+      tick();
+      expect(service.isSelfDeletionError(rd)).toBeTrue();
+    }));
+
+    it('ignores other failures', fakeAsync(() => {
+      let rd;
+      createFailedRemoteDataObject$('server error', 500).subscribe((value) => rd = value);
+      tick();
+      expect(service.isSelfDeletionError(rd)).toBeFalsy();
+      expect(service.isSelfDeletionError(null)).toBeFalsy();
+    }));
+  });
+
+  describe('showSelfDeleteNotification', () => {
+    it('emits the self-delete error notification', () => {
+      service.showSelfDeleteNotification();
+      expect(notificationsService.error).toHaveBeenCalled();
+      let translatedKey: string;
+      notificationsService.error.calls.mostRecent().args[0].subscribe((value) => translatedKey = value);
+      expect(translatedKey).toBe('admin.access-control.epeople.notification.deleted.forbidden.self');
+    });
+  });
+});

--- a/src/app/access-control/epeople-registry/eperson-delete-guard.service.ts
+++ b/src/app/access-control/epeople-registry/eperson-delete-guard.service.ts
@@ -1,0 +1,145 @@
+import { Injectable } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { combineLatest, Observable, of as observableOf } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { RequestParam } from '../../core/cache/models/request-param.model';
+import { AuthorizationDataService } from '../../core/data/feature-authorization/authorization-data.service';
+import { FeatureID } from '../../core/data/feature-authorization/feature-id';
+import { FindListOptions } from '../../core/data/find-list-options.model';
+import { PaginatedList } from '../../core/data/paginated-list.model';
+import { RemoteData } from '../../core/data/remote-data';
+import { EPerson } from '../../core/eperson/models/eperson.model';
+import { DSpaceObject } from '../../core/shared/dspace-object.model';
+import { NoContent } from '../../core/shared/NoContent.model';
+import { getFirstCompletedRemoteData } from '../../core/shared/operators';
+import { SearchService } from '../../core/shared/search/search.service';
+import { WorkflowItemDataService } from '../../core/submission/workflowitem-data.service';
+import { WorkspaceitemDataService } from '../../core/submission/workspaceitem-data.service';
+import { hasValue } from '../../shared/empty.util';
+import { NotificationsService } from '../../shared/notifications/notifications.service';
+import { PaginationComponentOptions } from '../../shared/pagination/pagination-component-options.model';
+import { PaginatedSearchOptions } from '../../shared/search/models/paginated-search-options.model';
+import { SearchObjects } from '../../shared/search/models/search-objects.model';
+
+/**
+ * Translation key for the notification shown when an admin tries to delete their own account.
+ * Exported so the templates can bind it as the disabled-delete-button tooltip.
+ */
+export const SELF_DELETE_WARNING_LABEL = 'admin.access-control.epeople.notification.deleted.forbidden.self';
+
+const WARNING_LABEL_PREFIX = 'admin.access-control.epeople.delete.warning.';
+
+/**
+ * Shared logic for the EPerson delete flow used by both the EPeople registry and the EPerson form.
+ * Determines a contextual warning for high-impact deletes, recognises the backend self-delete error
+ * and surfaces the self-delete notification. Centralised here so both call sites stay in sync
+ * (the previous per-component copies had already diverged in their error handling).
+ */
+@Injectable()
+export class EPersonDeleteGuardService {
+
+  constructor(
+    private authorizationService: AuthorizationDataService,
+    private workspaceItemDataService: WorkspaceitemDataService,
+    private workflowItemDataService: WorkflowItemDataService,
+    private searchService: SearchService,
+    private notificationsService: NotificationsService,
+    private translateService: TranslateService,
+  ) {
+  }
+
+  /**
+   * Whether the given EPerson is the currently authenticated user.
+   */
+  isCurrentUser(ePerson: EPerson, currentAuthenticatedUserId: string): boolean {
+    return hasValue(ePerson?.id) && ePerson.id === currentAuthenticatedUserId;
+  }
+
+  /**
+   * Resolve the contextual warning translation key for deleting the given EPerson,
+   * or undefined when there is nothing noteworthy to warn about.
+   * Warns when the user has submitted items, is an administrator, or both.
+   */
+  getDeleteWarningLabel(ePerson: EPerson): Observable<string | undefined> {
+    return combineLatest([
+      this.hasSubmittedItems(ePerson.id),
+      this.isAdministrator(ePerson),
+    ]).pipe(
+      map(([hasSubmittedItems, isAdmin]: [boolean, boolean]) => {
+        if (hasSubmittedItems && isAdmin) {
+          return WARNING_LABEL_PREFIX + 'submitterAndAdmin';
+        }
+        if (hasSubmittedItems) {
+          return WARNING_LABEL_PREFIX + 'submitter';
+        }
+        if (isAdmin) {
+          return WARNING_LABEL_PREFIX + 'admin';
+        }
+        return undefined;
+      })
+    );
+  }
+
+  /**
+   * Whether the backend rejected the delete because an admin tried to delete themselves.
+   */
+  isSelfDeletionError(restResponse: RemoteData<NoContent> | null): boolean {
+    return restResponse?.statusCode === 400 && restResponse?.errorMessage?.toLowerCase().includes('cannot delete yourself');
+  }
+
+  /**
+   * Show the "you cannot delete your own account" error notification.
+   */
+  showSelfDeleteNotification(): void {
+    this.notificationsService.error(this.translateService.get(SELF_DELETE_WARNING_LABEL));
+  }
+
+  /**
+   * Whether the EPerson is the submitter of any workspace, workflow or archived item.
+   * Each lookup degrades to `false` on error so a failed probe never blocks the delete.
+   */
+  private hasSubmittedItems(epersonId: string): Observable<boolean> {
+    const submitterSearchOptions = Object.assign(new FindListOptions(), {
+      currentPage: 1,
+      elementsPerPage: 1,
+      searchParams: [new RequestParam('uuid', epersonId)],
+    });
+    const archivedSearchOptions = new PaginatedSearchOptions({
+      query: `submitter_authority:"${epersonId}"`,
+      pagination: Object.assign(new PaginationComponentOptions(), {
+        currentPage: 1,
+        pageSize: 1,
+      }),
+    });
+
+    return combineLatest([
+      this.workspaceItemDataService.searchBy('findBySubmitter', submitterSearchOptions).pipe(
+        getFirstCompletedRemoteData(),
+        map((rd: RemoteData<PaginatedList<any>>) => rd.hasSucceeded && rd.payload.totalElements > 0),
+        catchError(() => observableOf(false)),
+      ),
+      this.workflowItemDataService.searchBy('findBySubmitter', submitterSearchOptions).pipe(
+        getFirstCompletedRemoteData(),
+        map((rd: RemoteData<PaginatedList<any>>) => rd.hasSucceeded && rd.payload.totalElements > 0),
+        catchError(() => observableOf(false)),
+      ),
+      this.searchService.search<DSpaceObject>(archivedSearchOptions).pipe(
+        getFirstCompletedRemoteData(),
+        map((rd: RemoteData<SearchObjects<DSpaceObject>>) => rd.hasSucceeded && rd.payload.totalElements > 0),
+        catchError(() => observableOf(false)),
+      ),
+    ]).pipe(
+      map((results: boolean[]) => results.some(Boolean)),
+    );
+  }
+
+  /**
+   * Whether the EPerson is a site administrator, via the authorization feature
+   * (catches indirect admin rights and avoids matching on a hard-coded group name).
+   */
+  private isAdministrator(ePerson: EPerson): Observable<boolean> {
+    return this.authorizationService.isAuthorized(FeatureID.AdministratorOf, undefined, ePerson?.id).pipe(
+      catchError(() => observableOf(false)),
+    );
+  }
+}

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.html
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.html
@@ -31,9 +31,21 @@
       <i class="fa fa-user-secret"></i> {{'admin.access-control.epeople.actions.stop-impersonating' | translate}}
     </button>
   </div>
-  <button after class="btn btn-danger delete-button" [disabled]="!(canDelete$ | async)" (click)="delete()">
-    <i class="fas fa-trash"></i> {{'admin.access-control.epeople.actions.delete' | translate}}
-  </button>
+  <span after *ngIf="activeEPerson$ | async as activeEPerson">
+    <span *ngIf="isCurrentUser(activeEPerson); else enabledDeleteButton"
+          tabindex="0"
+          [ngbTooltip]="selfDeleteWarningLabel | translate"
+          container="body">
+      <button class="btn btn-danger delete-button" [disabled]="true" tabindex="-1" type="button">
+        <i class="fas fa-trash"></i> {{'admin.access-control.epeople.actions.delete' | translate}}
+      </button>
+    </span>
+    <ng-template #enabledDeleteButton>
+      <button class="btn btn-danger delete-button" [disabled]="!(canDelete$ | async)" type="button" (click)="delete()">
+        <i class="fas fa-trash"></i> {{'admin.access-control.epeople.actions.delete' | translate}}
+      </button>
+    </ng-template>
+  </span>
 </ds-form>
 
 <ds-themed-loading [showMessage]="false" *ngIf="!formGroup"></ds-themed-loading>

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
@@ -31,6 +31,7 @@ import { PaginationServiceStub } from '../../../shared/testing/pagination-servic
 import { FindListOptions } from '../../../core/data/find-list-options.model';
 import { ValidateEmailNotTaken } from './validators/email-taken.validator';
 import { EpersonRegistrationService } from '../../../core/data/eperson-registration.service';
+import { EPersonDeleteGuardService } from '../eperson-delete-guard.service';
 
 describe('EPersonFormComponent', () => {
   let component: EPersonFormComponent;
@@ -40,6 +41,7 @@ describe('EPersonFormComponent', () => {
   let mockEPeople;
   let ePersonDataServiceStub: any;
   let authService: AuthServiceStub;
+  let deleteGuard: jasmine.SpyObj<EPersonDeleteGuardService>;
   let authorizationService: AuthorizationDataService;
   let groupsDataService: GroupDataService;
   let epersonRegistrationService: EpersonRegistrationService;
@@ -172,6 +174,10 @@ describe('EPersonFormComponent', () => {
       }
     });
     authService = new AuthServiceStub();
+    deleteGuard = jasmine.createSpyObj('deleteGuard', ['isCurrentUser', 'getDeleteWarningLabel', 'isSelfDeletionError', 'showSelfDeleteNotification']);
+    deleteGuard.isCurrentUser.and.callFake((ePerson: EPerson, currentId: string) => !!ePerson?.id && ePerson.id === currentId);
+    deleteGuard.getDeleteWarningLabel.and.returnValue(observableOf(undefined));
+    deleteGuard.isSelfDeletionError.and.returnValue(false);
     authorizationService = jasmine.createSpyObj('authorizationService', {
       isAuthorized: observableOf(true),
 
@@ -202,6 +208,7 @@ describe('EPersonFormComponent', () => {
         { provide: PaginationService, useValue: paginationService },
         { provide: RequestService, useValue: jasmine.createSpyObj('requestService', ['removeByHrefSubstring'])},
         { provide: EpersonRegistrationService, useValue: epersonRegistrationService },
+        { provide: EPersonDeleteGuardService, useValue: deleteGuard },
         EPeopleRegistryComponent
       ],
       schemas: [NO_ERRORS_SCHEMA]
@@ -474,17 +481,17 @@ describe('EPersonFormComponent', () => {
 
   describe('delete', () => {
 
-    let ePersonId;
     let eperson: EPerson;
     let modalService;
 
     beforeEach(() => {
       spyOn(authService, 'impersonate').and.callThrough();
-      ePersonId = 'testEPersonId';
-      eperson = EPersonMock;
+      eperson = EPersonMock2;
       component.epersonInitial = eperson;
       component.canDelete$ = observableOf(true);
       spyOn(component.epersonService, 'getActiveEPerson').and.returnValue(observableOf(eperson));
+      component.activeEPerson$ = observableOf(eperson);
+      component.currentAuthenticatedUserId = 'different-user-id';
       modalService = (component as any).modalService;
       spyOn(modalService, 'open').and.returnValue(Object.assign({ componentInstance: Object.assign({ response: observableOf(true) }) }));
       fixture.detectChanges();
@@ -519,6 +526,26 @@ describe('EPersonFormComponent', () => {
       deleteButton.triggerEventHandler('click', null);
       fixture.detectChanges();
       expect(component.epersonService.deleteEPerson).toHaveBeenCalledWith(eperson);
+    });
+
+    describe('when the EPerson is the currently authenticated user', () => {
+      beforeEach(() => {
+        component.currentAuthenticatedUserId = eperson.id;
+        fixture.detectChanges();
+      });
+
+      it('should render the delete button disabled', () => {
+        const deleteButton = fixture.debugElement.query(By.css('.delete-button'));
+        expect(deleteButton.nativeElement.disabled).toBe(true);
+      });
+
+      it('should notify instead of opening the confirmation modal', () => {
+        spyOn(component.epersonService, 'deleteEPerson').and.returnValue(createSuccessfulRemoteDataObject$('No Content', 204));
+        component.delete();
+        expect(deleteGuard.showSelfDeleteNotification).toHaveBeenCalled();
+        expect(modalService.open).not.toHaveBeenCalled();
+        expect(component.epersonService.deleteEPerson).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -37,6 +37,7 @@ import { ValidateEmailNotTaken } from './validators/email-taken.validator';
 import { Registration } from '../../../core/shared/registration.model';
 import { EpersonRegistrationService } from '../../../core/data/eperson-registration.service';
 import { TYPE_REQUEST_FORGOT } from '../../../register-email-form/register-email-form.component';
+import { EPersonDeleteGuardService, SELF_DELETE_WARNING_LABEL } from '../eperson-delete-guard.service';
 
 @Component({
   selector: 'ds-eperson-form',
@@ -48,6 +49,9 @@ import { TYPE_REQUEST_FORGOT } from '../../../register-email-form/register-email
 export class EPersonFormComponent implements OnInit, OnDestroy {
 
   labelPrefix = 'admin.access-control.epeople.form.';
+  selfDeleteWarningLabel = SELF_DELETE_WARNING_LABEL;
+
+  currentAuthenticatedUserId: string;
 
   /**
    * A unique id used for ds-form
@@ -161,6 +165,11 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
   epersonInitial: EPerson;
 
   /**
+   * The EPerson this form is currently showing
+   */
+  activeEPerson$: Observable<EPerson>;
+
+  /**
    * Whether or not this EPerson is currently being impersonated
    */
   isImpersonated = false;
@@ -183,6 +192,7 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
     private paginationService: PaginationService,
     public requestService: RequestService,
     private epersonRegistrationService: EpersonRegistrationService,
+    private deleteGuard: EPersonDeleteGuardService,
   ) {
     this.subs.push(this.epersonService.getActiveEPerson().subscribe((eperson: EPerson) => {
       this.epersonInitial = eperson;
@@ -193,6 +203,10 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    this.activeEPerson$ = this.epersonService.getActiveEPerson();
+    this.subs.push(this.authService.getAuthenticatedUserFromStore().subscribe((currentUser: EPerson) => {
+      this.currentAuthenticatedUserId = currentUser?.id;
+    }));
     this.initialisePage();
   }
 
@@ -452,30 +466,46 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
    */
   delete() {
     this.epersonService.getActiveEPerson().pipe(take(1)).subscribe((eperson: EPerson) => {
-      const modalRef = this.modalService.open(ConfirmationModalComponent);
-      modalRef.componentInstance.dso = eperson;
-      modalRef.componentInstance.headerLabel = 'confirmation-modal.delete-eperson.header';
-      modalRef.componentInstance.infoLabel = 'confirmation-modal.delete-eperson.info';
-      modalRef.componentInstance.cancelLabel = 'confirmation-modal.delete-eperson.cancel';
-      modalRef.componentInstance.confirmLabel = 'confirmation-modal.delete-eperson.confirm';
-      modalRef.componentInstance.brandColor = 'danger';
-      modalRef.componentInstance.confirmIcon = 'fas fa-trash';
-      modalRef.componentInstance.response.pipe(take(1)).subscribe((confirm: boolean) => {
-        if (confirm) {
-          if (hasValue(eperson.id)) {
+      if (!hasValue(eperson?.id) || !hasValue(this.currentAuthenticatedUserId)) {
+        return;
+      }
+
+      if (this.isCurrentUser(eperson)) {
+        this.deleteGuard.showSelfDeleteNotification();
+        return;
+      }
+
+      this.deleteGuard.getDeleteWarningLabel(eperson).pipe(take(1)).subscribe((warningLabel: string | undefined) => {
+        const modalRef = this.modalService.open(ConfirmationModalComponent);
+        modalRef.componentInstance.dso = eperson;
+        modalRef.componentInstance.headerLabel = 'confirmation-modal.delete-eperson.header';
+        modalRef.componentInstance.infoLabel = 'confirmation-modal.delete-eperson.info';
+        modalRef.componentInstance.warningLabel = warningLabel;
+        modalRef.componentInstance.cancelLabel = 'confirmation-modal.delete-eperson.cancel';
+        modalRef.componentInstance.confirmLabel = 'confirmation-modal.delete-eperson.confirm';
+        modalRef.componentInstance.brandColor = 'danger';
+        modalRef.componentInstance.confirmIcon = 'fas fa-trash';
+        modalRef.componentInstance.response.pipe(take(1)).subscribe((confirm: boolean) => {
+          if (confirm) {
             this.epersonService.deleteEPerson(eperson).pipe(getFirstCompletedRemoteData()).subscribe((restResponse: RemoteData<NoContent>) => {
               if (restResponse.hasSucceeded) {
                 this.notificationsService.success(this.translateService.get(this.labelPrefix + 'notification.deleted.success', { name: eperson.name }));
                 this.submitForm.emit();
+              } else if (this.isCurrentUser(eperson) || this.deleteGuard.isSelfDeletionError(restResponse)) {
+                this.deleteGuard.showSelfDeleteNotification();
               } else {
                 this.notificationsService.error('Error occured when trying to delete EPerson with id: ' + eperson.id + ' with code: ' + restResponse.statusCode + ' and message: ' + restResponse.errorMessage);
               }
               this.cancelForm.emit();
             });
           }
-        }
+        });
       });
     });
+  }
+
+  isCurrentUser(ePerson: EPerson): boolean {
+    return this.deleteGuard.isCurrentUser(ePerson, this.currentAuthenticatedUserId);
   }
 
   /**

--- a/src/app/shared/confirmation-modal/confirmation-modal.component.html
+++ b/src/app/shared/confirmation-modal/confirmation-modal.component.html
@@ -6,6 +6,7 @@
   </div>
   <div class="modal-body">
     <p>{{ infoLabel | translate:{dsoName: dso?.name} }}</p>
+    <p *ngIf="warningLabel" class="text-warning mb-0">{{ warningLabel | translate:{dsoName: dso?.name} }}</p>
   </div>
   <div class="modal-footer">
     <button type="button" class="cancel btn btn-outline-secondary" (click)="cancelPressed()" aria-label="Cancel">

--- a/src/app/shared/confirmation-modal/confirmation-modal.component.ts
+++ b/src/app/shared/confirmation-modal/confirmation-modal.component.ts
@@ -9,6 +9,7 @@ import { DSpaceObject } from '../../core/shared/dspace-object.model';
 export class ConfirmationModalComponent {
   @Input() headerLabel: string;
   @Input() infoLabel: string;
+  @Input() warningLabel?: string;
   @Input() cancelLabel: string;
   @Input() confirmLabel: string;
   @Input() confirmIcon: string;

--- a/src/app/shared/testing/auth-service.stub.ts
+++ b/src/app/shared/testing/auth-service.stub.ts
@@ -54,6 +54,10 @@ export class AuthServiceStub {
     return observableOf(EPersonMock);
   }
 
+  public getAuthenticatedUserFromStore(): Observable<EPerson> {
+    return observableOf(EPersonMock);
+  }
+
   public buildAuthHeader(token?: AuthTokenInfo): string {
     return `Bearer ${token ? token.accessToken : ''}`;
   }

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -2203,16 +2203,16 @@
   "admin.access-control.epeople.notification.deleted.success" : "Úspěšně vymazána EOsoba: \"{{name}}\"",
 
   // "admin.access-control.epeople.notification.deleted.forbidden.self": "You cannot delete your own EPerson account."
-  "admin.access-control.epeople.notification.deleted.forbidden.self" : "Nemůžete smazat svůj vlastní účet uživatele.",
+  "admin.access-control.epeople.notification.deleted.forbidden.self" : "Nemůžete smazat svůj vlastní uživatelský účet.",
 
   // "admin.access-control.epeople.delete.warning.submitter": "Warning: this user has submitted items. Deleting this EPerson may affect submission ownership and related repository records."
-  "admin.access-control.epeople.delete.warning.submitter" : "Upozornění: Tento uživatel odeslal položky. Smazání tohoto uživatele může ovlivnit vlastnictví příspěvků a související záznamy v repozitáři.",
+  "admin.access-control.epeople.delete.warning.submitter" : "Upozornění: Tento uživatel vložil do repozitáře záznamy. Jeho smazáním můžete ovlivnit vlastnictví těchto záznamů i souvisejících dat v repozitáři.",
 
   // "admin.access-control.epeople.delete.warning.admin": "Warning: this user has administrator privileges. Deleting this EPerson will remove an administrator account."
-  "admin.access-control.epeople.delete.warning.admin" : "Upozornění: Tento uživatel má oprávnění správce. Smazání tohoto uživatele odebere účet správce.",
+  "admin.access-control.epeople.delete.warning.admin" : "Upozornění: Tento uživatel má práva správce. Jeho smazáním odeberete účet správce.",
 
   // "admin.access-control.epeople.delete.warning.submitterAndAdmin": "Warning: this user has submitted items and has administrator privileges. Deleting this EPerson may affect submission ownership and remove an administrator account."
-  "admin.access-control.epeople.delete.warning.submitterAndAdmin" : "Upozornění: Tento uživatel odeslal položky a má oprávnění správce. Smazání tohoto uživatele může ovlivnit vlastnictví příspěvků a odebrat účet správce.",
+  "admin.access-control.epeople.delete.warning.submitterAndAdmin" : "Upozornění: Tento uživatel vložil do repozitáře záznamy a má práva správce. Jeho smazáním můžete ovlivnit vlastnictví záznamů a zároveň odeberete účet správce.",
 
   // "admin.access-control.groups.title" : "Groups"
   "admin.access-control.groups.title" : "Skupiny",

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -2202,6 +2202,18 @@
   // "admin.access-control.epeople.notification.deleted.success" : "Successfully deleted EPerson: \"{{name}}\""
   "admin.access-control.epeople.notification.deleted.success" : "Úspěšně vymazána EOsoba: \"{{name}}\"",
 
+  // "admin.access-control.epeople.notification.deleted.forbidden.self": "You cannot delete your own EPerson account."
+  "admin.access-control.epeople.notification.deleted.forbidden.self" : "Nemůžete smazat svůj vlastní účet uživatele.",
+
+  // "admin.access-control.epeople.delete.warning.submitter": "Warning: this user has submitted items. Deleting this EPerson may affect submission ownership and related repository records."
+  "admin.access-control.epeople.delete.warning.submitter" : "Upozornění: Tento uživatel odeslal položky. Smazání tohoto uživatele může ovlivnit vlastnictví příspěvků a související záznamy v repozitáři.",
+
+  // "admin.access-control.epeople.delete.warning.admin": "Warning: this user has administrator privileges. Deleting this EPerson will remove an administrator account."
+  "admin.access-control.epeople.delete.warning.admin" : "Upozornění: Tento uživatel má oprávnění správce. Smazání tohoto uživatele odebere účet správce.",
+
+  // "admin.access-control.epeople.delete.warning.submitterAndAdmin": "Warning: this user has submitted items and has administrator privileges. Deleting this EPerson may affect submission ownership and remove an administrator account."
+  "admin.access-control.epeople.delete.warning.submitterAndAdmin" : "Upozornění: Tento uživatel odeslal položky a má oprávnění správce. Smazání tohoto uživatele může ovlivnit vlastnictví příspěvků a odebrat účet správce.",
+
   // "admin.access-control.groups.title" : "Groups"
   "admin.access-control.groups.title" : "Skupiny",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -305,6 +305,14 @@
 
   "admin.access-control.epeople.form.notification.deleted.failure": "Failed to delete EPerson \"{{name}}\"",
 
+  "admin.access-control.epeople.notification.deleted.forbidden.self": "You cannot delete your own EPerson account.",
+
+  "admin.access-control.epeople.delete.warning.submitter": "Warning: this user has submitted items. Deleting this EPerson may affect submission ownership and related repository records.",
+
+  "admin.access-control.epeople.delete.warning.admin": "Warning: this user has administrator privileges. Deleting this EPerson will remove an administrator account.",
+
+  "admin.access-control.epeople.delete.warning.submitterAndAdmin": "Warning: this user has submitted items and has administrator privileges. Deleting this EPerson may affect submission ownership and remove an administrator account.",
+
   "admin.access-control.epeople.form.groupsEPersonIsMemberOf": "Member of these groups:",
 
   "admin.access-control.epeople.form.table.id": "ID",


### PR DESCRIPTION
Backport of the UFAL self-delete guard from `dtq-dev` onto `customer/TUL` — dataquest-dev/dspace-angular#1335 (the feature), #1357 (friendly rejection notification) and #1373 (tooltip clipped by the table).

**What changes**
- The EPeople registry and the EPerson form no longer offer *delete* for the currently authenticated user: the button renders disabled with a tooltip explaining why.
- Deleting a high-impact account now shows a contextual warning in the confirmation modal (submitter / administrator / both), via a new `warningLabel` input on `ConfirmationModalComponent`.
- If the backend still rejects a self-delete (400), the UI shows the friendly "you cannot delete your own account" notification instead of a generic failure.
- Shared logic lives in the new `EPersonDeleteGuardService` so the registry and the form stay in sync.
- New en/cs i18n keys for the notification and the three warnings.

**Branch-specific notes**
Translated (not cherry-picked): TUL is DSpace 7.5 / Angular 13 with a different registry template, no `dsBtnDisabled` directive and no `dsoNameService`, so the guard was re-derived against this branch's files using the native `[disabled]` binding.

**Verified locally** (Node 22): `ng test --include='src/app/access-control/epeople-registry/**/*.spec.ts'` and `--include='src/app/shared/confirmation-modal/**/*.spec.ts'` all green; `eslint` on the changed files reports **0 errors**.

Backend counterpart: dataquest-dev/DSpace#1396 — the two must ship together.

Refs dataquest-dev/dspace-customers#855

---

## How this was verified

### Manual — on a live instance (JCU 9.3 pair)
Throwaway stack: backend built from the paired branch `jcu/be-forbid-admin-self-delete` (REST on :8091,
own DB / Solr), frontend served from the branch under test, logged in as an administrator.

| | Result |
| --- | --- |
| **Before** (base branch) | The *Delete* button on the administrator's **own** row in *Access Control → EPeople* is enabled and clickable. Driving that same delete through the REST API returned `204` and the account was gone (`404`) — the bug in issue #855, reproduced. |
| **After** (this change) | The own row's *Delete* button is **disabled** and carries the tooltip *"You cannot delete your own EPerson account."*, rendered above the table without being clipped (the `container="body"` part of #1373). |
| Regression | Deleting a **different** EPerson still works end to end: confirmation modal → Delete → the row disappears. |
| Other rows | Unaffected — still enabled. |

### Automated
Locally on this branch (Node 22):
`ng test --include='src/app/access-control/epeople-registry/**/*.spec.ts'` → **45 tests, 0 failures**;
`--include='src/app/shared/confirmation-modal/**/*.spec.ts'` → **11 tests, 0 failures**;
`eslint` on the changed files → **0 errors**.
The CI `tests` job runs lint plus the full unit suite on this PR.

The live run was on the JCU 9.3 pair. TUL was **not** exercised in a browser and is the most heavily translated branch (DSpace 7.5 / Angular 13: no `dsBtnDisabled` directive, no `dsoNameService`, different registry template, simpler `delete()`), so it deserves the closest read of the three families. Its behaviour is covered by the unit tests below.

### Live UI screenshots

Captured live in a browser (7.5 FE against a genuine DSpace 7.6.5 backend): logged in as an administrator, opened
*Access Control → EPeople*. The admin's **own** row is the first one.

**Before** — the own row's *Delete* button is enabled/clickable (the bug). |
<img width="862" height="663" alt="855-tul-BEFORE-own-delete-enabled" src="https://github.com/user-attachments/assets/7a669a24-dced-4158-a61b-093a9d8dd0f4" />

**After** — the own row's *Delete* button is disabled and shows the tooltip *"You cannot delete your own EPerson account."*; other rows stay enabled.
<img width="862" height="663" alt="855-tul-AFTER-own-delete-disabled-tooltip" src="https://github.com/user-attachments/assets/72552a8b-2282-4aa1-9ea4-abd56446ce3d" />
