### PR TITLE
JCU/fix(ssr): return HTTP 404 for non-existent routes behind the dev-6.pc proxy

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -44,6 +44,15 @@ ssr:
     - pattern: "^/access-control/"
     - pattern: "^/health$"
 
+  # Extra hostnames allowed to be server-side rendered, on top of the hostname of ui.baseUrl
+  # (which is always allowed). Angular's SSR only renders when the request "Host" header matches
+  # an allowed host; any other host silently falls back to CSR (which always answers 200, so a
+  # "not found" page can never return a 404). When the app is served behind a reverse proxy on a
+  # hostname different from ui.baseUrl, list that hostname here. Compared by hostname only (the
+  # port is ignored). Defaults to none.
+  # allowedHosts:
+  #   - my-repository.example.com
+
   # Whether to enable rendering of Search component on SSR.
   # If set to true the component will be included in the HTML returned from the server side rendering.
   # If set to false the component will not be included in the HTML returned from the server side rendering.

--- a/config/config.yml
+++ b/config/config.yml
@@ -51,6 +51,13 @@ themes:
           href: assets/custom/images/favicons/manifest.webmanifest
 
 ssr:
+  # Hosts allowed to be server-side rendered in addition to ui.baseUrl's hostname (always allowed).
+  # The JCU test instance is served behind nginx on dev-6.pc while ui.baseUrl stays http://localhost:4000,
+  # so without dev-6.pc listed here SSR falls back to CSR for that host and "not found" pages answer 200
+  # instead of 404. Compared by hostname only (port ignored). Harmless in production, where the public
+  # hostname already matches ui.baseUrl.
+  allowedHosts:
+    - dev-6.pc
   excludePathPatterns:
     - pattern: "^/communities/[a-f0-9-]{36}/browse(/.*)?$"
       flag: "i"

--- a/server.ts
+++ b/server.ts
@@ -247,9 +247,16 @@ function ngApp(req, res, next) {
 function serverSideRender(req, res, next, sendToUser: boolean = true) {
   const { protocol, originalUrl, baseUrl, headers } = req;
   // "allowedHosts" specifies which hosts are allowed to be rendered via SSR.
-  // By default, this is set to the host of the UI's baseUrl.
+  // The host of the UI's baseUrl is always allowed; any extra hosts configured via
+  // ssr.allowedHosts are added so SSR keeps working when the app is reached through a
+  // reverse proxy on a hostname that differs from baseUrl (otherwise those requests
+  // silently fall back to CSR, which always answers 200 and can never return a 404).
+  const allowedHosts = [ ...new Set([
+    new URL(environment.ui.baseUrl).hostname,
+    ...(environment.ssr.allowedHosts ?? []),
+  ]) ];
   const commonEngine = new CommonEngine({ enablePerformanceProfiler: environment.ssr.enablePerformanceProfiler,
-                                          allowedHosts: [ new URL(environment.ui.baseUrl).hostname ],
+                                          allowedHosts,
                                         });
   // Render the page via SSR (server side rendering)
   commonEngine

--- a/src/config/ssr-config.interface.ts
+++ b/src/config/ssr-config.interface.ts
@@ -49,6 +49,18 @@ export interface SSRConfig extends Config {
   excludePathPatterns:  SsrExcludePatterns[];
 
   /**
+   * Extra hostnames that are allowed to be server-side rendered, in addition to the hostname of
+   * {@link UIServerConfig#baseUrl} (which is always allowed).
+   *
+   * Angular's SSR engine only renders a request when its `Host` header matches one of the allowed
+   * hosts; any other host silently falls back to client-side rendering (which always answers 200,
+   * so "not found" pages can never return a 404). When the app is reached through a reverse proxy
+   * on a hostname that differs from `ui.baseUrl` (e.g. a shared test box), list that hostname here
+   * so SSR keeps working. Compared by hostname only, the port is ignored. Defaults to none.
+   */
+  allowedHosts?: string[];
+
+  /**
    * Whether to enable rendering of search component on SSR
    */
   enableSearchComponent: boolean;


### PR DESCRIPTION
## Problem

`dspace-ui-tests` `tests/tests/notFoundPage.spec.ts` (**UNIVERSAL-016**) fails for JCU on the *non-existent route* scenario across chromium/firefox/webkit. `verifyNotFoundPage()` asserts the HTTP status is **404**, but on http://dev-6.pc:8593 `/route-does-not-exist-ui-test` renders the 404 page client-side while answering **HTTP 200**, failing the status assertion.

## Root cause (not a 404-component bug)

`PageNotFoundComponent` already calls `ServerResponseService.setNotFound()` and `server.ts` returns 404 correctly **when SSR runs**. SSR does not run for this host:

- `server.ts` builds the SSR engine with `allowedHosts: [ new URL(ui.baseUrl).hostname ]` (upstream-required). SSR only renders when the request `Host` matches; any other host silently falls back to `clientSideRender()`, which always answers **200**.
- The deployed `ui.baseUrl` is the DSpace default `http://localhost:4000`, but the instance is reached through nginx on `dev-6.pc`, so `dev-6.pc` ∉ `['localhost']` → CSR fallback → 200 for every path.

Proven live: spoofing `Host: localhost:4000` makes SSR return **404** for the same URL, confirming the FE code is correct and only host gating is at fault.

## Fix

Add an optional `ssr.allowedHosts` config list merged with the `ui.baseUrl` hostname when constructing the `CommonEngine`, and list `dev-6.pc` for JCU.

- `src/config/ssr-config.interface.ts` — optional `allowedHosts?: string[]`.
- `server.ts` — `allowedHosts = unique([ baseUrl hostname, ...ssr.allowedHosts ])`.
- `config/config.yml` — `ssr.allowedHosts: [dev-6.pc]`.
- `config/config.example.yml` — documented, commented-out example.

Matched by **hostname only** (port ignored). Harmless in production, where the public hostname already matches `ui.baseUrl`.

## Deploy note

Requires a frontend redeploy on dev-6.pc so the new `config.yml` + `server.ts` build take effect. After redeploy, SSR runs for `dev-6.pc` and `/route-does-not-exist-ui-test` returns 404.

## Scope

Targets the *non-existent route* test only, per request. The *non-existent static page* test is out of scope for JCU (`jcu.json` has `has_static_page: false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)