### PR TITLE
Remove invalid dspace healthcheck step from import jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -145,12 +145,6 @@ jobs:
           echo "dspace checker:"
           docker exec $DNAME /bin/bash -c "cd /dspace/bin && ./dspace checker -v -l"
 
-      - name: dspace healthcheck
-        run: |
-          export DNAME=dspace$INSTANCE
-          echo "dspace healthcheck:"
-          docker exec $DNAME /bin/bash -c "cd /dspace/bin && ./dspace healthcheck -v"
-
   import-8:
     runs-on: dspace-dep-1
     if: inputs.IMPORT
@@ -186,12 +180,6 @@ jobs:
 
           echo "dspace checker:"
           docker exec $DNAME /bin/bash -c "cd /dspace/bin && ./dspace checker -v -l"
-
-      - name: dspace healthcheck
-        run: |
-          export DNAME=dspace$INSTANCE
-          echo "dspace healthcheck:"
-          docker exec $DNAME /bin/bash -c "cd /dspace/bin && ./dspace healthcheck -v"
 
   playwright-after-deploy8:
     needs: deploy-8


### PR DESCRIPTION
## Problem
The scheduled `Import Weekly` run (`Deploy DSpace` → `import-5` / `import-8`) fails even though the DB import itself succeeds. The post-import **`dspace healthcheck`** step aborts the job.

Tracking issue: dataquest-dev/dspace-customers#908
Failed run: https://github.com/dataquest-dev/dspace-angular/actions/runs/31497534447 (job `import-8`):
```
dspace healthcheck:
Command not found: healthcheck
Usage: dspace [command-name] {parameters}
##[error]Process completed with exit code 1.
```

## Root cause
`./dspace healthcheck` is **not a valid CLI command** in the DSpace 7 backend (container image `dataquest/dspace:dspace-7_x`). The `healthcheck` launcher command (`org.dspace.health.HealthReport`) was a DSpace 5–era CLARIN feature and was never ported to the DSpace 7 fork — it is absent from `dataquest-dev/DSpace` `dspace/config/launcher.xml` on `dtq-dev`. The step is a leftover from DSpace 5. Since it runs under bash `-e -o pipefail` with no `continue-on-error`, the "command not found" (exit 1) fails the whole job.

## Change set
Remove the `dspace healthcheck` step from the two jobs that had it, in [.github/workflows/deploy.yml](.github/workflows/deploy.yml):
- `import-5`
- `import-8`

No replacement is added — there is no DSpace 7 equivalent, and the preceding **`dspace basic command`** step in each job already runs `./dspace version`, `./dspace cleanup`, `./dspace index-discovery`, `./dspace oai import`, and `./dspace checker -v -l`, which cover the intended post-import verification. Minimal and surgical: 12 lines removed, nothing else touched.

## Test evidence
```
# no healthcheck references remain
$ grep -ni healthcheck .github/workflows/deploy.yml
(no matches)

# workflow YAML still parses; all 8 jobs intact
$ python -c "import yaml; print(list(yaml.safe_load(open('.github/workflows/deploy.yml'))['jobs']))"
['deploy-5', 'deploy-8', 'import-5', 'import-8', 'playwright-after-deploy8', 'rest-tests-after-deploy8', 'playwright-after-import8', 'rest-tests-after-import8']
```
End-to-end verification is the next `Import Weekly` run — this workflow only executes on the self-hosted `dspace-dep-1` runner, so it can't be exercised from a fork/local box.

## Risk & rollback
Very low. The removed step never produced a successful result (the command does not exist), so no working behavior is lost. If a real health check is wanted later, it should be re-introduced as a valid DSpace 7 command in a separate change. Rollback: revert this commit.

## Notes / assumptions
- Nothing consumes the step's output — it only `echo`ed and invoked the missing command; no later step reads its result.
- Cross-repo: the fix lives in `dspace-angular` while the tracking issue is in `dspace-customers`, so a same-repo `Fixes #` keyword can't auto-close it; it is linked as a cross-reference instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
