### PR TITLE
TUL/fix(ssr): don't cache non-2XX responses (soft-404 on unknown pages)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -443,6 +443,10 @@ function saveToCache(req, page: any) {
     const key = getCacheKey(req);
     // Avoid caching "/reload/[random]" paths (these are hard refreshes after logout)
     if (key.startsWith('/reload')) { return; }
+    // Avoid caching non-successful responses (status code different from 2XX). Without this, the
+    // rendered 404 not-found page gets stored in the cache and is later replayed via res.send()
+    // as HTTP 200 - turning a correct 404 into a soft-404. (matches dtq-dev cache behaviour)
+    if (hasNotSucceeded(req.res.statusCode)) { return; }
 
     // If bot cache is enabled, save it to that cache if it doesn't exist or is expired
     // (NOTE: has() will return false if page is expired in cache)
@@ -457,6 +461,15 @@ function saveToCache(req, page: any) {
       if (environment.cache.serverSide.debug) { console.log(`CACHE SAVE FOR ${key} in anonymous cache.`); }
     }
   }
+}
+
+/**
+ * Check if status code is different from 2XX
+ * @param statusCode HTTP status code of the current response
+ */
+function hasNotSucceeded(statusCode) {
+  const rgx = new RegExp(/^20+/);
+  return !rgx.test(statusCode);
 }
 
 /**


### PR DESCRIPTION
Fixes soft-404 on tul: an unknown route / `/static/<missing>` renders the 404 page but the SSR cache replayed it as HTTP 200. `saveToCache()` stored the rendered page without checking status; serving a cached copy (`res.send(cachedCopy)`) does not restore the status. Add the `hasNotSucceeded` guard (as on dtq-dev/jcu) so non-2XX responses are never cached. tul has no StaticPageComponent, so both notFoundPage tests (route + static) share this 404 route and this one fix covers both. Note: a one-time redeploy clears the stale 200 cache entries; the guard prevents recurrence. Refs dataquest-dev/dspace-customers#566
<img width="914" height="869" alt="566-tul-static-404" src="https://github.com/user-attachments/assets/aae568db-2b51-414d-be34-4cc4a3b86dc3" />
<img width="914" height="869" alt="566-tul-route-404" src="https://github.com/user-attachments/assets/183f20ac-9835-46c1-9059-8fefd1d0ded0" />

