### PR TITLE
TUL/Browse links: carry only the parameters a browse page uses

### DIFF
--- a/src/app/shared/object-list/browse-entry-list-element/browse-entry-list-element.component.html
+++ b/src/app/shared/object-list/browse-entry-list-element/browse-entry-list-element.component.html
@@ -1,5 +1,5 @@
 <div class="d-flex flex-row">
-    <a *ngIf="linkType != linkTypes.None" [target]="(linkType == linkTypes.ExternalLink) ? '_blank' : '_self'" rel="noopener noreferrer" [routerLink]="[]" [queryParams]="queryParams$ | async" [queryParamsHandling]="'merge'" class="lead">
+    <a *ngIf="linkType != linkTypes.None" [target]="(linkType == linkTypes.ExternalLink) ? '_blank' : '_self'" rel="noopener noreferrer" [routerLink]="[]" [queryParams]="queryParams$ | async" class="lead">
         {{object.value}}
     </a>
     <span *ngIf="linkType == linkTypes.None" class="lead">

--- a/src/app/shared/object-list/browse-entry-list-element/browse-entry-list-element.component.spec.ts
+++ b/src/app/shared/object-list/browse-entry-list-element/browse-entry-list-element.component.spec.ts
@@ -1,15 +1,16 @@
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
-import { ChangeDetectionStrategy, NO_ERRORS_SCHEMA } from '@angular/core';
+import { ChangeDetectionStrategy, Component, NO_ERRORS_SCHEMA } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { Router } from '@angular/router';
+import { Params, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { Store } from '@ngrx/store';
 import { TruncatePipe } from '../../utils/truncate.pipe';
 import { BrowseEntryListElementComponent } from './browse-entry-list-element.component';
 import { BrowseEntry } from '../../../core/shared/browse-entry.model';
 import { PaginationService } from '../../../core/pagination/pagination.service';
 import { RouteService } from '../../../core/services/route.service';
 import { of as observableOf } from 'rxjs';
-import { take } from 'rxjs/operators';
+
 let browseEntryListElementComponent: BrowseEntryListElementComponent;
 let fixture: ComponentFixture<BrowseEntryListElementComponent>;
 
@@ -18,25 +19,21 @@ const mockValue: BrowseEntry = Object.assign(new BrowseEntry(), {
   value: 'De Langhe Kristof'
 });
 
-let paginationService;
-let routeService;
 const pageParam = 'bbm.page';
-let queryParamsInUrl: { [name: string]: string };
 
-function init() {
-  paginationService = jasmine.createSpyObj('paginationService', {
-    getPageParam: pageParam
-  });
-
-  queryParamsInUrl = { [pageParam]: '1' };
-  routeService = jasmine.createSpyObj('routeService', ['getQueryParameterValue']);
-  routeService.getQueryParameterValue.and.callFake(
-    (name: string) => observableOf(queryParamsInUrl[name])
-  );
+@Component({ template: '' })
+class DummyComponent {
 }
+
 describe('BrowseEntryListElementComponent', () => {
   beforeEach(waitForAsync(() => {
-    init();
+    const paginationService = jasmine.createSpyObj('paginationService', {
+      getPageParam: pageParam
+    });
+    const routeService = jasmine.createSpyObj('routeService', {
+      getQueryParameterValue: observableOf(undefined)
+    });
+
     TestBed.configureTestingModule({
       declarations: [BrowseEntryListElementComponent, TruncatePipe],
       providers: [
@@ -67,74 +64,86 @@ describe('BrowseEntryListElementComponent', () => {
       expect(browseEntryLink.nativeElement.textContent.trim()).toBe(mockValue.value);
     });
   });
+});
 
-  describe('queryParams', () => {
-    let emitted;
+describe('BrowseEntryListElementComponent link', () => {
+  // The real RouteService is used here on purpose: every parameter below reaches the component
+  // through the router, the way it does in the browser, so the assertions are on what the URL
+  // actually produces rather than on what a stub was told to answer.
+  const scopeUUID = 'a2f2d0a1-3f0e-4d3a-9c1b-5f7e8a9b0c1d';
+  let router: Router;
 
-    const buildQueryParams = () => {
-      browseEntryListElementComponent.object = mockValue;
-      fixture.detectChanges();
-      browseEntryListElementComponent.queryParams$.pipe(take(1)).subscribe((p) => emitted = p);
-    };
+  const hrefFor = (queryParams: Params): string => {
+    void router.navigate(['/browse/author'], { queryParams });
+    tick();
 
-    it('should keep the scope of the community or collection being browsed', () => {
-      queryParamsInUrl.scope = '0eb1f4d0-fd7c-4c2c-b0d9-32ee18f5e1c1';
-      buildQueryParams();
+    fixture = TestBed.createComponent(BrowseEntryListElementComponent);
+    fixture.componentInstance.object = mockValue;
+    fixture.detectChanges();
 
-      expect(emitted.scope).toBe('0eb1f4d0-fd7c-4c2c-b0d9-32ee18f5e1c1');
+    return fixture.debugElement.query(By.css('a.lead')).nativeElement.getAttribute('href');
+  };
+
+  beforeEach(waitForAsync(() => {
+    const paginationService = jasmine.createSpyObj('paginationService', {
+      getPageParam: pageParam
     });
 
-    it('should keep the page size and sort chosen by the user', () => {
-      queryParamsInUrl['bbm.rpp'] = '40';
-      queryParamsInUrl['bbm.sf'] = 'title';
-      queryParamsInUrl['bbm.sd'] = 'DESC';
-      buildQueryParams();
+    TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule.withRoutes([
+          { path: 'browse/author', component: DummyComponent }
+        ])
+      ],
+      declarations: [BrowseEntryListElementComponent, DummyComponent, TruncatePipe],
+      providers: [
+        { provide: 'objectElementProvider', useValue: { mockValue } },
+        {provide: PaginationService, useValue: paginationService},
+        {provide: Store, useValue: jasmine.createSpyObj('store', ['dispatch'])},
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+  }));
 
-      expect(emitted['bbm.rpp']).toBe('40');
-      expect(emitted['bbm.sf']).toBe('title');
-      expect(emitted['bbm.sd']).toBe('DESC');
+  beforeEach(() => {
+    router = TestBed.inject(Router);
+  });
+
+  it('should read its parameters through the real RouteService', () => {
+    expect(TestBed.inject(RouteService) instanceof RouteService).toBeTruthy();
+  });
+
+  it('should carry over the scope and the pagination settings', fakeAsync(() => {
+    const href = hrefFor({
+      scope: scopeUUID,
+      'bbm.rpp': '40',
+      'bbm.sf': 'title',
+      'bbm.sd': 'DESC'
     });
 
-  });
+    expect(href).toContain(`scope=${scopeUUID}`);
+    expect(href).toContain('bbm.rpp=40');
+    expect(href).toContain('bbm.sf=title');
+    expect(href).toContain('bbm.sd=DESC');
+  }));
 
-  describe('the rendered link', () => {
-    const scopeUUID = 'a2f2d0a1-3f0e-4d3a-9c1b-5f7e8a9b0c1d';
+  it('should replace the current page with the page to return to', fakeAsync(() => {
+    const href = hrefFor({ 'bbm.page': '3' });
 
-    beforeEach(waitForAsync(() => {
-      // the suite above already instantiated the TestBed, and this block needs a real Router in it
-      TestBed.resetTestingModule();
-      init();
-      queryParamsInUrl.scope = scopeUUID;
-      TestBed.configureTestingModule({
-        imports: [
-          RouterTestingModule.withRoutes([
-            { path: 'browse/author', component: BrowseEntryListElementComponent }
-          ])
-        ],
-        declarations: [BrowseEntryListElementComponent, TruncatePipe],
-        providers: [
-          { provide: 'objectElementProvider', useValue: { mockValue } },
-          {provide: PaginationService, useValue: paginationService},
-          {provide: RouteService, useValue: routeService},
-        ],
-        schemas: [NO_ERRORS_SCHEMA]
-      }).compileComponents();
-    }));
+    expect(href).toContain('bbm.return=3');
+    expect(href).not.toContain('bbm.page=');
+  }));
 
-    it('should keep the scope but not a parameter the page never asked for', fakeAsync(() => {
-      const router = TestBed.inject(Router);
-      router.navigate(['/browse/author'], {
-        queryParams: { scope: scopeUUID, 'amp;value': 'Some Author' }
-      });
-      tick();
+  it('should drop a parameter the browse page never asked for', fakeAsync(() => {
+    const href = hrefFor({ scope: scopeUUID, 'amp;value': 'Some Author' });
 
-      fixture = TestBed.createComponent(BrowseEntryListElementComponent);
-      fixture.componentInstance.object = mockValue;
-      fixture.detectChanges();
+    expect(href).toContain(`scope=${scopeUUID}`);
+    expect(href).not.toContain('amp');
+  }));
 
-      const href = fixture.debugElement.query(By.css('a.lead')).nativeElement.getAttribute('href');
-      expect(href).toContain(`scope=${scopeUUID}`);
-      expect(href).not.toContain('amp');
-    }));
-  });
+  it('should not pass on a scope that is present but empty', fakeAsync(() => {
+    const href = hrefFor({ scope: '' });
+
+    expect(href).not.toContain('scope=');
+  }));
 });

--- a/src/app/shared/object-list/browse-entry-list-element/browse-entry-list-element.component.spec.ts
+++ b/src/app/shared/object-list/browse-entry-list-element/browse-entry-list-element.component.spec.ts
@@ -1,6 +1,8 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { ChangeDetectionStrategy, NO_ERRORS_SCHEMA } from '@angular/core';
 import { By } from '@angular/platform-browser';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { TruncatePipe } from '../../utils/truncate.pipe';
 import { BrowseEntryListElementComponent } from './browse-entry-list-element.component';
 import { BrowseEntry } from '../../../core/shared/browse-entry.model';
@@ -93,13 +95,46 @@ describe('BrowseEntryListElementComponent', () => {
       expect(emitted['bbm.sd']).toBe('DESC');
     });
 
-    it('should drop parameters it does not recognise', () => {
-      queryParamsInUrl['amp;value'] = 'Some Author';
-      queryParamsInUrl.utm_source = 'newsletter';
-      buildQueryParams();
+  });
 
-      expect(Object.keys(emitted)).not.toContain('amp;value');
-      expect(Object.keys(emitted)).not.toContain('utm_source');
-    });
+  describe('the rendered link', () => {
+    const scopeUUID = 'a2f2d0a1-3f0e-4d3a-9c1b-5f7e8a9b0c1d';
+
+    beforeEach(waitForAsync(() => {
+      // the suite above already instantiated the TestBed, and this block needs a real Router in it
+      TestBed.resetTestingModule();
+      init();
+      queryParamsInUrl.scope = scopeUUID;
+      TestBed.configureTestingModule({
+        imports: [
+          RouterTestingModule.withRoutes([
+            { path: 'browse/author', component: BrowseEntryListElementComponent }
+          ])
+        ],
+        declarations: [BrowseEntryListElementComponent, TruncatePipe],
+        providers: [
+          { provide: 'objectElementProvider', useValue: { mockValue } },
+          {provide: PaginationService, useValue: paginationService},
+          {provide: RouteService, useValue: routeService},
+        ],
+        schemas: [NO_ERRORS_SCHEMA]
+      }).compileComponents();
+    }));
+
+    it('should keep the scope but not a parameter the page never asked for', fakeAsync(() => {
+      const router = TestBed.inject(Router);
+      router.navigate(['/browse/author'], {
+        queryParams: { scope: scopeUUID, 'amp;value': 'Some Author' }
+      });
+      tick();
+
+      fixture = TestBed.createComponent(BrowseEntryListElementComponent);
+      fixture.componentInstance.object = mockValue;
+      fixture.detectChanges();
+
+      const href = fixture.debugElement.query(By.css('a.lead')).nativeElement.getAttribute('href');
+      expect(href).toContain(`scope=${scopeUUID}`);
+      expect(href).not.toContain('amp');
+    }));
   });
 });

--- a/src/app/shared/object-list/browse-entry-list-element/browse-entry-list-element.component.spec.ts
+++ b/src/app/shared/object-list/browse-entry-list-element/browse-entry-list-element.component.spec.ts
@@ -7,6 +7,7 @@ import { BrowseEntry } from '../../../core/shared/browse-entry.model';
 import { PaginationService } from '../../../core/pagination/pagination.service';
 import { RouteService } from '../../../core/services/route.service';
 import { of as observableOf } from 'rxjs';
+import { take } from 'rxjs/operators';
 let browseEntryListElementComponent: BrowseEntryListElementComponent;
 let fixture: ComponentFixture<BrowseEntryListElementComponent>;
 
@@ -18,15 +19,18 @@ const mockValue: BrowseEntry = Object.assign(new BrowseEntry(), {
 let paginationService;
 let routeService;
 const pageParam = 'bbm.page';
+let queryParamsInUrl: { [name: string]: string };
 
 function init() {
   paginationService = jasmine.createSpyObj('paginationService', {
     getPageParam: pageParam
   });
 
-  routeService = jasmine.createSpyObj('routeService', {
-    getQueryParameterValue: observableOf('1')
-  });
+  queryParamsInUrl = { [pageParam]: '1' };
+  routeService = jasmine.createSpyObj('routeService', ['getQueryParameterValue']);
+  routeService.getQueryParameterValue.and.callFake(
+    (name: string) => observableOf(queryParamsInUrl[name])
+  );
 }
 describe('BrowseEntryListElementComponent', () => {
   beforeEach(waitForAsync(() => {
@@ -59,6 +63,43 @@ describe('BrowseEntryListElementComponent', () => {
     it('should show the value as a link', () => {
       const browseEntryLink = fixture.debugElement.query(By.css('a.lead'));
       expect(browseEntryLink.nativeElement.textContent.trim()).toBe(mockValue.value);
+    });
+  });
+
+  describe('queryParams', () => {
+    let emitted;
+
+    const buildQueryParams = () => {
+      browseEntryListElementComponent.object = mockValue;
+      fixture.detectChanges();
+      browseEntryListElementComponent.queryParams$.pipe(take(1)).subscribe((p) => emitted = p);
+    };
+
+    it('should keep the scope of the community or collection being browsed', () => {
+      queryParamsInUrl.scope = '0eb1f4d0-fd7c-4c2c-b0d9-32ee18f5e1c1';
+      buildQueryParams();
+
+      expect(emitted.scope).toBe('0eb1f4d0-fd7c-4c2c-b0d9-32ee18f5e1c1');
+    });
+
+    it('should keep the page size and sort chosen by the user', () => {
+      queryParamsInUrl['bbm.rpp'] = '40';
+      queryParamsInUrl['bbm.sf'] = 'title';
+      queryParamsInUrl['bbm.sd'] = 'DESC';
+      buildQueryParams();
+
+      expect(emitted['bbm.rpp']).toBe('40');
+      expect(emitted['bbm.sf']).toBe('title');
+      expect(emitted['bbm.sd']).toBe('DESC');
+    });
+
+    it('should drop parameters it does not recognise', () => {
+      queryParamsInUrl['amp;value'] = 'Some Author';
+      queryParamsInUrl.utm_source = 'newsletter';
+      buildQueryParams();
+
+      expect(Object.keys(emitted)).not.toContain('amp;value');
+      expect(Object.keys(emitted)).not.toContain('utm_source');
     });
   });
 });

--- a/src/app/shared/object-list/browse-entry-list-element/browse-entry-list-element.component.ts
+++ b/src/app/shared/object-list/browse-entry-list-element/browse-entry-list-element.component.ts
@@ -8,7 +8,7 @@ import { PaginationService } from '../../../core/pagination/pagination.service';
 import { Params } from '@angular/router';
 import { BBM_PAGINATION_ID } from '../../../browse-by/browse-by-metadata-page/browse-by-metadata-page.component';
 import { RouteService } from 'src/app/core/services/route.service';
-import { Observable } from 'rxjs';
+import { combineLatest, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 @Component({
@@ -37,16 +37,29 @@ export class BrowseEntryListElementComponent extends AbstractListableElementComp
 
   /**
    * Get the query params to access the item page of this browse entry.
+   *
+   * Carries over only the parameters a browse page actually uses. Anything else in the current URL
+   * is dropped, so a malformed parameter cannot be reflected back into the links we generate.
    */
   private getQueryParams(): Observable<Params> {
     const pageParamName = this.paginationService.getPageParam(BBM_PAGINATION_ID);
-    return this.routeService.getQueryParameterValue(pageParamName).pipe(
-      map((currentPage) => {
+    return combineLatest([
+      this.routeService.getQueryParameterValue(pageParamName),
+      this.routeService.getQueryParameterValue('scope'),
+      this.routeService.getQueryParameterValue(`${BBM_PAGINATION_ID}.rpp`),
+      this.routeService.getQueryParameterValue(`${BBM_PAGINATION_ID}.sf`),
+      this.routeService.getQueryParameterValue(`${BBM_PAGINATION_ID}.sd`),
+    ]).pipe(
+      map(([currentPage, scope, rpp, sortField, sortDirection]) => {
         return {
           value: this.object.value,
           authority: !!this.object.authority ? this.object.authority : undefined,
+          scope: scope || undefined,
           startsWith: undefined,
           [pageParamName]: null,
+          [`${BBM_PAGINATION_ID}.rpp`]: rpp || undefined,
+          [`${BBM_PAGINATION_ID}.sf`]: sortField || undefined,
+          [`${BBM_PAGINATION_ID}.sd`]: sortDirection || undefined,
           [BBM_PAGINATION_ID + '.return']: currentPage
         };
       })


### PR DESCRIPTION
## References

* New Relic alerts on TUL FE/BE, 6-9 August 2026
* Related upstream: DSpace/dspace-angular#2735 removed the same merge, DSpace/dspace-angular#5209 is the regression it caused

## Description

[pr-1453-explained.html](https://github.com/user-attachments/files/31167969/pr-1453-explained.html)
Browse value links copied the whole current query string into themselves. They now carry only the parameters a browse page actually uses.

## Instructions for Reviewers

A parameter nobody asked for used to come back in all 21 links on a browse page. A crawler that does not decode HTML entities then reads the escaped `&` as part of the next parameter name: `?zzz=1` comes back as `&amp;zzz=1`, gets requested as `amp;zzz=1`, comes back as `amp;amp;zzz=1`, and so on without end, because every one of those is a valid 200 page with 21 fresh links. On TUL this reached 11.7M such requests against 7.7M real ones, chains 35 levels deep, and three days of backend at 130 % CPU.

List of changes in this PR:

* `browse-entry-list-element.component.html`: dropped `[queryParamsHandling]="'merge'"`. That was the only route by which an unknown parameter entered the link.
* `browse-entry-list-element.component.ts`: `getQueryParams()` now also reads `scope`, `bbm.rpp`, `bbm.sf` and `bbm.sd`, the parameters `merge` used to bring along. Anything else in the URL is dropped.
* spec: the `RouteService` mock answers per parameter name, and one test asserts on the rendered `href` with a real `Router`, since the reflection happened inside `RouterLink` rather than in the params object.

The list comes from the source, not from logs. Browse-by components read `scope`, `startsWith`, `value` and `authority`; `PaginationService` reads `bbm.page`, `bbm.rpp`, `bbm.sf` and `bbm.sd`, and `bbm` is the only pagination id under `browse-by/`. `browseDefinition` arrives through `route.data` via `BrowseByGuard`, not the query string. Every other query parameter in the app belongs to search, the comcol create form, submission import or access control, none of which sits on a browse route.

Upstream removed the same merge in #2735 but did not carry `scope` with it, which broke browsing inside a community or collection (#5209, open, present since 7.6.6). Keeping `scope` avoids repeating that.

How to test:

1. `curl -s 'https://<host>/browse/author?zzz=1' | grep -c 'zzz=1'` prints 0 after the deploy. On an affected instance it is non-zero.
2. Open a collection, browse by author, click a name. The URL must still carry `?scope=`.
3. Set 40 items per page and sort descending, then click a name. Both must survive the click.

Only the browse value link changed. Pagination and starts-with links keep their own merge, so anything legitimately in the URL still survives a click through those. Steps 2 and 3 have not been run in a browser yet, they need a deploy; everything else is covered by CI and the specs.

Considered and dropped: porting the SSR exclusion of `/browse` from 7.6.5 (#4332). It serves the page as a CSR shell, so the reflection stays and browse pages leave the index for crawlers that do not run JavaScript. Reasonable as a separate performance change, not as the fix for this.

## Checklist

- [x] My PR is **created against the `main` branch** of code (against `customer/TUL`, which runs 7.5.0)
- [x] My PR is **small in size** (3 files, +61/-7)
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md)
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`
- [x] My PR **doesn't introduce circular dependencies** (verified via `npm run check-circ-deps`)
- [x] My PR **includes [TypeDoc](https://typedoc.org/) comments** for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **aligns with [Accessibility guidelines](https://wiki.lyrasis.org/spaces/DSDOC10x/pages/408944958/Accessibility)** if it makes changes to the user interface.
- [x] My PR **uses i18n (internationalization) keys** instead of hardcoded English text, to allow for translations. (no new text)
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation. (none added)
- [x] If my PR includes new features or configurations, I've provided basic technical documentation in the PR itself. (no new configuration)
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue). (no issue ticket, reported through New Relic)
