### PR TITLE
Add deployed-version info: VERSION_D at /static/VERSION_D (#813)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,9 +43,7 @@ jobs:
       - name: Checkout codebase
         uses: actions/checkout@v3
 
-      # Generate deployed-version info (git hash, commit date, build run) into a static
-      # file that the UI serves at `/static/VERSION_D` (issue #813). Must run before the
-      # Docker build so the file is included in the build context.
+      # Generate the version file before the Docker build so it is included in the image.
       - name: Add version
         run: python scripts/sourceversion.py ${{ github.server_url }}/${{ github.repository }}/actions/runs/ ${{ github.run_id }} > src/static-files/VERSION_D.html
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,6 +43,12 @@ jobs:
       - name: Checkout codebase
         uses: actions/checkout@v3
 
+      # Generate deployed-version info (git hash, commit date, build run) into a static
+      # file that the UI serves at `/static/VERSION_D` (issue #813). Must run before the
+      # Docker build so the file is included in the build context.
+      - name: Add version
+        run: python scripts/sourceversion.py ${{ github.server_url }}/${{ github.repository }}/actions/runs/ ${{ github.run_id }} > src/static-files/VERSION_D.html
+
       # https://github.com/docker/setup-buildx-action
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/angular.json
+++ b/angular.json
@@ -41,7 +41,11 @@
             "aot": true,
             "assets": [
               "src/assets",
-              "src/static-files",
+              {
+                "glob": "VERSION_D.html",
+                "input": "src/static-files",
+                "output": "static-files"
+              },
               "src/robots.txt"
             ],
             "styles": [

--- a/angular.json
+++ b/angular.json
@@ -41,6 +41,7 @@
             "aot": true,
             "assets": [
               "src/assets",
+              "src/static-files",
               "src/robots.txt"
             ],
             "styles": [

--- a/scripts/sourceversion.py
+++ b/scripts/sourceversion.py
@@ -1,0 +1,38 @@
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+# when next editing this script, please introduce argparse.
+# do not forget, it is called in BE by .github\workflows\reusable-docker-build.yml
+# argparse must be introduced there.
+# that action also calls BE version of this script, which is different (BE: scripts/sourceversion.py).
+# It must also cooperate with argparse
+
+# the idea is, that this will be different on each branch, but could be possibly passed by argv/argparse
+RELEASE_TAG_BASE='none'
+
+def get_time_in_timezone(zone: str = "Europe/Bratislava"):
+    try:
+        from zoneinfo import ZoneInfo
+        my_tz = ZoneInfo(zone)
+    except Exception as e:
+        my_tz = timezone.utc
+    return datetime.now(my_tz)
+
+
+if __name__ == '__main__':
+    ts = get_time_in_timezone()
+    # we have html tags, since this script ends up creating VERSION_D.html
+    print(f"<h4>This info was generated on: <br> <strong> {ts.strftime('%Y-%m-%d %H:%M:%S %Z%z')} </strong> </h4>")
+
+    cmd = 'git log -1 --pretty=format:"<h4>Git hash: <br><strong> %H </strong> <br> Date of commit: <br> <strong> %ai </strong></h4>"'
+    subprocess.check_call(cmd, shell=True)
+
+    # when adding argparse, this should be a bit more obvious
+    link = sys.argv[1] + sys.argv[2]
+    print('<br> <h4>Build run: </h4> <a href="' + link + '"> ' + link + '</a> ')
+
+    link = "https://github.com/dataquest-dev/dspace-angular/releases/tag/" \
+        + RELEASE_TAG_BASE + "-" + datetime.now().strftime('%Y.%m.') + sys.argv[2]
+
+    print('<br> <br> <h4>Release link: </h4><a href="' + link + '"> ' + link + '</a> (if it does not work, then this is not an official release instance) ')

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -43,6 +43,7 @@ import { ServerCheckGuard } from './core/server-check/server-check.guard';
 import { MenuResolver } from './menu.resolver';
 import { ThemedPageErrorComponent } from './page-error/themed-page-error.component';
 import { HANDLE_TABLE_MODULE_PATH } from './handle-page/handle-page-routing-paths';
+import { STATIC_PAGE_PATH } from './static-page/static-page-routing-paths';
 
 @NgModule({
   imports: [
@@ -259,6 +260,10 @@ import { HANDLE_TABLE_MODULE_PATH } from './handle-page/handle-page-routing-path
             path: HANDLE_TABLE_MODULE_PATH,
             loadChildren: () => import('./handle-page/handle-page.module').then((m) => m.HandlePageModule),
             canActivate: [SiteAdministratorGuard],
+          },
+          {
+            path: STATIC_PAGE_PATH,
+            loadChildren: () => import('./static-page/static-page.module').then((m) => m.StaticPageModule),
           },
           { path: '**', pathMatch: 'full', component: ThemedPageNotFoundComponent }
         ]

--- a/src/app/shared/html-content.service.spec.ts
+++ b/src/app/shared/html-content.service.spec.ts
@@ -1,0 +1,126 @@
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { firstValueFrom } from 'rxjs';
+
+import { HtmlContentService } from './html-content.service';
+import { LocaleService } from '../core/locale/locale.service';
+import { APP_CONFIG } from '../../config/app-config.interface';
+
+class LocaleServiceStub {
+  languageCode = 'en';
+
+  getCurrentLanguageCode(): string {
+    return this.languageCode;
+  }
+}
+
+describe('HtmlContentService', () => {
+  let service: HtmlContentService;
+  let httpMock: HttpTestingController;
+  let localeService: LocaleServiceStub;
+
+  function setup(nameSpace: string): void {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        HtmlContentService,
+        { provide: LocaleService, useClass: LocaleServiceStub },
+        {
+          provide: APP_CONFIG,
+          useValue: {
+            ui: { nameSpace },
+          },
+        },
+      ],
+    });
+
+    service = TestBed.inject(HtmlContentService);
+    httpMock = TestBed.inject(HttpTestingController);
+    localeService = TestBed.inject(LocaleService) as any;
+  }
+
+  afterEach(() => {
+    if (httpMock) {
+      httpMock.verify();
+    }
+  });
+
+  it('should request root namespaced URL for default locale', async () => {
+    setup('/');
+    localeService.languageCode = 'en';
+
+    const promise = service.getHmtlContentByPathAndLocale('license-ud-1.0');
+
+    const request = httpMock.expectOne('/static-files/license-ud-1.0.html');
+    expect(request.request.method).toBe('GET');
+    request.flush('Universal Dependencies 1.0 License Set');
+
+    const content = await promise;
+    expect(content).toBe('Universal Dependencies 1.0 License Set');
+  });
+
+  it('should request locale-specific namespaced URL for non-default locale', async () => {
+    setup('/repository');
+    localeService.languageCode = 'cs';
+
+    const promise = service.getHmtlContentByPathAndLocale('license-ud-1.0');
+
+    const request = httpMock.expectOne('/repository/static-files/cs/license-ud-1.0.html');
+    expect(request.request.method).toBe('GET');
+    request.flush('Localized content');
+
+    const content = await promise;
+    expect(content).toBe('Localized content');
+  });
+
+  it('should fallback from locale-specific to default namespaced URL when localized content is missing', fakeAsync(() => {
+    setup('/repository/');
+    localeService.languageCode = 'cs';
+
+    let content: string | undefined;
+    service.getHmtlContentByPathAndLocale('license-ud-1.0').then((result) => {
+      content = result;
+    });
+
+    const localizedRequest = httpMock.expectOne('/repository/static-files/cs/license-ud-1.0.html');
+    localizedRequest.flush('Not Found', { status: 404, statusText: 'Not Found' });
+    tick();
+
+    const fallbackRequest = httpMock.expectOne('/repository/static-files/license-ud-1.0.html');
+    fallbackRequest.flush('Fallback content');
+    tick();
+
+    expect(content).toBe('Fallback content');
+  }));
+
+  it('should fallback from locale-specific to default URL when locale returns 404', fakeAsync(() => {
+    setup('/');
+    localeService.languageCode = 'cs';
+
+    let content: string | undefined;
+    service.getHmtlContentByPathAndLocale('license').then((result) => {
+      content = result;
+    });
+
+    httpMock.expectOne('/static-files/cs/license.html')
+      .flush('Not Found', { status: 404, statusText: 'Not Found' });
+    tick();
+
+    httpMock.expectOne('/static-files/license.html').flush('<div>English Content</div>');
+    tick();
+
+    expect(content).toBe('<div>English Content</div>');
+  }));
+
+  it('should return empty string from getHtmlContent when request fails', async () => {
+    setup('/repository');
+
+    const contentPromise = firstValueFrom(service.getHtmlContent('static-files/missing-page.html'));
+
+    const request = httpMock.expectOne('/repository/static-files/missing-page.html');
+    request.flush('Not Found', { status: 404, statusText: 'Not Found' });
+
+    const content = await contentPromise;
+    expect(content).toBe('');
+  });
+});

--- a/src/app/shared/html-content.service.ts
+++ b/src/app/shared/html-content.service.ts
@@ -1,0 +1,124 @@
+import { isPlatformServer } from '@angular/common';
+import { Inject, Injectable, Optional, PLATFORM_ID } from '@angular/core';
+import { HttpClient, HttpResponse } from '@angular/common/http';
+import { catchError } from 'rxjs/operators';
+import { firstValueFrom, of as observableOf } from 'rxjs';
+import { HTML_SUFFIX, STATIC_FILES_PROJECT_PATH } from '../static-page/static-page-routing-paths';
+import { isEmpty } from './empty.util';
+import { LocaleService } from '../core/locale/locale.service';
+import { APP_CONFIG, AppConfig } from '../../config/app-config.interface';
+import { REQUEST } from '@nguniversal/express-engine/tokens';
+
+/**
+ * Service for loading static `.html` files stored in the `/static-files` folder.
+ */
+@Injectable()
+export class HtmlContentService {
+  constructor(private http: HttpClient,
+              private localeService: LocaleService,
+              @Inject(APP_CONFIG) protected appConfig?: AppConfig,
+              @Inject(PLATFORM_ID) private platformId?: object,
+              @Optional() @Inject(REQUEST) private request?: any,
+            ) {}
+
+  private getNamespacePrefix(): string {
+    const nameSpace = this.appConfig?.ui?.nameSpace ?? '/';
+    if (nameSpace === '/') {
+      return '';
+    }
+    return nameSpace.endsWith('/') ? nameSpace.slice(0, -1) : nameSpace;
+  }
+
+  private composeNamespacedUrl(url: string): string {
+    if (/^https?:\/\//i.test(url)) {
+      return url;
+    }
+
+    const normalizedPath = url.startsWith('/') ? url : `/${url}`;
+    const namespacePrefix = this.getNamespacePrefix();
+
+    if (namespacePrefix && normalizedPath.startsWith(`${namespacePrefix}/`)) {
+      return normalizedPath;
+    }
+
+    return `${namespacePrefix}${normalizedPath}`;
+  }
+
+  private buildRuntimeUrl(path: string): string {
+    if (!isPlatformServer(this.platformId) || !this.request) {
+      return path;
+    }
+
+    const protocol = this.request.protocol;
+    const host = this.request.get?.('host');
+    if (!protocol || !host) {
+      return path;
+    }
+
+    return `${protocol}://${host}${path}`;
+  }
+
+  getHtmlContent(url: string) {
+    const namespacedUrl = this.composeNamespacedUrl(url);
+    const runtimeUrl = this.buildRuntimeUrl(namespacedUrl);
+    return this.http.get(runtimeUrl, { responseType: 'text' }).pipe(
+      catchError(() => observableOf('')));
+  }
+
+  /**
+   * Load `.html` file content and return the full response.
+   * @param url file location
+   */
+  fetchHtmlContent(url: string) {
+    const namespacedUrl = this.composeNamespacedUrl(url);
+    const runtimeUrl = this.buildRuntimeUrl(namespacedUrl);
+    return this.http.get(runtimeUrl, { responseType: 'text', observe: 'response' }).pipe(
+      catchError((error) => observableOf(new HttpResponse({ status: error.status || 0, body: '' }))));
+  }
+
+  /**
+   * Load HTML content for a single URL attempt and handle cached 304 responses.
+   * @param url file location
+   */
+  private async loadHtmlContent(url: string): Promise<string | undefined> {
+    const response = await firstValueFrom(this.fetchHtmlContent(url));
+    if (response.status === 200) {
+      return response.body ?? '';
+    }
+    if (response.status === 304) {
+      return response.body ?? '';
+    }
+    return undefined;
+  }
+
+  /**
+   * Get the html file content as a string by the file name and the current locale.
+   */
+  async getHmtlContentByPathAndLocale(fileName: string) {
+    let url = '';
+    // Get current language
+    let language = this.localeService.getCurrentLanguageCode();
+    // If language is default = `en` do not load static files from translated package e.g. `cs`.
+    language = language === 'en' ? '' : language;
+
+    // Try to find the html file in the translated package. `static-files/language_code/some_file.html`
+    // Compose url
+    url = STATIC_FILES_PROJECT_PATH;
+    url += isEmpty(language) ? '/' + fileName : '/' + language + '/' + fileName;
+    // Add `.html` suffix to get the current html file
+    url = url.endsWith(HTML_SUFFIX) ? url : url + HTML_SUFFIX;
+    let potentialContent = await this.loadHtmlContent(url);
+    if (potentialContent !== undefined) {
+      return potentialContent;
+    }
+
+    // If the file wasn't find, get the non-translated file from the default package.
+    url = STATIC_FILES_PROJECT_PATH + '/' + fileName;
+    // Add `.html` suffix to match localized request behavior
+    url = url.endsWith(HTML_SUFFIX) ? url : url + HTML_SUFFIX;
+    potentialContent = await this.loadHtmlContent(url);
+    if (potentialContent !== undefined) {
+      return potentialContent;
+    }
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -250,6 +250,7 @@ import {
   ItemPageTitleFieldComponent
 } from '../item-page/simple/field-components/specific-field/title/item-page-title-field.component';
 import { MarkdownPipe } from './utils/markdown.pipe';
+import { ClarinSafeHtmlPipe } from './utils/clarin-safehtml.pipe';
 import { GoogleRecaptchaModule } from '../core/google-recaptcha/google-recaptcha.module';
 import { MenuModule } from './menu/menu.module';
 import {
@@ -318,7 +319,8 @@ const PIPES = [
   ClarinLicenseCheckedPipe,
   ClarinLicenseLabelRadioValuePipe,
   ClarinLicenseRequiredInfoPipe,
-  CharToEndPipe
+  CharToEndPipe,
+  ClarinSafeHtmlPipe
 ];
 
 const COMPONENTS = [

--- a/src/app/shared/utils/clarin-safehtml.pipe.ts
+++ b/src/app/shared/utils/clarin-safehtml.pipe.ts
@@ -1,0 +1,15 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+
+/**
+ * Pipe to keep html tags e.g., `id` in the `innerHTML` attribute.
+ */
+@Pipe({
+  name: 'dsSafeHtml'
+})
+export class ClarinSafeHtmlPipe implements PipeTransform {
+  constructor(private sanitized: DomSanitizer) {}
+  transform(htmlString: string): SafeHtml {
+    return this.sanitized.bypassSecurityTrustHtml(htmlString);
+  }
+}

--- a/src/app/static-page/static-page-routing-paths.ts
+++ b/src/app/static-page/static-page-routing-paths.ts
@@ -1,0 +1,7 @@
+/**
+ * Constants for `/static` route.
+ */
+export const STATIC_PAGE_PATH = 'static';
+export const STATIC_FILES_PROJECT_PATH = 'static-files';
+export const HTML_SUFFIX = '.html';
+export const STATIC_FILES_DEFAULT_ERROR_PAGE_PATH = STATIC_FILES_PROJECT_PATH + '/' + 'error.html';

--- a/src/app/static-page/static-page-routing.module.ts
+++ b/src/app/static-page/static-page-routing.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { StaticPageComponent } from './static-page.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    children: [
+      { path: '', component: StaticPageComponent },
+      { path: ':htmlFileName', component: StaticPageComponent },
+    ],
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class StaticPageRoutingModule { }

--- a/src/app/static-page/static-page.component.html
+++ b/src/app/static-page/static-page.component.html
@@ -1,0 +1,20 @@
+<div class="container text-center my-5" *ngIf="contentState === 'loading'">
+  <ds-themed-loading [spinner]="true" [showMessage]="false"></ds-themed-loading>
+</div>
+
+<!-- Show static page content when found -->
+<div class="container" *ngIf="contentState === 'found'">
+  <div [innerHTML]="(htmlContent | async) | dsSafeHtml" (click)="processLinks($event)"></div>
+</div>
+
+<!-- Show 404 error when content not found (matches PageNotFoundComponent design) -->
+<div class="container page-not-found" *ngIf="contentState === 'not-found' && !(htmlContent | async)">
+  <h1>404</h1>
+  <h2><small>{{"static-page.404.page-not-found" | translate}}</small></h2>
+  <br/>
+  <p>{{"static-page.404.help" | translate}}</p>
+  <br/>
+  <p class="text-center">
+    <a routerLink="/home" class="btn btn-primary">{{"static-page.404.link.home-page" | translate}}</a>
+  </p>
+</div>

--- a/src/app/static-page/static-page.component.scss
+++ b/src/app/static-page/static-page.component.scss
@@ -1,0 +1,3 @@
+/**
+File for styling the `static-page` component.
+ */

--- a/src/app/static-page/static-page.component.spec.ts
+++ b/src/app/static-page/static-page.component.spec.ts
@@ -1,0 +1,295 @@
+import { TestBed } from '@angular/core/testing';
+
+import { StaticPageComponent } from './static-page.component';
+import { HtmlContentService } from '../shared/html-content.service';
+import { Router } from '@angular/router';
+import { RouterMock } from '../shared/mocks/router.mock';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { APP_CONFIG } from '../../config/app-config.interface';
+import { environment } from '../../environments/environment';
+import { ClarinSafeHtmlPipe } from '../shared/utils/clarin-safehtml.pipe';
+import { ServerResponseService } from '../core/services/server-response.service';
+
+describe('StaticPageComponent', () => {
+  function createDeferred<T>() {
+    let resolve: (value: T) => void;
+    let reject: (reason?: any) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve: resolve!, reject: reject! };
+  }
+
+  async function setupTest(
+    html: string | undefined,
+    restBase?: string,
+    contentPromise?: Promise<string | undefined>,
+    route: string = '/static/test-file.html'
+  ) {
+    const htmlContentService = jasmine.createSpyObj('htmlContentService', {
+      fetchHtmlContent: of(html),
+      getHmtlContentByPathAndLocale: contentPromise ?? Promise.resolve(html)
+    });
+
+    const responseService = jasmine.createSpyObj('responseService', {
+      setNotFound: null
+    });
+
+    const router = new RouterMock();
+    router.setRoute(route);
+
+    const appConfig = {
+      ...environment,
+      ui: {
+        ...(environment as any).ui,
+        nameSpace: '/testNamespace'
+      },
+      rest: {
+        ...(environment as any).rest,
+        baseUrl: restBase
+      }
+    };
+
+    await TestBed.configureTestingModule({
+      declarations: [ StaticPageComponent, ClarinSafeHtmlPipe ],
+      imports: [
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        { provide: HtmlContentService, useValue: htmlContentService },
+        { provide: Router, useValue: router },
+        { provide: ServerResponseService, useValue: responseService },
+        { provide: APP_CONFIG, useValue: appConfig }
+      ]
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(StaticPageComponent);
+    const component = fixture.componentInstance;
+    return { fixture, component, htmlContentService, responseService };
+  }
+
+  function createLinkEvent(href: string, useNestedTarget = false): Event {
+    const anchor = document.createElement('a');
+    anchor.setAttribute('href', href);
+
+    let target: EventTarget = anchor;
+    if (useNestedTarget) {
+      const nestedElement = document.createElement('span');
+      anchor.appendChild(nestedElement);
+      target = nestedElement;
+    }
+
+    return {
+      target,
+      preventDefault: jasmine.createSpy('preventDefault')
+    } as unknown as Event;
+  }
+
+  it('should create', async () => {
+    const { component } = await setupTest('<div>test</div>');
+    expect(component).toBeTruthy();
+  });
+
+  it('should load html file content', async () => {
+    const { component } = await setupTest('<div id="idShouldNotBeRemoved">TEST MESSAGE</div>');
+    await component.ngOnInit();
+    expect(component.htmlContent.value).toBe('<div id="idShouldNotBeRemoved">TEST MESSAGE</div>');
+  });
+
+  it('should call HtmlContentService with the route html file name', async () => {
+    const { component, htmlContentService } = await setupTest('<div>TEST MESSAGE</div>', undefined, undefined, '/static/license-ud-1.0.html');
+    await component.ngOnInit();
+
+    expect(htmlContentService.getHmtlContentByPathAndLocale).toHaveBeenCalledWith('license-ud-1.0.html');
+  });
+
+  it('should rewrite OAI link with rest.baseUrl', async () => {
+    const oaiHtml = '<a href="/server/oai/request?verb=ListSets">OAI</a>';
+    const { fixture, component } = await setupTest(oaiHtml, 'https://api.example.org/server');
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const rewritten = 'https://api.example.org/server/oai/request?verb=ListSets';
+    expect(component.htmlContent.value).toContain(rewritten);
+    const anchor = fixture.nativeElement.querySelector('a');
+    expect(anchor.getAttribute('href')).toBe(rewritten);
+  });
+
+  it('should leave OAI link unchanged when rest.baseUrl is missing', async () => {
+    const oaiHtml = '<a href="/server/oai/request?verb=Identify">OAI</a>';
+    const { fixture, component } = await setupTest(oaiHtml, undefined);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.htmlContent.value).toContain('/server/oai/request?verb=Identify');
+  });
+
+  it('should avoid double slashes when rest.baseUrl ends with slash', async () => {
+    const oaiHtml = '<a href="/server/oai/request?verb=ListRecords">OAI</a>';
+    const { fixture, component } = await setupTest(oaiHtml, 'https://api.example.org/server/');
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.htmlContent.value).toContain('https://api.example.org/server/oai/request?verb=ListRecords');
+    expect(component.htmlContent.value).not.toContain('//oai');
+  });
+
+  it('should include namespace in OAI link when rest.baseUrl has namespace prefix', async () => {
+    const oaiHtml = '<a href="/server/oai/request?verb=ListMetadataFormats">full list</a>';
+    const { fixture, component } = await setupTest(oaiHtml, 'https://api.example.org/repository/server');
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const rewritten = 'https://api.example.org/repository/server/oai/request?verb=ListMetadataFormats';
+    expect(component.htmlContent.value).toContain(rewritten);
+    const anchor = fixture.nativeElement.querySelector('a');
+    expect(anchor.getAttribute('href')).toBe(rewritten);
+  });
+
+  it('should leave content unchanged when no OAI link is present', async () => {
+    const otherHtml = '<a href="/server/other">Other</a>';
+    const { fixture, component } = await setupTest(otherHtml, 'https://api.example.org/server');
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.htmlContent.value).toBe(otherHtml);
+  });
+
+  describe('contentState behavior', () => {
+    it('should initialize contentState to "loading"', async () => {
+      const { component } = await setupTest('<div>test</div>');
+      expect(component.contentState).toBe('loading');
+    });
+
+    it('should set contentState to "found" when content loads successfully', async () => {
+      const { component } = await setupTest('<div>Test Content</div>');
+      await component.ngOnInit();
+      expect(component.contentState).toBe('found');
+    });
+
+    it('should set contentState to "not-found" when content is undefined', async () => {
+      const { component, responseService } = await setupTest(undefined);
+
+      await component.ngOnInit();
+
+      expect(component.contentState).toBe('not-found');
+      expect(responseService.setNotFound).toHaveBeenCalled();
+    });
+
+    it('should keep loading state and not render 404 before content promise resolves', async () => {
+      const deferred = createDeferred<string | undefined>();
+      const { fixture, component } = await setupTest(undefined, undefined, deferred.promise);
+
+      const initPromise = component.ngOnInit();
+      fixture.detectChanges();
+
+      expect(component.contentState).toBe('loading');
+      expect(component.htmlContent.value).toBe('');
+      expect(fixture.nativeElement.querySelector('.page-not-found')).toBeNull();
+
+      deferred.resolve('<div>Loaded later</div>');
+      await initPromise;
+      fixture.detectChanges();
+
+      expect(component.contentState).toBe('found');
+      expect(fixture.nativeElement.querySelector('.page-not-found')).toBeNull();
+    });
+
+    it('should reset stale not-found state to loading on init', async () => {
+      const deferred = createDeferred<string | undefined>();
+      const { component } = await setupTest(undefined, undefined, deferred.promise);
+
+      component.contentState = 'not-found';
+      component.htmlContent.next('<div>stale</div>');
+
+      const initPromise = component.ngOnInit();
+
+      expect(component.contentState).toBe('loading');
+      expect(component.htmlContent.value).toBe('');
+
+      deferred.resolve('<div>fresh</div>');
+      await initPromise;
+
+      expect(component.contentState).toBe('found');
+    });
+  });
+
+  describe('change detection', () => {
+    it('should call changeDetector.detectChanges() after successful content load', async () => {
+      const { component } = await setupTest('<div>test</div>');
+      spyOn((component as any).changeDetector, 'detectChanges');
+
+      await component.ngOnInit();
+
+      expect((component as any).changeDetector.detectChanges).toHaveBeenCalled();
+    });
+
+    it('should call changeDetector.detectChanges() when content not found', async () => {
+      const { component } = await setupTest(undefined);
+
+      spyOn((component as any).changeDetector, 'detectChanges');
+
+      await component.ngOnInit();
+
+      expect((component as any).changeDetector.detectChanges).toHaveBeenCalled();
+    });
+  });
+
+  describe('link handling', () => {
+    it('should intercept and navigate dot-relative links under the static route', async () => {
+      const { component } = await setupTest('<div>test</div>');
+      const navigateTo = spyOn<any>(component, 'navigateTo');
+      const event = createLinkEvent('./cite');
+
+      component.processLinks(event);
+
+      expect((event.preventDefault as jasmine.Spy)).toHaveBeenCalled();
+      expect(navigateTo).toHaveBeenCalledWith(`${window.location.origin}/testNamespace/static/cite`);
+    });
+
+    it('should resolve nested relative-link clicks inside anchors', async () => {
+      const { component } = await setupTest('<div>test</div>');
+      const navigateTo = spyOn<any>(component, 'navigateTo');
+      const event = createLinkEvent('../discover?query=test', true);
+
+      component.processLinks(event);
+
+      expect((event.preventDefault as jasmine.Spy)).toHaveBeenCalled();
+      expect(navigateTo).toHaveBeenCalledWith(`${window.location.origin}/testNamespace/discover?query=test`);
+    });
+
+    it('should not intercept explicit app-route links', async () => {
+      const { component } = await setupTest('<div>test</div>');
+      const navigateTo = spyOn<any>(component, 'navigateTo');
+      const event = createLinkEvent('contract');
+
+      component.processLinks(event);
+
+      expect((event.preventDefault as jasmine.Spy)).not.toHaveBeenCalled();
+      expect(navigateTo).not.toHaveBeenCalled();
+    });
+
+    it('should not intercept fragment links', async () => {
+      const { component } = await setupTest('<div>test</div>');
+      const navigateTo = spyOn<any>(component, 'navigateTo');
+      const event = createLinkEvent('#about-contracts');
+
+      component.processLinks(event);
+
+      expect((event.preventDefault as jasmine.Spy)).not.toHaveBeenCalled();
+      expect(navigateTo).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/static-page/static-page.component.ts
+++ b/src/app/static-page/static-page.component.ts
@@ -1,0 +1,131 @@
+import { ChangeDetectorRef, Component, Inject, OnInit } from '@angular/core';
+import { HtmlContentService } from '../shared/html-content.service';
+import { BehaviorSubject } from 'rxjs';
+import { Router } from '@angular/router';
+import { isEmpty } from '../shared/empty.util';
+import { STATIC_PAGE_PATH } from './static-page-routing-paths';
+import { APP_CONFIG, AppConfig } from '../../config/app-config.interface';
+import { ServerResponseService } from '../core/services/server-response.service';
+
+/**
+ * Component which load and show static files from the `static-files` folder.
+ * E.g., `<UI_URL>/static/test_file.html will load the file content from the `static-files/test_file.html`/
+ */
+@Component({
+  selector: 'ds-static-page',
+  templateUrl: './static-page.component.html',
+  styleUrls: ['./static-page.component.scss']
+})
+export class StaticPageComponent implements OnInit {
+  htmlContent: BehaviorSubject<string> = new BehaviorSubject<string>('');
+  htmlFileName: string;
+  contentState: 'loading' | 'found' | 'not-found' = 'loading';
+
+  constructor(private htmlContentService: HtmlContentService,
+              private router: Router,
+              private responseService: ServerResponseService,
+              private changeDetector: ChangeDetectorRef,
+              @Inject(APP_CONFIG) protected appConfig?: AppConfig) { }
+
+  async ngOnInit(): Promise<void> {
+    try {
+      this.contentState = 'loading';
+      this.htmlContent.next('');
+
+      // Fetch html file name from the url path. `static/some_file.html`
+      this.htmlFileName = this.getHtmlFileName();
+
+      let htmlContent = await this.htmlContentService.getHmtlContentByPathAndLocale(this.htmlFileName);
+      if (htmlContent !== undefined) {
+        const restBase = this.appConfig?.rest?.baseUrl;
+        const oaiUrl = restBase ? restBase.replace(/\/+$/, '') + '/oai' : '/server/oai';
+        htmlContent = htmlContent.replace(/href="\/server\/oai/gi, 'href="' + oaiUrl);
+
+        this.htmlContent.next(htmlContent);
+        this.contentState = 'found';
+        this.changeDetector.detectChanges();
+        return;
+      }
+
+      // Content not found - set 404 status for SSR and show inline error
+      this.responseService.setNotFound();
+      this.contentState = 'not-found';
+      this.changeDetector.detectChanges();
+    } catch (error) {
+      console.error('Static page load error:', {
+        fileName: this.htmlFileName,
+        url: this.router.url,
+        error: error
+      });
+      this.responseService.setNotFound();
+      this.contentState = 'not-found';
+      this.changeDetector.detectChanges();
+    }
+  }
+
+  /**
+   * Handle click on links in the static page.
+   * @param event
+   */
+  processLinks(event: Event): void {
+    const targetElement = event.target as HTMLElement | null;
+    const anchorElement = targetElement?.closest?.('a');
+    if (!anchorElement) {
+      return;
+    }
+
+    const href = anchorElement.getAttribute('href');
+    if (!href || !this.isRelativeLink(href)) {
+      return;
+    }
+
+    event.preventDefault();
+    const namespacePrefix = this.getNamespacePrefix();
+    const staticPageBaseUrl = this.composeStaticPageBaseUrl(namespacePrefix);
+    this.redirectToRelativeLink(staticPageBaseUrl, href);
+  }
+
+  private getNamespacePrefix(): string {
+    const nameSpace = this.appConfig?.ui?.nameSpace ?? '/';
+    return nameSpace === '/' ? '' : nameSpace.replace(/\/$/, '');
+  }
+
+  private composeUrl(pathname: string): string {
+    const baseUrl = new URL(window.location.origin);
+    baseUrl.pathname = pathname;
+    return baseUrl.href;
+  }
+
+  private composeStaticPageBaseUrl(namespacePrefix: string): string {
+    return this.composeUrl(`${namespacePrefix}/${STATIC_PAGE_PATH}/`);
+  }
+
+  private isRelativeLink(href: string | null): boolean {
+    return href?.startsWith('.') ?? false;
+  }
+
+  private redirectToRelativeLink(redirectUrl: string, href: string | null): void {
+    this.navigateTo(new URL(href, redirectUrl).href);
+  }
+
+  private navigateTo(url: string): void {
+    window.location.href = url;
+  }
+
+  /**
+   * Load file name from the URL - `static/FILE_NAME.html`
+   * @private
+   */
+  private getHtmlFileName() {
+    let urlInList = this.router.url?.split('/');
+    // Filter empty elements
+    urlInList = urlInList.filter(n => n);
+    // if length is 1 - html file name wasn't defined.
+    if (isEmpty(urlInList) || urlInList.length === 1) {
+      return null;
+    }
+
+    // If the url is too long take just the first string after `/static` prefix.
+    return urlInList[1]?.split('#')?.[0];
+  }
+}

--- a/src/app/static-page/static-page.module.ts
+++ b/src/app/static-page/static-page.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { StaticPageRoutingModule } from './static-page-routing.module';
+import { StaticPageComponent } from './static-page.component';
+import { SharedModule } from '../shared/shared.module';
+
+
+@NgModule({
+  declarations: [
+    StaticPageComponent
+  ],
+    imports: [
+        CommonModule,
+        StaticPageRoutingModule,
+        SharedModule,
+    ]
+})
+export class StaticPageModule { }

--- a/src/assets/i18n/cs.json5
+++ b/src/assets/i18n/cs.json5
@@ -7204,6 +7204,15 @@
   // "sorting.lastModified.DESC" : "Last modified Descending"
   "sorting.lastModified.DESC" : "Poslední změna sestupně",
 
+  // "static-page.404.help" : "The static page you requested does not exist. It may have been moved or deleted. You can use the button below to get back to the home page."
+  "static-page.404.help" : "Požadovaná statická stránka neexistuje. Mohla být přesunuta nebo smazána. Pomocí níže uvedeného tlačítka se můžete vrátit na domovskou stránku.",
+
+  // "static-page.404.link.home-page" : "Take me to the home page"
+  "static-page.404.link.home-page" : "Návrat na domovskou stránku",
+
+  // "static-page.404.page-not-found" : "page not found"
+  "static-page.404.page-not-found" : "stránka nebyla nalezena",
+
   // "statistics.title" : "Statistics"
   "statistics.title" : "Statistiky",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -4443,6 +4443,13 @@
   "sorting.lastModified.DESC": "Last modified Descending",
 
 
+  "static-page.404.help": "The static page you requested does not exist. It may have been moved or deleted. You can use the button below to get back to the home page.",
+
+  "static-page.404.link.home-page": "Take me to the home page",
+
+  "static-page.404.page-not-found": "page not found",
+
+
   "statistics.title": "Statistics",
 
   "statistics.header": "Statistics for {{ scope }}",

--- a/src/static-files/VERSION_D.html
+++ b/src/static-files/VERSION_D.html
@@ -1,0 +1,7 @@
+<!--
+  Placeholder for the deployed-version info (issue #813).
+  This file is regenerated at Docker/CI build time by scripts/sourceversion.py
+  and served at /static/VERSION_D. The committed placeholder only ensures the
+  src/static-files directory exists so the build-time redirection and the
+  angular.json asset copy succeed.
+-->

--- a/src/static-files/VERSION_D.html
+++ b/src/static-files/VERSION_D.html
@@ -1,7 +1,1 @@
-<!--
-  Placeholder for the deployed-version info (issue #813).
-  This file is regenerated at Docker/CI build time by scripts/sourceversion.py
-  and served at /static/VERSION_D. The committed placeholder only ensures the
-  src/static-files directory exists so the build-time redirection and the
-  angular.json asset copy succeed.
--->
+<!-- Regenerated at build time by scripts/sourceversion.py and served at /static/VERSION_D. -->


### PR DESCRIPTION
## What & why (issue #813)

Every customer should be able to see **which commit is currently deployed** (served at `/static/VERSION_D`, as on `dtq-dev`). This branch had none of the mechanism, so the full feature is ported from `dtq-dev`.

## Changes

- `scripts/sourceversion.py` — generates `src/static-files/VERSION_D.html` (git hash, commit date, build-run + release links) at Docker build time.
- `.github/workflows/docker.yml` — new **Add version** step runs the script before the image build.
- `src/app/static-page/*` + `src/app/shared/html-content.service.ts` — static-page module that renders `/static/<name>` from `static-files/<name>.html`.
- `src/app/shared/utils/clarin-safehtml.pipe.ts` — `dsSafeHtml` pipe (required by the template) registered in `SharedModule`.
- `angular.json` — register `src/static-files` build asset.
- `src/app/app-routing.module.ts` — register the `/static` route.
- `en/cs` i18n — `static-page.404.*` strings.

## Verification

- `ng build` compiles; `dist/browser/static-files/VERSION_D.html` is produced.
- `/static/VERSION_D` renders the deployed-commit info.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
