### PR TITLE
Clarin9/Fix menu-links and legacy-bitstream-redirect UI test regressions (#876)

### DIFF
--- a/src/app/bitstream-page/legacy-bitstream-url-redirect.guard.spec.ts
+++ b/src/app/bitstream-page/legacy-bitstream-url-redirect.guard.spec.ts
@@ -151,7 +151,8 @@ describe('legacyBitstreamURLRedirectGuard', () => {
         }));
         resolver(route, state, bitstreamDataService, hardRedirectService, router).subscribe(() => {
           expect(bitstreamDataService.findByItemHandle).toHaveBeenCalled();
-          expect(hardRedirectService.redirect).toHaveBeenCalledWith(new URL(`/bitstreams/${bitstream.uuid}/download`, environment.ui.baseUrl).href, 301);
+          const nameSpace = environment.ui.nameSpace?.replace(/\/$/, '') || '';
+          expect(hardRedirectService.redirect).toHaveBeenCalledWith(nameSpace + `/bitstreams/${bitstream.uuid}/download`, 301);
         });
       });
     });

--- a/src/app/bitstream-page/legacy-bitstream-url-redirect.guard.ts
+++ b/src/app/bitstream-page/legacy-bitstream-url-redirect.guard.ts
@@ -51,11 +51,8 @@ export const legacyBitstreamURLRedirectGuard: CanActivateFn = (
     getFirstCompletedRemoteData(),
     map((rd: RemoteData<Bitstream>) => {
       if (rd.hasSucceeded && !rd.hasNoContent) {
-        // Redirect to a namespace-prefixed, root-relative path so the target stays inside the app
-        // when it is mounted under a sub-path (e.g. '/repository'). Building an absolute URL from
-        // HardRedirectService.getBaseUrl() (environment.ui.baseUrl) dropped that namespace - a
-        // leading-slash path resolves against the origin only - and could even point at the
-        // internal SSR host, landing the user on a broken URL.
+        // Prefix the UI namespace and redirect to a root-relative path so the target keeps the
+        // '/repository' base path when the app is mounted under a sub-path.
         const nameSpace = environment.ui.nameSpace?.replace(/\/$/, '') || '';
         serverHardRedirectService.redirect(nameSpace + getBitstreamDownloadRoute(rd.payload), 301);
         return false;

--- a/src/app/bitstream-page/legacy-bitstream-url-redirect.guard.ts
+++ b/src/app/bitstream-page/legacy-bitstream-url-redirect.guard.ts
@@ -9,6 +9,7 @@ import {
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
+import { environment } from '../../environments/environment';
 import {
   getBitstreamDownloadRoute,
   PAGE_NOT_FOUND_PATH,
@@ -50,7 +51,13 @@ export const legacyBitstreamURLRedirectGuard: CanActivateFn = (
     getFirstCompletedRemoteData(),
     map((rd: RemoteData<Bitstream>) => {
       if (rd.hasSucceeded && !rd.hasNoContent) {
-        serverHardRedirectService.redirect(new URL(getBitstreamDownloadRoute(rd.payload), serverHardRedirectService.getBaseUrl()).href, 301);
+        // Redirect to a namespace-prefixed, root-relative path so the target stays inside the app
+        // when it is mounted under a sub-path (e.g. '/repository'). Building an absolute URL from
+        // HardRedirectService.getBaseUrl() (environment.ui.baseUrl) dropped that namespace - a
+        // leading-slash path resolves against the origin only - and could even point at the
+        // internal SSR host, landing the user on a broken URL.
+        const nameSpace = environment.ui.nameSpace?.replace(/\/$/, '') || '';
+        serverHardRedirectService.redirect(nameSpace + getBitstreamDownloadRoute(rd.payload), 301);
         return false;
       } else {
         return router.createUrlTree([PAGE_NOT_FOUND_PATH]);

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,13 +1,18 @@
 import { AsyncPipe } from '@angular/common';
 import {
   Component,
+  inject,
   OnInit,
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
-import { TranslateModule } from '@ngx-translate/core';
+import {
+  TranslateModule,
+  TranslateService,
+} from '@ngx-translate/core';
 import { Observable } from 'rxjs';
 
+import { environment } from '../../environments/environment';
 import { ThemedSearchNavbarComponent } from '../search-navbar/themed-search-navbar.component';
 import { ThemedAuthNavMenuComponent } from '../shared/auth-nav-menu/themed-auth-nav-menu.component';
 import {
@@ -50,6 +55,8 @@ export class HeaderComponent implements OnInit {
   menuID = MenuID.PUBLIC;
   maxMobileWidth = WidthCategory.SM;
 
+  private readonly translate = inject(TranslateService);
+
   constructor(
     protected menuService: MenuService,
     protected windowService: HostWindowService,
@@ -62,5 +69,29 @@ export class HeaderComponent implements OnInit {
 
   public toggleNavbar(): void {
     this.menuService.toggleMenu(this.menuID);
+  }
+
+  // Current UI language, read synchronously for the themed LINDAT portal links (in v9 LocaleService is async).
+  getLangCode(): string {
+    return this.translate.currentLang || environment.fallbackLanguage;
+  }
+
+  // Locale segment for the portal links: 'cs' in Czech, '' otherwise.
+  getLangCodeIfCzech(): string {
+    return this.getLangCode() === 'cs' ? 'cs' : '';
+  }
+
+  // Czech portal slug for an English slug; English keeps the original.
+  translateSlug(slug: string): string {
+    if (this.getLangCode() === 'en') {
+      return slug;
+    }
+    const translations = {
+      'partners': this.getLangCodeIfCzech() + '/' + 'partneri',
+      'integration': this.getLangCodeIfCzech() + '/' + 'integrace',
+      'partnership': this.getLangCodeIfCzech() + '/' + 'partnerstvi',
+      'services': 'sluzby',
+    };
+    return translations[slug] || '';
   }
 }

--- a/src/themes/dspace/app/header/header.component.html
+++ b/src/themes/dspace/app/header/header.component.html
@@ -21,36 +21,37 @@
             <div class="lindat-block lindat-block--clariah-theme-main-menu">
               <ul class="lindat-nav lindat-navbar-nav">
                 <li class="lindat-nav-item ">
-                  <a routerLink="community-list" class="lindat-nav-link">{{'navbar.community-list' | translate}}</a>
+                  <a href="/services/catalog" class="lindat-nav-link">{{'navbar.community-list' | translate}}</a>
                 </li>
                 <li class="lindat-nav-item ">
                   <a routerLink="home" class="lindat-nav-link">{{'navbar.repository' | translate}}</a>
                 </li>
                 <li class="lindat-nav-item ">
-                  <a routerLink="education" class="lindat-nav-link">{{'navbar.education' | translate}}</a>
+                  <a href="{{ '/' + getLangCodeIfCzech() + '#education' }}" class="lindat-nav-link">{{'navbar.education' | translate}}</a>
                 </li>
                 <li class="lindat-nav-item ">
-                  <a routerLink="projects" class="lindat-nav-link">{{'navbar.project' | translate}}</a>
+                  <a href="{{ '/' + getLangCodeIfCzech() + '#projects' }}" class="lindat-nav-link">{{'navbar.project' | translate}}</a>
                 </li>
                 <li class="lindat-nav-item ">
-                  <a routerLink="tools" class="lindat-nav-link ">{{'navbar.tools' | translate}}</a>
+                  <a href="{{ '/' + getLangCodeIfCzech() + '#tools' }}" class="lindat-nav-link ">{{'navbar.tools' | translate}}</a>
                 </li>
                 <li class="lindat-nav-item ">
-                  <a routerLink="en/services" class="lindat-nav-link ">{{'navbar.services' | translate}}</a>
+                  <a href="{{ '/' + getLangCode() + '/' + translateSlug('services') }}" class="lindat-nav-link ">{{'navbar.services' | translate}}</a>
                 </li>
                 <li class="lindat-nav-item lindat-dropdown">
-                  <!-- no routerLink here: Angular's RouterLink would navigate on every click even
-                       when the inline handler returns false, so the dropdown could never stay open -->
-                  <a href="javascript:void(0);" class="lindat-nav-link lindat-dropdown-toggle"
+                  <!-- LINDAT/CLARIAH-CZ portal links are absolute site paths, not in-app routes, so they
+                       use plain href (not routerLink). The inline handler returns false to toggle the
+                       dropdown without navigating away. -->
+                  <a href="{{ '/' + getLangCodeIfCzech() }}" class="lindat-nav-link lindat-dropdown-toggle"
                      data-toggle="dropdown"
                      onclick="this.parentNode.querySelector('.lindat-dropdown-toggle+div.lindat-dropdown-menu').classList.toggle('lindat-show'); return false;">{{'navbar.about' | translate}}</a>
                   <div class="lindat-dropdown-menu">
-                    <a routerLink="partners" class="lindat-dropdown-item">{{'navbar.about.partners' | translate}}</a>
-                    <a routerLink="files/mission-en.pdf" class="lindat-dropdown-item">{{'navbar.about.mission-statement' | translate}}</a>
+                    <a href="{{ '/' + translateSlug('partners') }}" class="lindat-dropdown-item">{{'navbar.about.partners' | translate}}</a>
+                    <a href="/files/mission-en.pdf" class="lindat-dropdown-item">{{'navbar.about.mission-statement' | translate}}</a>
                     <a href="https://www.clarin.eu/" class="lindat-dropdown-item">{{'navbar.about.clarin' | translate}}</a>
                     <a href="https://www.dariah.eu/" class="lindat-dropdown-item">{{'navbar.about.dariah' | translate}}</a>
-                    <a routerLink="integration" class="lindat-dropdown-item">{{'navbar.about.service-integrations' | translate}}</a>
-                    <a routerLink="partnership" class="lindat-dropdown-item">{{'navbar.about.project-partnership' | translate}}</a>
+                    <a href="{{ '/' + translateSlug('integration') }}" class="lindat-dropdown-item">{{'navbar.about.service-integrations' | translate}}</a>
+                    <a href="{{ '/' + translateSlug('partnership') }}" class="lindat-dropdown-item">{{'navbar.about.project-partnership' | translate}}</a>
                   </div>
                 </li>
               </ul>

--- a/src/themes/dspace/app/header/header.component.ts
+++ b/src/themes/dspace/app/header/header.component.ts
@@ -33,30 +33,17 @@ export class HeaderComponent extends BaseComponent {
 
   private readonly translate = inject(TranslateService);
 
-  /**
-   * The UI language normalized to the two languages the LINDAT/CLARIAH-CZ portal supports:
-   * 'cs' for Czech, 'en' for anything else. Read synchronously from TranslateService so it can be
-   * used directly in the template href bindings (in v9 LocaleService#getCurrentLanguageCode is
-   * asynchronous). Normalizing keeps the portal links well-formed even when the UI is shown in
-   * another active language (e.g. a browser-negotiated 'de'/'fr'), which would otherwise produce
-   * broken targets such as '/de/sluzby'; it also guarantees a non-empty value before a language is set.
-   */
+  // UI language for the LINDAT portal links, normalized to the two it supports: 'cs' for Czech, 'en' otherwise.
   getLangCode(): string {
     return this.translate.currentLang === 'cs' ? 'cs' : 'en';
   }
 
-  /**
-   * Returns the current language code only if it's Czech ('cs'), otherwise an empty string.
-   * Used to prefix the LINDAT portal links with the locale segment ('' for English, 'cs' for Czech).
-   */
+  // Locale segment for portal links: 'cs' in Czech, '' in English.
   getLangCodeIfCzech(): string {
     return this.getLangCode() === 'cs' ? 'cs' : '';
   }
 
-  /**
-   * Translates the English portal slug to its Czech equivalent when the current language is Czech.
-   * Returns the original slug in English, or an empty string when no translation is known.
-   */
+  // Czech portal slug for an English slug; English keeps the original.
   translateSlug(slug: string): string {
     if (this.getLangCode() === 'en') {
       return slug;

--- a/src/themes/dspace/app/header/header.component.ts
+++ b/src/themes/dspace/app/header/header.component.ts
@@ -1,12 +1,6 @@
-import {
-  Component,
-  inject,
-} from '@angular/core';
+import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import {
-  TranslateModule,
-  TranslateService,
-} from '@ngx-translate/core';
+import { TranslateModule } from '@ngx-translate/core';
 import { ClarinNavbarTopComponent } from 'src/app/clarin-navbar-top/clarin-navbar-top.component';
 
 import { HeaderComponent as BaseComponent } from '../../../../app/header/header.component';
@@ -30,32 +24,4 @@ import { ImpersonateNavbarComponent } from '../../../../app/shared/impersonate-n
   ],
 })
 export class HeaderComponent extends BaseComponent {
-
-  private readonly translate = inject(TranslateService);
-
-  // UI language for the LINDAT portal links, normalized to the two it supports: 'cs' for Czech, 'en' otherwise.
-  getLangCode(): string {
-    return this.translate.currentLang === 'cs' ? 'cs' : 'en';
-  }
-
-  // Locale segment for portal links: 'cs' in Czech, '' in English.
-  getLangCodeIfCzech(): string {
-    return this.getLangCode() === 'cs' ? 'cs' : '';
-  }
-
-  // Czech portal slug for an English slug; English keeps the original.
-  translateSlug(slug: string): string {
-    if (this.getLangCode() === 'en') {
-      return slug;
-    }
-
-    const translations = {
-      'partners': this.getLangCodeIfCzech() + '/' + 'partneri',
-      'integration': this.getLangCodeIfCzech() + '/' + 'integrace',
-      'partnership': this.getLangCodeIfCzech() + '/' + 'partnerstvi',
-      'services': 'sluzby',
-    };
-
-    return translations[slug] || '';
-  }
 }

--- a/src/themes/dspace/app/header/header.component.ts
+++ b/src/themes/dspace/app/header/header.component.ts
@@ -11,7 +11,6 @@ import { ClarinNavbarTopComponent } from 'src/app/clarin-navbar-top/clarin-navba
 
 import { HeaderComponent as BaseComponent } from '../../../../app/header/header.component';
 import { ImpersonateNavbarComponent } from '../../../../app/shared/impersonate-navbar/impersonate-navbar.component';
-import { environment } from '../../../../environments/environment';
 
 /**
  * Represents the LINDAT/CLARIAH-CZ header: the CLARIN top bar (language flags + AAI/DiscoJuice
@@ -35,12 +34,15 @@ export class HeaderComponent extends BaseComponent {
   private readonly translate = inject(TranslateService);
 
   /**
-   * Returns the language code currently in use. Read synchronously from TranslateService so it can
-   * be used directly in the template href bindings (in v9 LocaleService#getCurrentLanguageCode is
-   * asynchronous). Falls back to the configured fallback language before the app sets a language.
+   * The UI language normalized to the two languages the LINDAT/CLARIAH-CZ portal supports:
+   * 'cs' for Czech, 'en' for anything else. Read synchronously from TranslateService so it can be
+   * used directly in the template href bindings (in v9 LocaleService#getCurrentLanguageCode is
+   * asynchronous). Normalizing keeps the portal links well-formed even when the UI is shown in
+   * another active language (e.g. a browser-negotiated 'de'/'fr'), which would otherwise produce
+   * broken targets such as '/de/sluzby'; it also guarantees a non-empty value before a language is set.
    */
   getLangCode(): string {
-    return this.translate.currentLang || environment.fallbackLanguage;
+    return this.translate.currentLang === 'cs' ? 'cs' : 'en';
   }
 
   /**

--- a/src/themes/dspace/app/header/header.component.ts
+++ b/src/themes/dspace/app/header/header.component.ts
@@ -1,10 +1,17 @@
-import { Component } from '@angular/core';
+import {
+  Component,
+  inject,
+} from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
+import {
+  TranslateModule,
+  TranslateService,
+} from '@ngx-translate/core';
 import { ClarinNavbarTopComponent } from 'src/app/clarin-navbar-top/clarin-navbar-top.component';
 
 import { HeaderComponent as BaseComponent } from '../../../../app/header/header.component';
 import { ImpersonateNavbarComponent } from '../../../../app/shared/impersonate-navbar/impersonate-navbar.component';
+import { environment } from '../../../../environments/environment';
 
 /**
  * Represents the LINDAT/CLARIAH-CZ header: the CLARIN top bar (language flags + AAI/DiscoJuice
@@ -24,4 +31,42 @@ import { ImpersonateNavbarComponent } from '../../../../app/shared/impersonate-n
   ],
 })
 export class HeaderComponent extends BaseComponent {
+
+  private readonly translate = inject(TranslateService);
+
+  /**
+   * Returns the language code currently in use. Read synchronously from TranslateService so it can
+   * be used directly in the template href bindings (in v9 LocaleService#getCurrentLanguageCode is
+   * asynchronous). Falls back to the configured fallback language before the app sets a language.
+   */
+  getLangCode(): string {
+    return this.translate.currentLang || environment.fallbackLanguage;
+  }
+
+  /**
+   * Returns the current language code only if it's Czech ('cs'), otherwise an empty string.
+   * Used to prefix the LINDAT portal links with the locale segment ('' for English, 'cs' for Czech).
+   */
+  getLangCodeIfCzech(): string {
+    return this.getLangCode() === 'cs' ? 'cs' : '';
+  }
+
+  /**
+   * Translates the English portal slug to its Czech equivalent when the current language is Czech.
+   * Returns the original slug in English, or an empty string when no translation is known.
+   */
+  translateSlug(slug: string): string {
+    if (this.getLangCode() === 'en') {
+      return slug;
+    }
+
+    const translations = {
+      'partners': this.getLangCodeIfCzech() + '/' + 'partneri',
+      'integration': this.getLangCodeIfCzech() + '/' + 'integrace',
+      'partnership': this.getLangCodeIfCzech() + '/' + 'partnerstvi',
+      'services': 'sluzby',
+    };
+
+    return translations[slug] || '';
+  }
 }


### PR DESCRIPTION
## Why

Playwright tests from [dataquest-dev/dspace-ui-tests](https://github.com/dataquest-dev/dspace-ui-tests) were failing for the `lindat-9` customer (the `dtq-dev-9-base` build, `http://dev-6.pc:8603/repository/`). This PR fixes the two that are **real UI regressions** introduced while porting the LINDAT/CLARIAH-CZ customisations to the DSpace 9 base. The other three have a **backend cause** and are documented below for a separate backend fix (no UI change).

## Fixed here

### 1. Header menu pointed at in-app routes → `homePage: "menu options should have correct target links"`
The `dspace`-theme header (the active LINDAT theme) linked the top menu to `routerLink="community-list" | "education" | "projects" | "tools" | "en/services" | "partners" | ...`, which resolve under the `/repository` base href instead of the LINDAT/CLARIAH-CZ portal.

**Fix:** restore the absolute portal targets (`/services/catalog`, `/#education`, `/en/services`, `/partners`, …) and their Czech equivalents, matching the v7 production theme. `Repository` keeps `routerLink="home"`. The template's locale helpers (`getLangCode`, `getLangCodeIfCzech`, `translateSlug`) are re-added; since `LocaleService#getCurrentLanguageCode` is async in v9, the language is read synchronously from `TranslateService#currentLang`.

### 2. Legacy bitstream redirect dropped `/repository` → `itemPage: "old bitstream url should redirect to the download page"`
`legacyBitstreamURLRedirectGuard` built the target as `new URL(getBitstreamDownloadRoute(payload), getBaseUrl())`. `getBitstreamDownloadRoute` returns a leading-slash path (`/bitstreams/<id>/download`), so resolving it against a base URL keeps only the origin and **drops the `/repository` namespace** (and `getBaseUrl()` / `environment.ui.baseUrl` may carry the internal SSR host). The old URL therefore redirected to a 404.

**Fix:** redirect to a namespace-prefixed, root-relative path (`<nameSpace>/bitstreams/<id>/download`) so the browser/SSR resolves it against the current origin and it stays inside the app under a sub-path. Works for a root deployment too (empty namespace).

Confirmed on dev-6: `…/repository/bitstreams/<uuid>/download` → **HTTP 200**, while the previous target (without `/repository`) → **HTTP 404**.

## Not a UI bug — backend cause (needs a backend fix, NOT changed here)

These three fail because of the **backend**, not the Angular code:
- `consoleErrors: page "login"` should not have console errors
- `consoleErrors: page "register"` should not have console errors (`/register` redirects to `/login`)
- `loginPage: "login from search page should redirect back to search page"`

**Symptom:** `GET …/repository/server/api/discojuice/feeds` returns **HTTP 204 (empty)** on dev-6. The (LINDAT-customised but **byte-identical to v7**) `discojuice.js` merges that JSONP response with `$.merge(a.data, f)`; with an empty feed `f` is `undefined` and jQuery throws `Cannot read properties of undefined (reading 'length')`. The login auto-popup fires this on page load, logging the console error and aborting the popup so the "Local authentication" entry never renders (breaking login-from-search).

**Backend chain (`dataquest-dev/DSpace`):**
- `ClarinDiscoJuiceFeedsController` → returns **204** when `getFeedsContent()` is blank.
- `ClarinDiscoJuiceFeedsUpdateScheduler` → caches the feed, refreshed on cron `discojuice.refresh`.
- `ClarinDiscoJuiceFeedsDownloadService.createFeedsContent()` → downloads from **`shibboleth.discofeed.url`**; `downloadJSON()` swallows any IO/parse error and returns empty → feed blank → 204.

`dspace/config/clarin-dspace.cfg` points the feed at **dev-5**: `shibboleth.discofeed.url = https://dev-5.pc:8443/Shibboleth.sso/DiscoFeed`, which the dev-6 backend can't fetch (cross-host / SSL / no redirect following), so the cached feed stays empty. (Cf. backend branch `112-be/clarindiscojuicefeedsdownloadservice-causes-big-log-file`.)

**Proper fix is on the backend/deployment**: set `shibboleth.discofeed.url` to a feed dev-6 can actually reach — its own `Shibboleth.sso/DiscoFeed`, or the `TEST:` prefix to serve the bundled `discofeedResponse.json` sample on a dev instance without a real SP — and/or make the download resilient. Tracked separately for the backend. Since `discojuice.js` is identical to v7 and production (dev-5) returns a populated feed, this never triggered in v7 and is not patched in the UI.

## Changes
- `src/themes/dspace/app/header/header.component.{html,ts}` — portal links + locale helpers
- `src/app/bitstream-page/legacy-bitstream-url-redirect.guard.ts` (+ spec) — keep base path

## Testing
- Menu-link hrefs verified against the test's `menu_links_en` / `menu_links_cz` and the `navbar.*` translations.
- Bitstream target verified against the live backend (200 with `/repository`, 404 without); guard unit spec updated accordingly.
- The DiscoJuice/empty-feed backend cause was reproduced end-to-end against dev-6 (headless Chrome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
