### PR TITLE
TUL/Reduce the footer vendor credit to the company name

### DIFF
--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -90,7 +90,6 @@
               </ul>
             </div>
             <div class="footer-sign">
-              <p class="theme-by">Theme by</p>
               <a class="dtq-sign text-white"
                  [href]="(themedByUrl$ | async)?.payload?.values[0]"
                  [title]="(themedByCompanyName$ | async)?.payload?.values[0]">

--- a/src/app/footer/footer.component.scss
+++ b/src/app/footer/footer.component.scss
@@ -42,10 +42,6 @@
       }
     }
   }
-  .theme-by {
-    padding-top: 4px;
-    font-size: 12px !important;
-  }
 }
 
 


### PR DESCRIPTION
Drops the `Theme by` wording from the footer's vendor credit and leaves the company name on its own.

Part of dataquest-dev/dspace-customers#592. Same change as #1464 (MENDELU), which the team agreed on after voting between several wordings. Rolling out to the remaining customers one branch at a time.

## Before / after

| | |
| --- | --- |
| before | `Theme by` on its own line, `+ dataquest` underneath |
| after | `+ dataquest` alone |

_Screenshot below._

## What changed

Five deleted lines, nothing added.

**`footer.component.html`** — the `<p class="theme-by">Theme by</p>` above the link is gone. The anchor itself is untouched, so its `[href]`, `[title]` and hard-coded `+ dataquest` text all behave exactly as before.

**`footer.component.scss`** — the `.theme-by` rule (`padding-top: 4px; font-size: 12px !important`) is deleted along with the element it styled; it had no other use.

Note that on this branch the wording was hard-coded in the template rather than translated, so unlike MENDELU there is no i18n key to remove.

## Verification

Built the production image from this branch and ran it against a local DSpace 7.5 backend with `themed.by.*` exposed:

| | |
| --- | --- |
| rendered text | `+ dataquest` |
| `.theme-by` element | not present in the DOM |
| `href` | `https://www.dataquest.sk/dspace` |
| `title` | `+ dataquest` (from `themed.by.company.name`) |
| footer height | 78px |

## Notes for the reviewer

- The `DSpace software copyright © 2002-2026 LYRASIS` line above is untouched, so the software copyright and the vendor credit stay clearly separate.
- The credit keeps the footer's existing link styling — no new CSS. Making it look more like a signature would be a visual change beyond what this issue asks for, so it is deliberately left alone.
- The leading `+` in `+ dataquest` is part of the text on this branch; on other customers it comes from the backend property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
