### PR TITLE
VSB-TUO/Reduce the footer vendor credit to the company name

### DIFF
--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -11913,6 +11913,4 @@
   // "footer.link.university": "University Library",
   "footer.link.university": "Univerzitni Knihovna",
 
-  // "footer.theme.by.message": "Theme by",
-  "footer.theme.by.message": "Theme by",
 }

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -6437,6 +6437,4 @@
   "clarin-license-agreement-page.download-error": "An error occurred while downloading the file. Please try again later.",
 
   "footer.link.university": "University Library",
-
-  "footer.theme.by.message": "Theme by",
 }

--- a/src/themes/custom/app/footer/footer.component.html
+++ b/src/themes/custom/app/footer/footer.component.html
@@ -93,7 +93,6 @@
               </ul>
             </div>
             <div class="footer-sign">
-              <p class="theme-by">{{ 'footer.theme.by.message' | translate }}</p>
               <a class="dtq-sign text-white" *ngVar="(themedByCompanyName$ | async)?.payload?.values[0] as companyName"
                  [href]="(themedByUrl$ | async)?.payload?.values[0]"
                  [title]="companyName">


### PR DESCRIPTION
Drops the `Theme by` wording from the footer's vendor credit and leaves the company name on its own.

Part of dataquest-dev/dspace-customers#592, following #1464 (MENDELU), #1466 (TUL), #1467 and #1468 (ZCU).

## Before / after

| | |
| --- | --- |
| before | `Theme by` on its own line, `+ dataquest` underneath |
| after | `+ dataquest` alone |

_Screenshots below._

## What changed

Five deleted lines, nothing added.

**`src/themes/custom/app/footer/footer.component.html`** — the `<p class="theme-by">` above the link is gone. The anchor is untouched: its `*ngVar` binding, `[href]` and `[title]` behave exactly as before, and the name still comes from `themed.by.company.name`.

**`en.json5` / `cs.json5`** — `footer.theme.by.message` removed, now unused.

No CSS is added or changed by this PR.

## How this was verified, and the one gap

Two separate checks, because neither covers everything on its own:

**1. The markup — from a production build of this branch.** Rendered against the live VSB-TUO backend:

| | |
| --- | --- |
| rendered text | `+ dataquest` |
| `.theme-by` element | not present in the DOM |
| `href` | `https://www.dataquest.sk/dspace` |
| font-size / weight | 16px / 400 — unchanged |

**2. The look — on the live dev-6 instance.** My local run renders the bar navy rather than the instance's teal, because the deployed instances load their own config from `/opt/dspace-envs/<instance>/` and I only have the repo defaults locally. So the appearance screenshot below is the live instance with `<p class="theme-by">` removed from the DOM — the same element this PR deletes — rather than a render of my build.

That split is worth stating plainly: the text and structure are proven by the build, the colours and layout by the live instance. This PR changes no CSS, so the colour is not something it can affect either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
