### PR TITLE
feat(docker): run Handle server as a separate service (not embedded)

### DIFF
--- a/docker/docker-compose-handle.yml
+++ b/docker/docker-compose-handle.yml
@@ -23,9 +23,6 @@
 #     -f docker/docker-compose-rest.yml \
 #     -f docker/docker-compose-handle.yml up -d
 #
-networks:
-  dspacenet:
-
 services:
   # Backend: enable the remote-resolver endpoints and STOP starting the embedded
   # Handle server. This entrypoint is identical to docker-compose-rest.yml with
@@ -33,6 +30,18 @@ services:
   dspace:
     environment:
       handle__P__remote__D__resolver__P__enabled: 'true'
+    # The backend no longer runs a Handle server, so drop the (now unused) Handle
+    # ports it publishes in docker-compose-rest.yml (native 264${INSTANCE} and
+    # HTTP 801${INSTANCE}). `!override` REPLACES the ports list instead of the
+    # default append-merge, which is what lets us remove them; this also avoids a
+    # "port is already allocated" clash with dspace-handle-server. Keep REST + debug.
+    ports: !override
+      - published: 808${INSTANCE}
+        target: 8080
+        host_ip: ${HOST_IP:-127.0.0.1}
+      - published: 800${INSTANCE}
+        target: 8000
+        host_ip: ${HOST_IP:-127.0.0.1}
     entrypoint:
       - /bin/bash
       - '-c'
@@ -55,7 +64,9 @@ services:
       # Backend REST base the resolver plugin talks to.
       DSPACE_HANDLE_ENDPOINT: ${DSPACE_HANDLE_ENDPOINT:-http://dspace:8080/server}
     ports:
-      - published: ${HANDLE_HTTP_PORT:-8000}
+      # HTTP resolver. Default 8010 matches the Handle HTTP port the embedded
+      # server used to expose, and avoids the backend debug port (800${INSTANCE}).
+      - published: ${HANDLE_HTTP_PORT:-8010}
         target: 8000
         host_ip: ${HOST_IP:-127.0.0.1}
       - published: ${HANDLE_NATIVE_PORT:-2641}

--- a/docker/docker-compose-handle.yml
+++ b/docker/docker-compose-handle.yml
@@ -1,0 +1,87 @@
+#
+# The contents of this file are subject to the license and copyright
+# detailed in the LICENSE and NOTICE files at the root of the source
+# tree and available online at
+#
+# http://www.dspace.org/license/
+#
+
+# Overlay that runs the Handle server as a SEPARATE service instead of the one
+# embedded in the backend. The backend stops starting its own Handle server and
+# the standalone service resolves via the backend's remote-resolver REST API:
+#
+#   client -> dspace-handle-server(:8000) --HTTP /server/resolve--> dspace (backend) -> dspacedb
+#
+# The Handle server never connects to the database itself.
+#
+# This overlay MUST be listed LAST so its backend `entrypoint` override wins over
+# docker-compose-rest.yml (entrypoint is replaced, not merged). The network ipam
+# from docker-compose-rest.yml is preserved (this file only references dspacenet):
+#
+#   docker compose -p d7 \
+#     -f docker/docker-compose.yml \
+#     -f docker/docker-compose-rest.yml \
+#     -f docker/docker-compose-handle.yml up -d
+#
+networks:
+  dspacenet:
+
+services:
+  # Backend: enable the remote-resolver endpoints and STOP starting the embedded
+  # Handle server. This entrypoint is identical to docker-compose-rest.yml with
+  # the `/dspace/bin/start-handle-server` line removed.
+  dspace:
+    environment:
+      handle__P__remote__D__resolver__P__enabled: 'true'
+    entrypoint:
+      - /bin/bash
+      - '-c'
+      - |
+        while (!</dev/tcp/dspacedb/5432) > /dev/null 2>&1; do sleep 1; done;
+        pushd /usr/local/tomcat/webapps && (unlink server || true) && (ln -s /dspace/webapps/server/ `echo -n "${DSPACE_REST_NAMESPACE}" | sed -e 's#^/##' -e 'sx/x#x'` || true) && popd
+        /dspace/bin/dspace database migrate force
+        ./custom_run.sh
+
+  # Standalone CNRI Handle server (image built from dataquest-dev/docker-handle-server).
+  dspace-handle-server:
+    image: ${DSPACE_HANDLE_IMAGE:-ghcr.io/dataquest-dev/docker-handle-server:latest}
+    container_name: dspace-handle-server${INSTANCE}
+    restart: unless-stopped
+    depends_on:
+      - dspace
+    networks:
+      - dspacenet
+    environment:
+      # Backend REST base the resolver plugin talks to.
+      DSPACE_HANDLE_ENDPOINT: ${DSPACE_HANDLE_ENDPOINT:-http://dspace:8080/server}
+    ports:
+      - published: ${HANDLE_HTTP_PORT:-8000}
+        target: 8000
+        host_ip: ${HOST_IP:-127.0.0.1}
+      - published: ${HANDLE_NATIVE_PORT:-2641}
+        target: 2641
+        protocol: tcp
+        host_ip: ${HOST_IP:-127.0.0.1}
+      - published: ${HANDLE_NATIVE_PORT:-2641}
+        target: 2641
+        protocol: udp
+        host_ip: ${HOST_IP:-127.0.0.1}
+    # Configure the plugin at runtime (works with the current published image):
+    #  1) switch config.dct to the remote-resolver storage plugin (if not already),
+    #  2) point the plugin at the backend,
+    #  3) wait for the backend (the plugin loads the prefix list on startup and
+    #     aborts if the backend is unreachable), then start the Handle server.
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        grep -q MultiRemoteDSpaceRepositoryHandlePlugin /app/config/config.dct || \
+          sed -i 's#"server_config" = {#"server_config" = {\n    "storage_type" = "CUSTOM"\n    "storage_class" = "org.dspace.handle.MultiRemoteDSpaceRepositoryHandlePlugin"#' /app/config/config.dct
+        echo "dspace.handle.endpoint1 = $$DSPACE_HANDLE_ENDPOINT" > /app/config/handle-dspace-plugin.cfg
+        echo "Backend endpoint: $$DSPACE_HANDLE_ENDPOINT"
+        until wget -q -O- "$$DSPACE_HANDLE_ENDPOINT/listprefixes" >/dev/null 2>&1; do
+          echo "  waiting for backend $$DSPACE_HANDLE_ENDPOINT ...";
+          sleep 5;
+        done
+        echo "Backend is up. Starting Handle server."
+        exec /app/hs/bin/hdl-server /app/config/


### PR DESCRIPTION
## What

Runs the DSpace **Handle server as a separate service** instead of the one embedded
in the backend. This is the "take the Handle server out of the backend, keep only
the standalone one" change on the deployment side.

Adds one file — `docker/docker-compose-handle.yml` — an overlay that:

1. **Stops the backend from starting the embedded Handle server** — overrides the
   `dspace` entrypoint with the same script as `docker-compose-rest.yml` but with the
   `/dspace/bin/start-handle-server` line removed.
2. **Enables the remote-resolver endpoints** — `handle.remote-resolver.enabled = true`
   (`/server/listprefixes`, `/listhandles`, `/resolve`).
3. **Adds a standalone `dspace-handle-server` service** (image from
   `dataquest-dev/docker-handle-server`) that resolves through the backend REST API,
   waits for the backend on startup, and never touches the database.

```
client -> dspace-handle-server(:8000) --HTTP /server/resolve--> dspace (backend) -> dspacedb
```

## Usage

Include the overlay **last** (its entrypoint override must win; the network ipam from
`docker-compose-rest.yml` is preserved):

```
docker compose -p d7 \
  -f docker/docker-compose.yml \
  -f docker/docker-compose-rest.yml \
  -f docker/docker-compose-handle.yml up -d
```

Ports/endpoint are configurable via `.env` (`HANDLE_HTTP_PORT`, `HANDLE_NATIVE_PORT`,
`DSPACE_HANDLE_ENDPOINT`, `DSPACE_HANDLE_IMAGE`).

## Tested

- `docker compose config` merges cleanly: backend entrypoint no longer contains
  `start-handle-server`, resolver is enabled, the standalone service is added, and the
  network subnet from `docker-compose-rest.yml` is preserved.
- The equivalent stack was run live: with the embedded server disabled, the standalone
  Handle server loaded all prefixes from the backend and resolved handles
  (`responseCode: 1`), verified in real time (a handle inserted into Postgres was
  immediately resolvable through the standalone server).

## Related

- `dataquest-dev/docker-handle-server#3` — makes that image clone-and-run friendly
  (default remote-resolver `config.dct`, `.env.example`, LF fix). This overlay works
  with the current published image regardless, patching the config at container start.

## Notes / follow-ups

- Opt-in overlay — default behaviour (embedded Handle server) is unchanged unless this
  file is included.
- Per-deployment Handle keys / prefix registration on handle.net remain deployment steps.
