### PR TITLE
Trigger-ui-tests shift nightly cron to 02:15 UTC

### DIFF
--- a/.github/workflows/trigger-ui-tests.yml
+++ b/.github/workflows/trigger-ui-tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   workflow_call:
   schedule:
-    - cron: '0 5 * * *'
+    - cron: '15 2 * * *'
 
 permissions:
   actions: write # Grants permission to trigger workflows


### PR DESCRIPTION
## What

Shift the nightly UI-test trigger schedule in `.github/workflows/trigger-ui-tests.yml`:

```diff
   schedule:
-    - cron: '0 5 * * *'
+    - cron: '15 2 * * *'
```

This is the only change — a single cron line.

## Why

- **GitHub Actions cron runs in UTC.** `'0 5 * * *'` fires at **05:00 UTC**, which is **07:00 local in summer** (CEST/UTC+2) and **06:00 in winter** (CET/UTC+1). That lands the run right when the team arrives and needs the self-hosted runner.
- **Moving to `'15 2 * * *'` (02:15 UTC)** means ~**04:15 local (summer)** / ~**03:15 local (winter)**, finishing well before the workday even with GitHub's scheduler queue delay and the ~60 min suite.
- **Using `:15` instead of `:00`** avoids the top-of-the-hour scheduler congestion that was delaying the run by 20-30 minutes.

## Impact

No functional change to the job itself — only *when* the nightly trigger fires. `workflow_dispatch` and `workflow_call` are unaffected.
