### PR TITLE
DSpace9/Restore "Submissions" entry in admin sidebar

### DIFF
--- a/src/app/app.menus.ts
+++ b/src/app/app.menus.ts
@@ -31,6 +31,7 @@ import { NotificationsMenuProvider } from './shared/menu/providers/notifications
 import { ProcessesMenuProvider } from './shared/menu/providers/processes.menu';
 import { RegistriesMenuProvider } from './shared/menu/providers/registries.menu';
 import { StatisticsMenuProvider } from './shared/menu/providers/statistics.menu';
+import { SubmissionsMenuProvider } from './shared/menu/providers/submissions.menu';
 import { SystemWideAlertMenuProvider } from './shared/menu/providers/system-wide-alert.menu';
 import { WithdrawnReinstateItemMenuProvider } from './shared/menu/providers/withdrawn-reinstate-item.menu';
 import { WorkflowMenuProvider } from './shared/menu/providers/workflow.menu';
@@ -60,6 +61,8 @@ export const MENUS = buildMenuStructure({
   [MenuID.ADMIN]: [
     NewMenuProvider,
     EditMenuProvider,
+    // CLARIN/LINDAT: "Submissions" link to MyDSpace (ported from the v7 fork)
+    SubmissionsMenuProvider,
     ImportMenuProvider,
     ExportMenuProvider,
     NotificationsMenuProvider,

--- a/src/app/app.menus.ts
+++ b/src/app/app.menus.ts
@@ -61,7 +61,7 @@ export const MENUS = buildMenuStructure({
   [MenuID.ADMIN]: [
     NewMenuProvider,
     EditMenuProvider,
-    // CLARIN/LINDAT: "Submissions" link to MyDSpace (ported from the v7 fork)
+    // CLARIN/LINDAT: "Submissions" link to MyDSpace
     SubmissionsMenuProvider,
     ImportMenuProvider,
     ExportMenuProvider,

--- a/src/app/shared/menu/providers/submissions.menu.spec.ts
+++ b/src/app/shared/menu/providers/submissions.menu.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+import { TestBed } from '@angular/core/testing';
+
+import { MYDSPACE_ROUTE } from '../../../my-dspace-page/my-dspace-page.component';
+import { MenuItemType } from '../menu-item-type.model';
+import { PartialMenuSection } from '../menu-provider.model';
+import { SubmissionsMenuProvider } from './submissions.menu';
+
+describe('SubmissionsMenuProvider', () => {
+  const expectedSections: PartialMenuSection[] = [
+    {
+      visible: true,
+      model: {
+        type: MenuItemType.LINK,
+        text: 'menu.section.submissions',
+        link: MYDSPACE_ROUTE,
+      },
+      icon: 'upload',
+    },
+  ];
+
+  let provider: SubmissionsMenuProvider;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        SubmissionsMenuProvider,
+      ],
+    });
+    provider = TestBed.inject(SubmissionsMenuProvider);
+  });
+
+  it('should be created', () => {
+    expect(provider).toBeTruthy();
+  });
+
+  it('getSections should return expected menu sections', (done) => {
+    provider.getSections().subscribe((sections) => {
+      expect(sections).toEqual(expectedSections);
+      done();
+    });
+  });
+});

--- a/src/app/shared/menu/providers/submissions.menu.ts
+++ b/src/app/shared/menu/providers/submissions.menu.ts
@@ -12,6 +12,7 @@ import {
   of,
 } from 'rxjs';
 
+import { MYDSPACE_ROUTE } from '../../../my-dspace-page/my-dspace-page.component';
 import { MenuItemType } from '../menu-item-type.model';
 import {
   AbstractMenuProvider,
@@ -32,7 +33,7 @@ export class SubmissionsMenuProvider extends AbstractMenuProvider {
         model: {
           type: MenuItemType.LINK,
           text: 'menu.section.submissions',
-          link: '/mydspace',
+          link: MYDSPACE_ROUTE,
         },
         icon: 'upload',
       },

--- a/src/app/shared/menu/providers/submissions.menu.ts
+++ b/src/app/shared/menu/providers/submissions.menu.ts
@@ -1,0 +1,41 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+import { Injectable } from '@angular/core';
+import {
+  Observable,
+  of,
+} from 'rxjs';
+
+import { MenuItemType } from '../menu-item-type.model';
+import {
+  AbstractMenuProvider,
+  PartialMenuSection,
+} from '../menu-provider.model';
+
+/**
+ * CLARIN/LINDAT: "Submissions" entry in the admin sidebar (ported from the v7 fork's menu.resolver.ts).
+ * Links to the user's MyDSpace page and is always visible, matching the original fork behaviour.
+ */
+@Injectable()
+export class SubmissionsMenuProvider extends AbstractMenuProvider {
+
+  public getSections(): Observable<PartialMenuSection[]> {
+    return of([
+      {
+        visible: true,
+        model: {
+          type: MenuItemType.LINK,
+          text: 'menu.section.submissions',
+          link: '/mydspace',
+        },
+        icon: 'upload',
+      },
+    ] as PartialMenuSection[]);
+  }
+}

--- a/src/app/shared/menu/providers/submissions.menu.ts
+++ b/src/app/shared/menu/providers/submissions.menu.ts
@@ -20,8 +20,8 @@ import {
 } from '../menu-provider.model';
 
 /**
- * CLARIN/LINDAT: "Submissions" entry in the admin sidebar (ported from the v7 fork's menu.resolver.ts).
- * Links to the user's MyDSpace page and is always visible, matching the original fork behaviour.
+ * CLARIN/LINDAT: "Submissions" entry in the admin sidebar.
+ * Links to the user's MyDSpace page and is always visible.
  */
 @Injectable()
 export class SubmissionsMenuProvider extends AbstractMenuProvider {


### PR DESCRIPTION
## Problem
The **Submissions** link that existed in the admin sidebar on `dtq-dev` (v7) is missing on `dtq-dev-9-base` (v9).

## Cause
The v9 upgrade replaced the monolithic `menu.resolver.ts` with the new menu-provider architecture. The CLARIN admin entries (handle table, ePIC handles, licenses) were ported into `clarin-admin.menu.ts`, but the **Submissions** entry was not migrated. The i18n keys were still present but no longer referenced.

## Fix
- Add a dedicated `SubmissionsMenuProvider` (link to `/mydspace`, `upload` icon, always visible) — same behaviour as v7.
- Register it in `app.menus.ts` right after `EditMenuProvider`, matching its original position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)