### PR TITLE
DSpace9/Redirect back to originating page after DiscoJuice local login

### DIFF
--- a/src/app/shared/log-in/methods/password/log-in-password.component.spec.ts
+++ b/src/app/shared/log-in/methods/password/log-in-password.component.spec.ts
@@ -164,7 +164,7 @@ describe('LogInPasswordComponent', () => {
     let setRedirectUrlSpy: jasmine.Spy;
     let setRedirectUrlIfNotSetSpy: jasmine.Spy;
 
-    const setQueryParams = (queryParams: Record<string, string>) => {
+    const setQueryParams = (queryParams: Record<string, unknown>) => {
       (component as any).route = { snapshot: { queryParams } };
     };
 
@@ -207,8 +207,25 @@ describe('LogInPasswordComponent', () => {
       expect(setRedirectUrlSpy).toHaveBeenCalledWith('/repository/items/1');
     });
 
+    it('passes through an already-relative redirectUrl unchanged', () => {
+      setQueryParams({ redirectUrl: '/repository/search' });
+
+      component.submit();
+
+      expect(setRedirectUrlSpy).toHaveBeenCalledWith('/repository/search');
+    });
+
     it('falls back to setRedirectUrlIfNotSet("/") when no redirectUrl query param is present', () => {
       setQueryParams({});
+
+      component.submit();
+
+      expect(setRedirectUrlIfNotSetSpy).toHaveBeenCalledWith('/');
+      expect(setRedirectUrlSpy).not.toHaveBeenCalled();
+    });
+
+    it('falls back cleanly when redirectUrl is not a string (repeated query param)', () => {
+      setQueryParams({ redirectUrl: ['/repository/a', '/repository/b'] });
 
       component.submit();
 

--- a/src/app/shared/log-in/methods/password/log-in-password.component.spec.ts
+++ b/src/app/shared/log-in/methods/password/log-in-password.component.spec.ts
@@ -158,6 +158,67 @@ describe('LogInPasswordComponent', () => {
     });
   });
 
+  // On the standalone login page (isStandalonePage === true) the redirect target comes from the
+  // `redirectUrl` query param that the DiscoJuice local-auth flow (aai.js) appends as the absolute
+  // page URL. Reduce it to an app-relative path so the user returns to where they logged in from.
+  describe('standalone login redirect (redirectUrl query param)', () => {
+    let authService: AuthServiceStub;
+    let setRedirectUrlSpy: jasmine.Spy;
+    let setRedirectUrlIfNotSetSpy: jasmine.Spy;
+
+    const setQueryParams = (queryParams: Record<string, string>) => {
+      (component as any).route = { snapshot: { queryParams } };
+    };
+
+    beforeEach(() => {
+      authService = TestBed.inject(AuthService) as unknown as AuthServiceStub;
+      setRedirectUrlSpy = spyOn(authService, 'setRedirectUrl').and.callThrough();
+      setRedirectUrlIfNotSetSpy = spyOn(authService, 'setRedirectUrlIfNotSet').and.callThrough();
+      // Avoid scheduling the real DiscoJuice popup timer during ngOnInit.
+      spyOn(component as any, 'popUpDiscoJuiceLogin');
+
+      fixture.detectChanges();
+      component.form.controls.email.setValue('user');
+      component.form.controls.password.setValue('password');
+    });
+
+    it('redirects back to the redirectUrl page, reduced to an app-relative path', () => {
+      setQueryParams({ redirectUrl: 'http://dev-6.pc:8603/repository/search' });
+
+      component.submit();
+
+      expect(setRedirectUrlSpy).toHaveBeenCalledWith('/repository/search');
+      expect(setRedirectUrlIfNotSetSpy).not.toHaveBeenCalled();
+    });
+
+    it('keeps the query string of the originating page', () => {
+      setQueryParams({ redirectUrl: 'http://dev-6.pc:8603/repository/search?query=test' });
+
+      component.submit();
+
+      expect(setRedirectUrlSpy).toHaveBeenCalledWith('/repository/search?query=test');
+    });
+
+    it('prefers a nested redirectUrl so the login page is not the redirect target', () => {
+      setQueryParams({
+        redirectUrl: 'http://dev-6.pc:8603/repository/login?redirectUrl=http://dev-6.pc:8603/repository/items/1',
+      });
+
+      component.submit();
+
+      expect(setRedirectUrlSpy).toHaveBeenCalledWith('/repository/items/1');
+    });
+
+    it('falls back to setRedirectUrlIfNotSet("/") when no redirectUrl query param is present', () => {
+      setQueryParams({});
+
+      component.submit();
+
+      expect(setRedirectUrlIfNotSetSpy).toHaveBeenCalledWith('/');
+      expect(setRedirectUrlSpy).not.toHaveBeenCalled();
+    });
+  });
+
 });
 
 /**

--- a/src/app/shared/log-in/methods/password/log-in-password.component.spec.ts
+++ b/src/app/shared/log-in/methods/password/log-in-password.component.spec.ts
@@ -158,9 +158,7 @@ describe('LogInPasswordComponent', () => {
     });
   });
 
-  // On the standalone login page (isStandalonePage === true) the redirect target comes from the
-  // `redirectUrl` query param that the DiscoJuice local-auth flow (aai.js) appends as the absolute
-  // page URL. Reduce it to an app-relative path so the user returns to where they logged in from.
+  // Standalone login reads the redirect target from the `redirectUrl` query param (set by aai.js).
   describe('standalone login redirect (redirectUrl query param)', () => {
     let authService: AuthServiceStub;
     let setRedirectUrlSpy: jasmine.Spy;

--- a/src/app/shared/log-in/methods/password/log-in-password.component.ts
+++ b/src/app/shared/log-in/methods/password/log-in-password.component.ts
@@ -243,9 +243,7 @@ export class LogInPasswordComponent implements OnInit, OnDestroy {
     if (!this.isStandalonePage) {
       this.authService.setRedirectUrl(this.hardRedirectService.getCurrentRoute());
     } else {
-      // On the standalone login page, honor the `redirectUrl` query param set by the DiscoJuice
-      // local-auth flow (src/aai/aai.js) so the user returns to the page they logged in from
-      // (e.g. the search page) instead of being sent to the home page.
+      // Standalone login: return to the `redirectUrl` query param set by the aai.js local-auth flow.
       const redirectUrl = this.getRedirectUrlFromQueryParams();
       if (isNotEmpty(redirectUrl)) {
         this.authService.setRedirectUrl(redirectUrl);
@@ -261,36 +259,21 @@ export class LogInPasswordComponent implements OnInit, OnDestroy {
     this.form.reset();
   }
 
-  /**
-   * Resolve the post-login redirect target from the `redirectUrl` query param on the standalone
-   * login page.
-   *
-   * The DiscoJuice local-auth flow (src/aai/aai.js) sends the user to
-   * `/login?redirectUrl=<absolute page URL>` so that after signing in they return to the page the
-   * login was initiated from. The value is lost from the auth store while passing through
-   * DiscoJuice, so it has to be read back from the URL here.
-   *
-   * @returns an app-relative path (same format as {@link HardRedirectService#getCurrentRoute}), or
-   *          `null` when there is no usable redirect target.
-   */
+  /** Post-login redirect target from the `redirectUrl` query param (aai.js), as an app-relative path or null. */
   private getRedirectUrlFromQueryParams(): string {
     const rawRedirectUrl: string = this.route.snapshot.queryParams?.redirectUrl;
     if (isEmpty(rawRedirectUrl)) {
       return null;
     }
 
-    // When the value itself carries a nested `redirectUrl` (login initiated while already on the
-    // login page), prefer that inner target so we don't redirect back to the login page.
+    // Prefer a nested `redirectUrl` so login is never the redirect target.
     const nestedRedirectUrl = new URLSearchParams(rawRedirectUrl.split('?')[1] ?? '').get('redirectUrl');
     const redirectUrl = isNotEmpty(nestedRedirectUrl) ? nestedRedirectUrl : rawRedirectUrl;
 
     return this.toRelativePath(redirectUrl);
   }
 
-  /**
-   * Reduce a possibly-absolute URL to an app-relative path (`/path?query#hash`) by dropping the
-   * origin. Values that are already relative are returned unchanged.
-   */
+  /** Reduce a possibly-absolute URL to an app-relative path (drops origin); relative values pass through. */
   private toRelativePath(url: string): string {
     if (/^https?:\/\//i.test(url)) {
       const parsed = new URL(url);

--- a/src/app/shared/log-in/methods/password/log-in-password.component.ts
+++ b/src/app/shared/log-in/methods/password/log-in-password.component.ts
@@ -17,7 +17,10 @@ import {
   UntypedFormGroup,
   Validators,
 } from '@angular/forms';
-import { RouterLink } from '@angular/router';
+import {
+  ActivatedRoute,
+  RouterLink,
+} from '@angular/router';
 import {
   select,
   Store,
@@ -145,6 +148,7 @@ export class LogInPasswordComponent implements OnInit, OnDestroy {
     @Inject('isStandalonePage') public isStandalonePage: boolean,
     private authService: AuthService,
     private hardRedirectService: HardRedirectService,
+    private route: ActivatedRoute,
     private formBuilder: UntypedFormBuilder,
     protected store: Store<CoreState>,
     protected authorizationService: AuthorizationDataService,
@@ -239,7 +243,15 @@ export class LogInPasswordComponent implements OnInit, OnDestroy {
     if (!this.isStandalonePage) {
       this.authService.setRedirectUrl(this.hardRedirectService.getCurrentRoute());
     } else {
-      this.authService.setRedirectUrlIfNotSet('/');
+      // On the standalone login page, honor the `redirectUrl` query param set by the DiscoJuice
+      // local-auth flow (src/aai/aai.js) so the user returns to the page they logged in from
+      // (e.g. the search page) instead of being sent to the home page.
+      const redirectUrl = this.getRedirectUrlFromQueryParams();
+      if (isNotEmpty(redirectUrl)) {
+        this.authService.setRedirectUrl(redirectUrl);
+      } else {
+        this.authService.setRedirectUrlIfNotSet('/');
+      }
     }
 
     // dispatch AuthenticationAction
@@ -247,6 +259,44 @@ export class LogInPasswordComponent implements OnInit, OnDestroy {
 
     // clear form
     this.form.reset();
+  }
+
+  /**
+   * Resolve the post-login redirect target from the `redirectUrl` query param on the standalone
+   * login page.
+   *
+   * The DiscoJuice local-auth flow (src/aai/aai.js) sends the user to
+   * `/login?redirectUrl=<absolute page URL>` so that after signing in they return to the page the
+   * login was initiated from. The value is lost from the auth store while passing through
+   * DiscoJuice, so it has to be read back from the URL here.
+   *
+   * @returns an app-relative path (same format as {@link HardRedirectService#getCurrentRoute}), or
+   *          `null` when there is no usable redirect target.
+   */
+  private getRedirectUrlFromQueryParams(): string {
+    const rawRedirectUrl: string = this.route.snapshot.queryParams?.redirectUrl;
+    if (isEmpty(rawRedirectUrl)) {
+      return null;
+    }
+
+    // When the value itself carries a nested `redirectUrl` (login initiated while already on the
+    // login page), prefer that inner target so we don't redirect back to the login page.
+    const nestedRedirectUrl = new URLSearchParams(rawRedirectUrl.split('?')[1] ?? '').get('redirectUrl');
+    const redirectUrl = isNotEmpty(nestedRedirectUrl) ? nestedRedirectUrl : rawRedirectUrl;
+
+    return this.toRelativePath(redirectUrl);
+  }
+
+  /**
+   * Reduce a possibly-absolute URL to an app-relative path (`/path?query#hash`) by dropping the
+   * origin. Values that are already relative are returned unchanged.
+   */
+  private toRelativePath(url: string): string {
+    if (/^https?:\/\//i.test(url)) {
+      const parsed = new URL(url);
+      return parsed.pathname + parsed.search + parsed.hash;
+    }
+    return url;
   }
 
   /**

--- a/src/app/shared/log-in/methods/password/log-in-password.component.ts
+++ b/src/app/shared/log-in/methods/password/log-in-password.component.ts
@@ -260,9 +260,10 @@ export class LogInPasswordComponent implements OnInit, OnDestroy {
   }
 
   /** Post-login redirect target from the `redirectUrl` query param (aai.js), as an app-relative path or null. */
-  private getRedirectUrlFromQueryParams(): string {
-    const rawRedirectUrl: string = this.route.snapshot.queryParams?.redirectUrl;
-    if (isEmpty(rawRedirectUrl)) {
+  private getRedirectUrlFromQueryParams(): string | null {
+    // Query params are untyped (can be a string[]); only a non-empty string is usable here.
+    const rawRedirectUrl = this.route.snapshot.queryParams?.redirectUrl;
+    if (typeof rawRedirectUrl !== 'string' || isEmpty(rawRedirectUrl)) {
       return null;
     }
 
@@ -273,13 +274,9 @@ export class LogInPasswordComponent implements OnInit, OnDestroy {
     return this.toRelativePath(redirectUrl);
   }
 
-  /** Reduce a possibly-absolute URL to an app-relative path (drops origin); relative values pass through. */
+  /** Reduce a possibly-absolute URL to an app-relative path by dropping the scheme+host; relative values pass through. */
   private toRelativePath(url: string): string {
-    if (/^https?:\/\//i.test(url)) {
-      const parsed = new URL(url);
-      return parsed.pathname + parsed.search + parsed.hash;
-    }
-    return url;
+    return url.replace(/^https?:\/\/[^/]+/i, '');
   }
 
   /**


### PR DESCRIPTION
## Problem
On CLARIN DSpace v9, logging in from a non-home page through the DiscoJuice **local authentication** flow always redirected the user to the **home page** instead of back to the page they started from. The `dspace-ui-tests` scenario **LINDAT-013** (`loginPage.spec.ts` → *login from search page should redirect back to search page*) failed because of this.

## Root cause
The DiscoJuice local-auth handler (`src/aai/aai.js`) sends the user to `/login?redirectUrl=<absolute page URL>`. On the **standalone** login page, `LogInPasswordComponent.submit()` ignored that query param and always called `setRedirectUrlIfNotSet('/')`, so the stored post-login target was the home page. (The value travels through the URL on purpose — it is lost from the auth store while passing through DiscoJuice.)

## Fix
On the standalone login page, `LogInPasswordComponent` now reads the `redirectUrl` query param and:
- reduces it to an app-relative path (`/repository/search`) — the same format `HardRedirectService.getCurrentRoute()` produces and that the existing `reloadGuard` already consumes;
- prefers a nested `redirectUrl` (login initiated from the login page) so we never redirect back to `/login`;
- falls back to the previous `setRedirectUrlIfNotSet('/')` when no `redirectUrl` is present.

Mirrors the verified dtq-dev fix `9dff6af543`, adapted to the refactored v9 component (v9 uses `HardRedirectService` instead of the v7 `baseUrl`/config lookup).

### Implementation notes
Kept the code comments terse; the detail lives here.
- `getRedirectUrlFromQueryParams()` reads `route.snapshot.queryParams.redirectUrl`. `aai.js` appends it as the **absolute** page URL (e.g. `http://host/repository/search`) — the value is dropped from the auth store while passing through DiscoJuice, so it has to be read back from the URL.
- If that value itself carries a nested `?redirectUrl=…` (login started while already on `/login`), the inner target is preferred so we never redirect back to `/login`.
- `toRelativePath()` drops the scheme+host with a string `.replace(/^https?:\/\/[^/]+/i, '')` (`http://host/repository/search` → `/repository/search`); already-relative values pass through unchanged. This is the same string-replace technique v7 uses (`redirectUrl.replace(baseUrl, '')`) — but host-agnostic, so it cannot throw and is unaffected by a misconfigured `ui.baseUrl`. The result matches the format `HardRedirectService.getCurrentRoute()` produces, which `reloadGuard` then strips to the app route.
- Query params are untyped: `getRedirectUrlFromQueryParams()` returns `string | null` and falls back to the default redirect for a missing or non-string (`string[]`) `redirectUrl`, so login submission can never break on a malformed value.

### Scope
Covers LINDAT-013 (login initiated from a public page, where `aai.js` puts the target in the URL). It does **not** port dtq-dev's `ngOnInit → setUpRedirectUrl()` re-navigation, which additionally covers the guard-initiated flow (e.g. a restricted collection bounces to `/login` with the target only in the store) through DiscoJuice. No test covers that flow; can be added on request.

## Tests
Added unit tests to `log-in-password.component.spec.ts` covering the relative-path reduction, query-string preservation, nested-`redirectUrl` handling, and the no-param fallback. `ng test` for this spec passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
