### PR TITLE
ZCU-DATA/fix(static-page): return HTTP 404 for missing static pages

### DIFF
--- a/src/app/static-page/static-page.component.html
+++ b/src/app/static-page/static-page.component.html
@@ -1,3 +1,21 @@
-<div class="container" >
+<!-- Loading spinner while the static file is being fetched -->
+<div class="container text-center my-5" *ngIf="contentState === 'loading'">
+  <ds-themed-loading [spinner]="true" [showMessage]="false"></ds-themed-loading>
+</div>
+
+<!-- Show static page content when found -->
+<div class="container" *ngIf="contentState === 'found'">
   <div [innerHTML]="(htmlContent | async) | dsSafeHtml" (click)="processLinks($event)"></div>
+</div>
+
+<!-- Show 404 error when content not found (matches PageNotFoundComponent design) -->
+<div class="container page-not-found" *ngIf="contentState === 'not-found'">
+  <h1>404</h1>
+  <h2><small>{{"404.page-not-found" | translate}}</small></h2>
+  <br/>
+  <p>{{"404.help" | translate}}</p>
+  <br/>
+  <p class="text-center">
+    <a routerLink="/home" class="btn btn-primary">{{"404.link.home-page" | translate}}</a>
+  </p>
 </div>

--- a/src/app/static-page/static-page.component.spec.ts
+++ b/src/app/static-page/static-page.component.spec.ts
@@ -18,7 +18,7 @@ describe('StaticPageComponent', () => {
   let component: StaticPageComponent;
   let fixture: ComponentFixture<StaticPageComponent>;
 
-  let htmlContentService: any;
+  let htmlContentService: jasmine.SpyObj<HtmlContentService>;
   let localeService: any;
   let responseService: jasmine.SpyObj<ServerResponseService>;
   let appConfig: any;

--- a/src/app/static-page/static-page.component.spec.ts
+++ b/src/app/static-page/static-page.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CommonModule } from '@angular/common';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { StaticPageComponent } from './static-page.component';
 import { HtmlContentService } from '../shared/html-content.service';
@@ -10,13 +12,15 @@ import { of } from 'rxjs';
 import { APP_CONFIG } from '../../config/app-config.interface';
 import { environment } from '../../environments/environment';
 import { ClarinSafeHtmlPipe } from '../shared/utils/clarin-safehtml.pipe';
+import { ServerResponseService } from '../core/services/server-response.service';
 
 describe('StaticPageComponent', () => {
   let component: StaticPageComponent;
   let fixture: ComponentFixture<StaticPageComponent>;
 
-  let htmlContentService: HtmlContentService;
+  let htmlContentService: any;
   let localeService: any;
+  let responseService: jasmine.SpyObj<ServerResponseService>;
   let appConfig: any;
 
   beforeEach(async () => {
@@ -26,6 +30,7 @@ describe('StaticPageComponent', () => {
     localeService = jasmine.createSpyObj('LocaleService', {
       getCurrentLanguageCode: jasmine.createSpy('getCurrentLanguageCode'),
     });
+    responseService = jasmine.createSpyObj('responseService', ['setNotFound']);
 
     // Do not mutate the shared `environment` object - replacing `environment.ui` would
     // break any later spec that reads e.g. environment.ui.nameSpace
@@ -38,14 +43,17 @@ describe('StaticPageComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ StaticPageComponent, ClarinSafeHtmlPipe ],
       imports: [
+        CommonModule,
         TranslateModule.forRoot()
       ],
       providers: [
         { provide: HtmlContentService, useValue: htmlContentService },
         { provide: Router, useValue: new RouterMock() },
         { provide: LocaleService, useValue: localeService },
+        { provide: ServerResponseService, useValue: responseService },
         { provide: APP_CONFIG, useValue: appConfig }
-      ]
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
     });
 
     localeService = TestBed.inject(LocaleService);
@@ -65,5 +73,14 @@ describe('StaticPageComponent', () => {
   it('should load html file content', async () => {
     await component.ngOnInit();
     expect(component.htmlContent.value).toBe('<div id="idShouldNotBeRemoved">TEST MESSAGE</div>');
+    expect(component.contentState).toBe('found');
+  });
+
+  // When the file is missing, set a 404 status for SSR and switch to the not-found state
+  it('should set 404 status when content is not found', async () => {
+    htmlContentService.fetchHtmlContent.and.returnValue(of(''));
+    await component.ngOnInit();
+    expect(responseService.setNotFound).toHaveBeenCalled();
+    expect(component.contentState).toBe('not-found');
   });
 });

--- a/src/app/static-page/static-page.component.ts
+++ b/src/app/static-page/static-page.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, Inject, OnInit } from '@angular/core';
 import { HtmlContentService } from '../shared/html-content.service';
 import { BehaviorSubject, firstValueFrom } from 'rxjs';
 import { Router } from '@angular/router';
@@ -6,10 +6,10 @@ import { isEmpty, isNotEmpty } from '../shared/empty.util';
 import { LocaleService } from '../core/locale/locale.service';
 import {
   HTML_SUFFIX,
-  STATIC_FILES_DEFAULT_ERROR_PAGE_PATH,
   STATIC_FILES_PROJECT_PATH, STATIC_PAGE_PATH
 } from './static-page-routing-paths';
 import { APP_CONFIG, AppConfig } from '../../config/app-config.interface';
+import { ServerResponseService } from '../core/services/server-response.service';
 
 /**
  * Component which load and show static files from the `static-files` folder.
@@ -23,10 +23,13 @@ import { APP_CONFIG, AppConfig } from '../../config/app-config.interface';
 export class StaticPageComponent implements OnInit {
   htmlContent: BehaviorSubject<string> = new BehaviorSubject<string>('');
   htmlFileName: string;
+  contentState: 'loading' | 'found' | 'not-found' = 'loading';
 
   constructor(private htmlContentService: HtmlContentService,
               private router: Router,
               private localeService: LocaleService,
+              private responseService: ServerResponseService,
+              private changeDetector: ChangeDetectorRef,
               @Inject(APP_CONFIG) protected appConfig?: AppConfig) { }
 
   async ngOnInit(): Promise<void> {
@@ -48,6 +51,8 @@ export class StaticPageComponent implements OnInit {
     let potentialContent = await firstValueFrom(this.htmlContentService.fetchHtmlContent(url));
     if (isNotEmpty(potentialContent)) {
       this.htmlContent.next(potentialContent);
+      this.contentState = 'found';
+      this.changeDetector.detectChanges();
       return;
     }
 
@@ -56,11 +61,15 @@ export class StaticPageComponent implements OnInit {
     potentialContent = await firstValueFrom(this.htmlContentService.fetchHtmlContent(url));
     if (isNotEmpty(potentialContent)) {
       this.htmlContent.next(potentialContent);
+      this.contentState = 'found';
+      this.changeDetector.detectChanges();
       return;
     }
 
-    // Show error page
-    await this.loadErrorPage();
+    // Content not found - set 404 status for SSR and show the inline 404 page
+    this.responseService.setNotFound();
+    this.contentState = 'not-found';
+    this.changeDetector.detectChanges();
   }
 
   /**
@@ -139,24 +148,10 @@ export class StaticPageComponent implements OnInit {
     urlInList = urlInList.filter(n => n);
     // if length is 1 - html file name wasn't defined.
     if (isEmpty(urlInList) || urlInList.length === 1) {
-      void this.loadErrorPage();
       return null;
     }
 
     // If the url is too long take just the first string after `/static` prefix.
     return urlInList[1]?.split('#')?.[0];
-  }
-
-  /**
-   * Load `static-files/error.html`
-   * @private
-   */
-  private async loadErrorPage() {
-    let errorPage = await firstValueFrom(this.htmlContentService.fetchHtmlContent(STATIC_FILES_DEFAULT_ERROR_PAGE_PATH));
-    if (isEmpty(errorPage)) {
-      console.error('Cannot load error page from the path: ' + STATIC_FILES_DEFAULT_ERROR_PAGE_PATH);
-      return;
-    }
-    this.htmlContent.next(errorPage);
   }
 }


### PR DESCRIPTION
## Problem
`/static/<missing>` answered **HTTP 200** with an empty shell instead of a 404 page. `StaticPageComponent` tried to load `static-files/error.html` and, when that was empty/missing, rendered nothing and never set a 404 status. UNIVERSAL-016 (dspace-ui-tests `notFoundPage.spec.ts` → *non-existent static page shows 404 page*) failed on this instance, while dtq-dev returns a proper 404.

## Fix
- Set the SSR response to **404** via `ServerResponseService.setNotFound()` when the static file is not found.
- Render the inline 404 page (same markup + reused `404.*` i18n keys as `PageNotFoundComponent`) via a `contentState` (`loading` / `found` / `not-found`).
- Drop the legacy `error.html` loading path.
- Update the unit spec (provide `ServerResponseService`, add a not-found test).

Mirrors the verified dtq-dev fix (`f8495ea85c`) on the same Angular 15 base.

## Result
`/static/<missing>` now returns **HTTP 404** with the "404 / Take me to the home page" page — matching dtq-dev. Verified locally with an AOT `ng build` (development) on the `sav` branch (identical change across all four customers).
<img width="929" height="869" alt="566-zcu-data-static-404" src="https://github.com/user-attachments/assets/2018ec54-9680-4ad9-b06f-52f94da97afd" />

Refs dataquest-dev/dspace-customers#566

🤖 Generated with [Claude Code](https://claude.com/claude-code)