### PR TITLE
ZCU/Reduce the footer vendor credit to the company name

### DIFF
--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -93,7 +93,6 @@
               </ul>
             </div>
             <div class="footer-sign">
-              <p class="theme-by">{{ 'footer.theme.by.message' | translate }}</p>
               <a class="dtq-sign text-white" *ngVar="(themedByCompanyName$ | async)?.payload?.values[0] as companyName"
                  [href]="(themedByUrl$ | async)?.payload?.values[0]"
                  [title]="companyName">

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1730,8 +1730,6 @@
 
   "footer.link.university": "University Library",
 
-  "footer.theme.by.message": "Theme by",
-
   "forgot-email.form.header": "Forgot Password",
 
   "forgot-email.form.info": "Enter the email address associated with the account.",


### PR DESCRIPTION
Drops the `Theme by` wording from the footer's vendor credit and leaves the company name on its own.

Part of dataquest-dev/dspace-customers#592, following #1464 (MENDELU), #1466 (TUL) and #1467 (ZCU public).

## Before / after

| | |
| --- | --- |
| before | `Theme by` on its own line, `+ dataquest` underneath |
| after | `+ dataquest` alone |

## What changed

Three deleted lines, nothing added.

**`src/app/footer/footer.component.html`** — the `<p class="theme-by">` above the link is gone. The anchor is untouched: its `*ngVar` binding, `[href]` and `[title]` behave exactly as before, and the name still comes from the backend property `themed.by.company.name`.

**`en.json5`** — `footer.theme.by.message` removed, now unused. `cs.json5` on this branch never carried the key, so it is not touched.

No new CSS; the credit keeps the footer's existing link styling.

## Verification

This branch carries the same footer markup as `customer/zcu-pub` — the only difference is that it lives in `src/app/footer/` rather than in the theme — and the two branches share a byte-identical `yarn.lock`. The rendering was verified on #1467, screenshot there:

| | |
| --- | --- |
| rendered text | `+ dataquest` |
| `.theme-by` element | not present in the DOM |
| `href` | `https://www.dataquest.sk/dspace` |

I did not stand up a separate build for this branch. If you would rather see a screenshot from this exact branch before merging, say so and I will produce one.

## Notes for the reviewer

- The `DSpace software copyright © 2002-2026 LYRASIS` line above is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
