### PR TITLE
Clarin9/Restrict main search page to items only

### DIFF
--- a/src/app/search-page/search-page.component.html
+++ b/src/app/search-page/search-page.component.html
@@ -1,1 +1,1 @@
-<ds-search [showCsvExport]="true" [trackStatistics]="true"></ds-search>
+<ds-search [showCsvExport]="true" [trackStatistics]="true" [forcedDsoTypes]="forcedDsoTypes"></ds-search>

--- a/src/app/search-page/search-page.component.ts
+++ b/src/app/search-page/search-page.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 
+import { DSpaceObjectType } from '../core/shared/dspace-object-type.model';
 import { SearchConfigurationService } from '../core/shared/search/search-configuration.service';
 import { SEARCH_CONFIG_SERVICE } from '../my-dspace-page/my-dspace-configuration.service';
 import { ThemedSearchComponent } from '../shared/search/themed-search.component';
@@ -22,4 +23,6 @@ import { ThemedSearchComponent } from '../shared/search/themed-search.component'
  * It renders search results depending on the current search options
  */
 export class SearchPageComponent {
+  /** Restrict the search page to items only (hides community/collection results); empty = all types. */
+  forcedDsoTypes: DSpaceObjectType[] = [DSpaceObjectType.ITEM];
 }

--- a/src/app/shared/search/search.component.spec.ts
+++ b/src/app/shared/search/search.component.spec.ts
@@ -39,6 +39,7 @@ import { CommunityDataService } from '../../core/data/community-data.service';
 import { RemoteData } from '../../core/data/remote-data';
 import { RouteService } from '../../core/services/route.service';
 import { DSpaceObject } from '../../core/shared/dspace-object.model';
+import { DSpaceObjectType } from '../../core/shared/dspace-object-type.model';
 import { Item } from '../../core/shared/item.model';
 import { SearchService } from '../../core/shared/search/search.service';
 import { SearchConfigurationService } from '../../core/shared/search/search-configuration.service';
@@ -314,6 +315,16 @@ describe('SearchComponent', () => {
       b: expectedSearchOptions,
     }));
     expect((comp as any).retrieveSearchResults).toHaveBeenCalledWith(expectedSearchOptions);
+  }));
+
+  it('should force the configured dsoTypes onto the search options when forcedDsoTypes is set', fakeAsync(() => {
+    const retrieveSpy = spyOn((comp as any), 'retrieveSearchResults').and.callThrough();
+    comp.forcedDsoTypes = [DSpaceObjectType.ITEM];
+    fixture.detectChanges();
+    tick(100);
+
+    const usedOptions = retrieveSpy.calls.mostRecent().args[0] as PaginatedSearchOptions;
+    expect(usedOptions.dsoTypes).toEqual([DSpaceObjectType.ITEM]);
   }));
 
   it('should retrieve SearchResults', fakeAsync(() => {

--- a/src/app/shared/search/search.component.ts
+++ b/src/app/shared/search/search.component.ts
@@ -47,6 +47,7 @@ import { RemoteData } from '../../core/data/remote-data';
 import { RouteService } from '../../core/services/route.service';
 import { Context } from '../../core/shared/context.model';
 import { DSpaceObject } from '../../core/shared/dspace-object.model';
+import { DSpaceObjectType } from '../../core/shared/dspace-object-type.model';
 import { Item } from '../../core/shared/item.model';
 import { getFirstCompletedRemoteData } from '../../core/shared/operators';
 import { SearchService } from '../../core/shared/search/search.service';
@@ -242,6 +243,9 @@ export class SearchComponent implements OnDestroy, OnInit {
    */
   @Input() renderOnServerSide: boolean;
 
+  /** Restrict results to these DSpaceObject types (e.g. items only); empty = all types. */
+  @Input() forcedDsoTypes: DSpaceObjectType[] = [];
+
   /**
    * The current configuration used during the search
    */
@@ -430,6 +434,10 @@ export class SearchComponent implements OnDestroy, OnInit {
       }
       if (isEmpty(combinedOptions.scope)) {
         combinedOptions.scope = scope;
+      }
+      // Force the configured result types (e.g. items only) when no explicit dsoTypes are set.
+      if (isNotEmpty(this.forcedDsoTypes) && isEmpty(combinedOptions.dsoTypes)) {
+        combinedOptions.dsoTypes = [...this.forcedDsoTypes];
       }
       const newSearchOptions = new PaginatedSearchOptions(combinedOptions);
       // check if search options are changed

--- a/src/app/shared/search/themed-search.component.ts
+++ b/src/app/shared/search/themed-search.component.ts
@@ -7,6 +7,7 @@ import {
 
 import { Context } from '../../core/shared/context.model';
 import { DSpaceObject } from '../../core/shared/dspace-object.model';
+import { DSpaceObjectType } from '../../core/shared/dspace-object-type.model';
 import { ViewMode } from '../../core/shared/view-mode.model';
 import { CollectionElementLinkType } from '../object-collection/collection-element-link.type';
 import { ListableObject } from '../object-collection/shared/listable-object.model';
@@ -51,6 +52,7 @@ export class ThemedSearchComponent extends ThemedComponent<SearchComponent> {
     'query',
     'scope',
     'hideScopeInUrl',
+    'forcedDsoTypes',
     'resultFound',
     'deselectObject',
     'selectObject',
@@ -105,6 +107,8 @@ export class ThemedSearchComponent extends ThemedComponent<SearchComponent> {
   @Input() scope: string;
 
   @Input() hideScopeInUrl: boolean;
+
+  @Input() forcedDsoTypes: DSpaceObjectType[];
 
   @Output() resultFound: EventEmitter<SearchObjects<DSpaceObject>> = new EventEmitter();
 


### PR DESCRIPTION
## Problem

On the main **/search** page the result list shows **all** DSpace object types — items, collections and communities — because the backend `default` discovery configuration indexes all of them. In v7 only **items** were shown on the search page.

Verified against the live v9 dev backend (dev-6):
- `configuration=default` → **2373** results
- `configuration=default&dsoType=item` → **2348** results (25 collections/communities filtered out)

## Fix (frontend only)

Add a reusable `forcedDsoTypes` input to the (themed) `SearchComponent`. When set, those `DSpaceObjectType`s are forced onto every search request the component makes (they map to `dsoType=` query params on the REST `discover/search/objects` call), regardless of the discovery configuration.

The main search page sets it to **items only**, so community/collection results are hidden from `/search`. Facets/filters are driven by the discovery configuration and are left untouched, as are all other search surfaces (MyDSpace, admin search, browse, scoped configuration searches).

## Why this shape

- **Reusable, not hard-coded deep in the pipeline** — any search surface can opt in, and it can later back a facet or a config toggle with almost no extra work.
- **Easy to revert / adjust** — clearing `SearchPageComponent.forcedDsoTypes` restores the previous "all types" behaviour.
- The force applies only when the request carries no explicit `dsoTypes` array; a caller that sets its own types is left untouched.

## Changes

- `shared/search/search.component.ts` — new `@Input() forcedDsoTypes`; injected into the combined search options (so results **and** CSV export stay consistent).
- `shared/search/themed-search.component.ts` — thread the input through the themed wrapper.
- `search-page/search-page.component.{ts,html}` — set `forcedDsoTypes = [ITEM]` on the main search page (shared by base + custom theme).
- `shared/search/search.component.spec.ts` — test that the configured types are applied.

## Testing

- `tsc -p tsconfig.app.json --noEmit` passes.
- Added unit test covering the forced-types injection.
- Backend behaviour confirmed live via the REST `dsoType` filter (counts above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

