### PR TITLE
ZCU/Reduce the footer vendor credit to the company name

### DIFF
--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -2174,8 +2174,6 @@
   "footer.link.contact-us": "Kontaktujte nás",
   // "footer.link.university": "University Library",
   "footer.link.university": "Univerzitni Knihovna",
-  // "footer.theme.by.message": "Theme by",
-  "footer.theme.by.message": "Theme by",
   // "forgot-email.form.header": "Forgot Password",
   "forgot-email.form.header": "Zapomenuté heslo",
   // "forgot-email.form.info": "Enter the email address associated with the account.",

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1733,8 +1733,6 @@
 
   "footer.link.university": "University Library",
 
-  "footer.theme.by.message": "Theme by",
-
   "forgot-email.form.header": "Forgot Password",
 
   "forgot-email.form.info": "Enter the email address associated with the account.",

--- a/src/themes/custom/app/footer/footer.component.html
+++ b/src/themes/custom/app/footer/footer.component.html
@@ -93,7 +93,6 @@
               </ul>
             </div>
             <div class="footer-sign">
-              <p class="theme-by">{{ 'footer.theme.by.message' | translate }}</p>
               <a class="dtq-sign text-white" *ngVar="(themedByCompanyName$ | async)?.payload?.values[0] as companyName"
                  [href]="(themedByUrl$ | async)?.payload?.values[0]"
                  [title]="companyName">


### PR DESCRIPTION
Drops the `Theme by` wording from the footer's vendor credit and leaves the company name on its own.

Part of dataquest-dev/dspace-customers#592, following #1464 (MENDELU) and #1466 (TUL). The wording was picked by the team after voting between several options.

## Before / after

| | |
| --- | --- |
| before | `Theme by` on its own line, `+ dataquest` underneath |
| after | `+ dataquest` alone |

_Screenshot below._

## What changed

Five deleted lines, nothing added.

**`src/themes/custom/app/footer/footer.component.html`** — the `<p class="theme-by">` above the link is gone. The anchor is untouched: its `*ngVar` binding, `[href]` and `[title]` behave exactly as before, and the name still comes from the backend property `themed.by.company.name`.

**`en.json5` / `cs.json5`** — `footer.theme.by.message` removed, now unused.

No new CSS. Neither `.footer-sign` nor `.dtq-sign` had any rule of its own on this branch, and the credit keeps the footer's existing link styling.

## Verification

Built the production image from this branch and rendered it against a local DSpace 7.6 backend with `themed.by.*` exposed:

| | |
| --- | --- |
| rendered text | `+ dataquest` |
| `.theme-by` element | not present in the DOM |
| `href` | `https://www.dataquest.sk/dspace` |
| footer height | 54px |

## Notes for the reviewer

- The `DSpace software copyright © 2002-2026 LYRASIS` line above is untouched, so the software copyright stays separate from the vendor credit.
- `customer/zcu-data` carries the same footer markup in `src/app/footer/` instead of the theme; it gets the same change in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
