### PR TITLE
MENDELU/Replace footer "Theme by" with a copyright sign

### DIFF
--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -10980,8 +10980,5 @@
   // "contact-us.email": "Email: ",
   "contact-us.email": "Email: ",
 
-  // "footer.theme.by.message": "Theme by",
-  "footer.theme.by.message": "Theme by",
-
 
 }

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -7281,6 +7281,4 @@
   "contact-us.feedback": "Feedback",
 
   "contact-us.email": "Email: ",
-
-  "footer.theme.by.message": "Theme by",
 }

--- a/src/themes/custom/app/footer/footer.component.html
+++ b/src/themes/custom/app/footer/footer.component.html
@@ -104,10 +104,11 @@
 
         <!-- Right Column - Theme Sign -->
         <div class="col-12 col-md-2 text-center">
-          <p class="footer-sign"><a class="dtq-sign"
-            *ngVar="(themedByCompanyName$ | async)?.payload?.values[0] as companyName"
-            [href]="(themedByUrl$ | async)?.payload?.values[0]"
-            rel="noopener">{{ companyName }}</a><span class="footer-sign__mark">&#169;</span></p>
+          @if ((themedByCompanyName$ | async)?.payload?.values?.[0]; as companyName) {
+            <p class="footer-sign"><a class="dtq-sign"
+              [href]="(themedByUrl$ | async)?.payload?.values?.[0]"
+              rel="noopener">{{ companyName }}</a><span class="footer-sign__mark">&#169;</span></p>
+          }
         </div>
       </div>
     </div>

--- a/src/themes/custom/app/footer/footer.component.html
+++ b/src/themes/custom/app/footer/footer.component.html
@@ -104,14 +104,10 @@
 
         <!-- Right Column - Theme Sign -->
         <div class="col-12 col-md-2 text-center">
-          <div class="footer-sign">
-            <p class="theme-by mb-1">{{ 'footer.theme.by.message' | translate }}</p>
-            <a class="dtq-sign text-white" *ngVar="(themedByCompanyName$ | async)?.payload?.values[0] as companyName"
-               [href]="(themedByUrl$ | async)?.payload?.values[0]"
-               [title]="companyName">
-              {{ companyName }}
-            </a>
-          </div>
+          <p class="footer-sign"><a class="dtq-sign"
+            *ngVar="(themedByCompanyName$ | async)?.payload?.values[0] as companyName"
+            [href]="(themedByUrl$ | async)?.payload?.values[0]"
+            rel="noopener">{{ companyName }}</a><span class="footer-sign__mark">&#169;</span></p>
         </div>
       </div>
     </div>

--- a/src/themes/custom/app/footer/footer.component.scss
+++ b/src/themes/custom/app/footer/footer.component.scss
@@ -75,6 +75,46 @@
     .btn {
       box-shadow: none;
     }
+
+    // Vendor credit at the right end of the bar. White to match the nav links
+    // beside it — note that #fff on this green measures 2.29:1 and is below the
+    // WCAG AA threshold, same as those links already are. Kept on a single
+    // non-breaking line so the © can never strand itself above the name.
+    .footer-sign {
+      font-size: 1.0625rem;
+      font-weight: 500;
+      line-height: 1.2;
+      letter-spacing: 0.012em;
+      white-space: nowrap;
+      color: #fff;
+
+      // The © is set as a superscript of the company name, the way a trademark
+      // mark rides a wordmark. line-height: 0 keeps it from adding to the line box.
+      &__mark {
+        font-size: 0.68em;
+        font-weight: 400;
+        vertical-align: super;
+        line-height: 0;
+        margin-left: 0.12em;
+      }
+
+      .dtq-sign {
+        color: inherit;
+        text-decoration: none;
+
+        &:hover,
+        &:focus-visible {
+          text-decoration: underline;
+          text-underline-offset: 0.18em;
+        }
+
+        &:focus-visible {
+          outline: 2px solid #fff;
+          outline-offset: 3px;
+          border-radius: 2px;
+        }
+      }
+    }
   }
 
   .footer-logo {

--- a/src/themes/custom/app/footer/footer.component.ts
+++ b/src/themes/custom/app/footer/footer.component.ts
@@ -4,7 +4,6 @@ import { RouterLink } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { FooterComponent as BaseComponent } from '../../../../app/footer/footer.component';
-import { VarDirective } from '../../../../app/shared/utils/var.directive';
 
 @Component({
   selector: 'ds-themed-footer',
@@ -17,7 +16,6 @@ import { VarDirective } from '../../../../app/shared/utils/var.directive';
     AsyncPipe,
     RouterLink,
     TranslateModule,
-    VarDirective,
   ],
 })
 export class FooterComponent extends BaseComponent {


### PR DESCRIPTION
Replaces the `Theme by` wording in the footer's vendor credit with a bare copyright sign, set as a superscript of the company name.

Part of dataquest-dev/dspace-customers#592. MENDELU first — once this is approved the same change goes out to the remaining seven customers.

## Before / after

| | |
| --- | --- |
| before | `Theme by` on its own line, `+ dataquest` stacked underneath |
| after | `+ dataquest©` on a single line, sign riding the name as a superscript |

_Screenshot below._

## What changed

**`footer.component.html`** — the credit was a block-level `<p>` plus an `<a>` inside a `d-flex` wrapper, sitting in a narrow `col-md-2` cell. That is what forced the two halves onto separate lines. It is now one line of text:

```html
<p class="footer-sign"><a class="dtq-sign" …>{{ companyName }}</a><span class="footer-sign__mark">&#169;</span></p>
```

**`footer.component.scss`** — new `.footer-sign` block. `.footer-sign`, `.theme-by` and `.dtq-sign` had no rules of their own before; the layout came entirely from Bootstrap utilities, which cannot express a superscript or a non-breaking pair.

**`en.json5` / `cs.json5`** — `footer.theme.by.message` removed. It is now unused: a copyright sign is a symbol, not a translated word, so English and Czech render identically. Both files still parse (3698 / 3695 keys).

## Verification

Run locally against the live dev-6 backend (real MENDELU theme and data), checked in both languages on the compiled build:

| | |
| --- | --- |
| rendered text | `+ dataquest©` (EN and CS identical) |
| name | 17px, weight 500, `#fff` |
| sign | 11.56px, `vertical-align: super`, `line-height: 0` |
| link target | `https://www.dataquest.sk/dspace` |
| footer height | **83px — unchanged** |

`line-height: 0` on the superscript is deliberate: without it the raised glyph grows the line box and the whole bar gets taller.

## Notes for the reviewer

- The leading `+` in `+ dataquest` comes from the backend property `themed.by.company.name` and is untouched.
- The credit stays white to match the nav links beside it. Worth knowing: `#fff` on this green measures **2.29:1**, below the WCAG AA threshold of 4.5:1 — but the five nav links next to it already have exactly the same problem, so this PR neither introduces nor fixes it. Flagging it as a separate ticket rather than smuggling a visual change in here.
- The redundant `[title]` tooltip is dropped — the link text already supplies the accessible name.
- Merging this triggers the deploy of instance 8573 on dev-6. Per the issue, **JM and PU need to agree to the change first.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
