### PR TITLE
DSpace9/Increased timeout

### DIFF
--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   playwright-tests:
     runs-on: dspace-test-1
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Checkout Playwright tests
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem description
Cancelled playwright test after increased the number of tests. 45 minutes is not enough.

### Sync verification
If en.json5 or cs.json5 translation files were updated:
- [ ] Run `yarn run sync-i18n -t src/assets/i18n/cs.json5 -i` to synchronize messages, and changes are included in this PR.

### Manual Testing (if applicable)
- [ ] Added to [testing scenarios](https://github.com/dataquest-dev/dspace-customers/issues/55)

### Copilot review
- [ ] Requested review from Copilot