### PR TITLE
Clarin9/Save submission immediately when a type/sponsor/author field changes

### DIFF
--- a/src/app/shared/form/builder/form-builder.service.ts
+++ b/src/app/shared/form/builder/form-builder.service.ts
@@ -708,4 +708,9 @@ export class FormBuilderService extends DynamicFormService {
     return this.getDefaultTypeBindModelId();
   }
 
+  /** Type-bind controlling fields (underscore notation, e.g. `dc_type`, `edm_type`) from `submit.type-bind.field`. */
+  getTypeFieldValues(): string[] {
+    return Array.from(this.typeFields.values());
+  }
+
 }

--- a/src/app/shared/mocks/form-builder-service.mock.ts
+++ b/src/app/shared/mocks/form-builder-service.mock.ts
@@ -48,6 +48,7 @@ export function getMockFormBuilderService(): FormBuilderService {
     ),
     getTypeBindModelUpdates: EMPTY,
     resolveTypeBindModelId: undefined,
+    getTypeFieldValues: ['dc_type'],
   });
 
   // as the real implementation behaves for a reference the type field map does not remap

--- a/src/app/submission/sections/form/section-form.component.spec.ts
+++ b/src/app/submission/sections/form/section-form.component.spec.ts
@@ -608,6 +608,36 @@ describe('SubmissionSectionFormComponent test suite', () => {
 
     });
 
+    it('should call dispatchSaveSection on form change when a type-bind field (e.g. dc.type) changes', () => {
+      spyOn(comp, 'hasStoredValue').and.returnValue(false);
+      formOperationsService.getFieldPathSegmentedFromChangeEvent.and.returnValue('dc.type');
+      formOperationsService.getFieldValueFromChangeEvent.and.returnValue({ value: 'Corpus' });
+
+      comp.onChange(dynamicFormControlEvent);
+
+      expect(submissionServiceStub.dispatchSaveSection).toHaveBeenCalledWith(submissionId, sectionObject.id);
+    });
+
+    it('should call dispatchSaveSection on form change when a sponsor value changes', () => {
+      spyOn(comp, 'hasStoredValue').and.returnValue(false);
+      formOperationsService.getFieldPathSegmentedFromChangeEvent.and.returnValue('local.sponsor');
+      formOperationsService.getFieldValueFromChangeEvent.and.returnValue({ value: 'EU' });
+
+      comp.onChange(dynamicFormControlEvent);
+
+      expect(submissionServiceStub.dispatchSaveSection).toHaveBeenCalledWith(submissionId, sectionObject.id);
+    });
+
+    it('should not call dispatchSaveSection on form change for a regular field', () => {
+      spyOn(comp, 'hasStoredValue').and.returnValue(false);
+      formOperationsService.getFieldPathSegmentedFromChangeEvent.and.returnValue('dc.description');
+      formOperationsService.getFieldValueFromChangeEvent.and.returnValue('some text');
+
+      comp.onChange(dynamicFormControlEvent);
+
+      expect(submissionServiceStub.dispatchSaveSection).not.toHaveBeenCalled();
+    });
+
     it('should set previousValue on form focus event', () => {
       formBuilderService.hasMappedGroupValue.and.returnValue(false);
       formOperationsService.getFieldValueFromChangeEvent.and.returnValue('test');

--- a/src/app/submission/sections/form/section-form.component.ts
+++ b/src/app/submission/sections/form/section-form.component.ts
@@ -52,6 +52,8 @@ import {
   isNotEmpty,
   isUndefined,
 } from '../../../shared/empty.util';
+import { AUTHOR_METADATA_FIELD_NAME } from '../../../shared/form/builder/ds-dynamic-form-ui/models/clarin-name.model';
+import { SPONSOR_METADATA_NAME } from '../../../shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-complex.model';
 import { FormBuilderService } from '../../../shared/form/builder/form-builder.service';
 import { FormFieldPreviousValueObject } from '../../../shared/form/builder/models/form-field-previous-value-object';
 import { FormComponent } from '../../../shared/form/form.component';
@@ -445,6 +447,13 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
 
     if ((environment.submission.autosave.metadata.indexOf(metadata) !== -1 && isNotEmpty(value)) || this.hasRelatedCustomError(metadata)) {
       this.submissionService.dispatchSave(this.submissionId);
+    }
+
+    // Save immediately when a type-bind field (values like `dc_type`, `edm_type`) or a sponsor/author value changes.
+    const isTypeBindField = this.formBuilderService.getTypeFieldValues()
+      .some((typeValue) => typeValue.replace('_', '.') === metadata);
+    if (isTypeBindField || [SPONSOR_METADATA_NAME, AUTHOR_METADATA_FIELD_NAME].includes(metadata)) {
+      this.submissionService.dispatchSaveSection(this.submissionId, this.sectionData.id);
     }
   }
 

--- a/src/app/submission/sections/form/section-form.component.ts
+++ b/src/app/submission/sections/form/section-form.component.ts
@@ -451,7 +451,7 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
 
     // Save immediately when a type-bind field (values like `dc_type`, `edm_type`) or a sponsor/author value changes.
     const isTypeBindField = this.formBuilderService.getTypeFieldValues()
-      .some((typeValue) => typeValue.replace('_', '.') === metadata);
+      .some((typeValue) => typeValue === metadata.replace(/\./g, '_'));
     if (isTypeBindField || [SPONSOR_METADATA_NAME, AUTHOR_METADATA_FIELD_NAME].includes(metadata)) {
       this.submissionService.dispatchSaveSection(this.submissionId, this.sectionData.id);
     }


### PR DESCRIPTION
## The regression (confirmed live on both dev machines)

In v7 (dev-5), selecting a value in a **dropdown that drives type-bind** (e.g. the resource **type**) — or picking a **sponsor/author** autocomplete value — saved the submission **immediately**. I verified it live: choosing a resource type fires a `PATCH .../workspaceitems/{id}` right away, with no need to leave the section.

In v9 (dev-6) this does **not** happen — the choice is only persisted once the whole section loses focus (i.e. when you click into another section). If the user picks a type and then leaves/loses the session, the choice is lost.

## Root cause

The CLARIN logic in `SubmissionSectionFormComponent.onChange` was **not propagated** in the DSpace 9 upgrade. v7 (`dtq-dev`) had:

```ts
[...this.typeFields.values()].some(typeValue => {
  if (typeValue.replace('_', '.') === metadata) {
    this.dispatchFormSaveAndReinitialize(typeValue, value); // -> dispatchSaveSection + reinit
    return true;
  }
});
if ([SPONSOR_METADATA_NAME, AUTHOR_METADATA_FIELD_NAME].includes(metadata)) {
  this.dispatchFormSaveAndReinitialize(metadata, value);
}
```

v9's `onChange` only kept the (disabled-by-default) `autosave.metadata` check — none of the type/sponsor/author handling.

## Fix

Restore the immediate save in `onChange` for type-bind controlling fields and the sponsor/author fields.

- `form-builder.service.ts` — new `getTypeFieldValues()` accessor. In v9 the type-bind field map moved into `FormBuilderService` (populated from `submit.type-bind.field`), so the component reads the controlling field names from there instead of maintaining its own copy (as v7 did).
- `section-form.component.ts` — in `onChange`, when the changed field is a type-bind controlling field (e.g. `dc.type`, `edm.type`) or `local.sponsor` / `dc.contributor.author`, dispatch `dispatchSaveSection` immediately.
- `form-builder-service.mock.ts`, `section-form.component.spec.ts` — mock + tests.

### Scope note — save vs. reinitialize

v7's `dispatchFormSaveAndReinitialize` did two things: **save the section** and **reinitialize the form** (a 20s DB-polling `reinitializeForm` that rebuilt the form via `ngOnInit`). This PR restores the **save** — the observed regression. The **form reconfiguration** on type change is already handled reactively in v9 (`FormBuilderService.typeBindModelUpdates` / `registerTypeBindModels`), so the old polling reinit is not re-added. If, after testing on a dev deploy, the author/sponsor sub-fields don't refresh with server-computed values the way they did in v7, I'll port that refresh too as a follow-up.

## Testing

- `tsc -p tsconfig.app.json --noEmit` and `tsconfig.spec.json` pass (the only spec error is pre-existing in an unrelated file, `server-hard-redirect.service.spec.ts`).
- Added unit tests: save fires on `dc.type` change and on `local.sponsor` change; does **not** fire for a regular field.
- v7 behaviour confirmed live (PATCH on type selection); this change makes v9 do the same. Should be re-verified on a dev deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
