### PR TITLE
[Port to dtq-dev] fix(self-link): say what happened when the REST API reduces a page size

### DIFF
--- a/src/app/core/data/dspace-rest-response-parsing.service.spec.ts
+++ b/src/app/core/data/dspace-rest-response-parsing.service.spec.ts
@@ -19,6 +19,7 @@ describe('DspaceRestResponseParsingService', () => {
   let objectCache: ObjectCacheService;
 
   const MISMATCH = jasmine.stringMatching(/These don't match/);
+  const REDUCED_PAGE = jasmine.stringMatching(/asked for a page of 9999 elements, but the REST API served 1000/);
   const NO_SELF_LINK = jasmine.stringMatching(/doesn't have a self link/);
 
   const requestFor = (href: string): RestRequest =>
@@ -64,7 +65,6 @@ describe('DspaceRestResponseParsingService', () => {
       });
 
       it('should not warn when the self link echoes embed params and the request has no other params', () => {
-        // observed in the browser against a DSpace 9.1 backend
         const href = 'https://rest.api/core/items/eba1c085/bundles?embed=primaryBitstream&embed=bitstreams/format&embed.size=bitstreams=5';
         const response = service.callEnsureSelfLink(requestFor(href), responseWithSelfLink(href));
 
@@ -97,19 +97,35 @@ describe('DspaceRestResponseParsingService', () => {
 
     describe('differences that point at a problem with the endpoint', () => {
 
-      it('should warn when the REST API reduced the requested page size', () => {
-        // callers are expected to stay within MAX_PAGE_SIZE, so a reduced size means a caller asked
-        // for a page the API was never going to serve
+      it('should say so when the REST API reduced the requested page size', () => {
         const request = requestFor('https://rest.api/core/items/eba1c085/bundles?size=9999');
         service.callEnsureSelfLink(request, responseWithSelfLink(
           'https://rest.api/core/items/eba1c085/bundles?size=1000',
           { number: 0, size: 1000, totalPages: 1, totalElements: 2 }));
 
         expect(console.warn).toHaveBeenCalledTimes(1);
+        expect(console.warn).toHaveBeenCalledWith(REDUCED_PAGE);
+      });
+
+      it('should report a reduced page size alongside other params without confusing the two', () => {
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?page=0&size=9999&sort=name,ASC');
+        service.callEnsureSelfLink(request, responseWithSelfLink(
+          'https://rest.api/core/items/eba1c085/bundles?page=0&size=1000&sort=name,ASC'));
+
+        expect(console.warn).toHaveBeenCalledTimes(1);
+        expect(console.warn).toHaveBeenCalledWith(REDUCED_PAGE);
+      });
+
+      it('should fall back to the generic warning when more than the page size differs', () => {
+        const request = requestFor('https://rest.api/core/items/eba1c085/bundles?page=0&size=9999');
+        service.callEnsureSelfLink(request, responseWithSelfLink(
+          'https://rest.api/core/items/eba1c085/bundles?page=3&size=1000'));
+
+        expect(console.warn).toHaveBeenCalledTimes(1);
         expect(console.warn).toHaveBeenCalledWith(MISMATCH);
       });
 
-      it('should warn when the returned page size is larger than the requested one', () => {
+      it('should use the generic warning when the returned page size is larger than requested', () => {
         const request = requestFor('https://rest.api/core/items/eba1c085/bundles?size=5');
         service.callEnsureSelfLink(request, responseWithSelfLink(
           'https://rest.api/core/items/eba1c085/bundles?size=50',

--- a/src/app/core/data/dspace-rest-response-parsing.service.ts
+++ b/src/app/core/data/dspace-rest-response-parsing.service.ts
@@ -44,6 +44,11 @@ export function isRestPaginatedList(halObj: any): boolean {
 }
 
 /**
+ * The url param holding the page size
+ */
+const PAGE_SIZE_PARAM = 'size=';
+
+/**
  * Split a url into parts
  *
  * @param url the url to split
@@ -63,8 +68,8 @@ const urlPartsDiffer = (expected: string[], actual: string[]): boolean => {
 };
 
 /**
- * Percent decode each url part, so `uri=http%3A%2F%2Fx` and `uri=http://x` compare equal. Parts are
- * decoded one by one, after the url was split, so a decoded `&` can't merge two params.
+ * Percent decode each url part, so `uri=http%3A%2F%2Fx` and `uri=http://x` compare equal. Decoding
+ * after the split keeps a decoded `&` from merging two params.
  */
 const decodeUrlParts = (parts: string[]): string[] => {
   return parts.map((part: string) => {
@@ -77,20 +82,39 @@ const decodeUrlParts = (parts: string[]): string[] => {
 };
 
 /**
- * Return true if the self link differs from the requested url in a way that isn't just a different
- * way of writing the same request. Takes the requested url already split, since the caller has it.
- *
- * Both sides are brought to the same form first: `embed`/`embed.size` params are stripped, because
- * the frontend treats them as not part of a resource's identity and indexes without them, and both
- * are percent decoded. Anything still differing is a real difference between what was asked for and
- * what came back, including a page size the API reduced — callers are expected to stay within
- * `MAX_PAGE_SIZE` rather than have that reported difference filtered out here.
+ * The page size a url asks for, or undefined when it doesn't ask for a usable one
  */
-const isUnexpectedSelfLink = (requestedUrlParts: string[], selfLink: string): boolean => {
-  return urlPartsDiffer(
-    decodeUrlParts(requestedUrlParts),
-    decodeUrlParts(splitUrlInParts(getUrlWithoutEmbedParams(selfLink))),
-  );
+const getPageSize = (parts: string[]): number | undefined => {
+  return parts.filter((part: string) => part.startsWith(PAGE_SIZE_PARAM))
+    .map((part: string) => Number(part.substring(PAGE_SIZE_PARAM.length)))
+    .find((size: number) => Number.isInteger(size) && size > 0);
+};
+
+/**
+ * Return the parts without the one holding the page size
+ */
+const withoutPageSize = (parts: string[]): string[] => {
+  return parts.filter((part: string) => !part.startsWith(PAGE_SIZE_PARAM));
+};
+
+/**
+ * Return the warning to log for a self link, or undefined when it describes the same request as the
+ * url it was requested with. A reduced page size gets its own message, since the generic one blames
+ * the endpoint for something the caller did.
+ */
+const selfLinkWarning = (requestedUrl: string, requestedUrlParts: string[], selfLink: string): string | undefined => {
+  const expected = decodeUrlParts(requestedUrlParts);
+  const actual = decodeUrlParts(splitUrlInParts(getUrlWithoutEmbedParams(selfLink)));
+  if (!urlPartsDiffer(expected, actual)) {
+    return undefined;
+  }
+  const requestedSize = getPageSize(expected);
+  const servedSize = getPageSize(actual);
+  if (hasValue(requestedSize) && hasValue(servedSize) && servedSize < requestedSize
+    && !urlPartsDiffer(withoutPageSize(expected), withoutPageSize(actual))) {
+    return `The request for '${requestedUrl}' asked for a page of ${requestedSize} elements, but the REST API served ${servedSize}. Ask for at most MAX_PAGE_SIZE elements`;
+  }
+  return `The response for '${requestedUrl}' has the self link '${selfLink}'. These don't match. This could mean there's an issue with the REST endpoint`;
 };
 
 @Injectable({ providedIn: 'root' })
@@ -199,9 +223,10 @@ export class DspaceRestResponseParsingService implements ResponseParsingService 
         const expected = splitUrlInParts(urlWithoutEmbedParams);
         const actual = splitUrlInParts(selfLink);
         if (expected[0] === actual[0] && urlPartsDiffer(expected, actual)) {
-          // the self link is normalized either way, only the warning is filtered
-          if (isUnexpectedSelfLink(expected, selfLink)) {
-            console.warn(`The response for '${urlWithoutEmbedParams}' has the self link '${selfLink}'. These don't match. This could mean there's an issue with the REST endpoint`);
+          // the self link is normalized either way, only the warning is conditional
+          const warning = selfLinkWarning(urlWithoutEmbedParams, expected, selfLink);
+          if (hasValue(warning)) {
+            console.warn(warning);
           }
           response.payload._links = Object.assign({}, response.payload._links, {
             self: {


### PR DESCRIPTION
## References
* Fixes https://github.com/dataquest-dev/dspace-customers/issues/934 (cross-repo, so it will not auto-close)
* Ports the second commit of DSpace/dspace-angular PR 6083, which fixes DSpace/DSpace issue 8577
* Follows #1415, which already landed the first commit's content on dtq-dev
* Same change as #1448, which went to `customer/jcu` only

## Description
`ensureSelfLink()` uses one wording for every self link that differs from the url it was requested with, and it ends with "This could mean there's an issue with the REST endpoint". For a page size the API reduced that points at the wrong place: the API did what its contract says, the caller asked for a bigger page than it will serve.

## Instructions for Reviewers

Why this comes after #1415: that PR normalized `embed` params and percent encoding on both sides and replaced the oversized page sizes with `MAX_PAGE_SIZE` at ten call sites. Now that nothing asks for an impossible page, a reduced page size means the caller was wrong, and the message can say so.

```
The request for '.../bundles?size=9999' asked for a page of 9999 elements, but the REST API served 1000. Ask for at most MAX_PAGE_SIZE elements
```

Changes:
* `isUnexpectedSelfLink()` becomes `selfLinkWarning()`, returning the message to log or `undefined`, plus the `getPageSize()` / `withoutPageSize()` helpers.
* The specific message applies only when the two urls are otherwise identical, so an accepted reduction cannot mask a wrong page or sort. Anything else keeps the generic message, including a page that came back larger than requested.
* The code that rewrites `_links.self` is unchanged, so caching is unaffected.
* Spec goes from 17 to 19 cases.

Left out of the upstream commit: nothing. What differs is the file around it — upstream `main` uses `@dspace/*` aliases and `inject(APP_CONFIG)` and a TestBed spec, none of which exist on 7.6.5.

**How to test:** temporarily change `elementsPerPage: MAX_PAGE_SIZE` to `9999` in `findByItemAndName()` in `bundle-data.service.ts` (line 84) and open an item page with the console open. Before the change it blames the REST endpoint, after it names the requested and the served size. Revert afterwards.

## Checklist
- [x] My PR is **created against `dtq-dev`** (port of an upstream fix onto our 7.6.5 line).
- [x] My PR is **small in size** (2 files, +64/-23).
- [x] My PR **follows all coding best practices** based on the Code Conventions Guide.
- [x] My PR **passes ESLint** validation (0 errors; 1 warning on a pre-existing line, identical on dtq-dev).
- [ ] My PR **doesn't introduce circular dependencies** — the npm script cannot run on Windows (pre-existing quoting bug in `package.json`); madge run directly reports none over 2995 files.
- [x] My PR **includes TypeDoc comments** for all new methods.
- [x] My PR **passes all specs/tests and includes new/updated specs or tests** (full suite 5510 SUCCESS; target spec 19 SUCCESS).
- [x] My PR **aligns with Accessibility guidelines**: no UI changes.
- [x] My PR **uses i18n keys**: nothing user facing, the only string is a console warning.
- [x] My PR **includes details on how to test it**.
- [x] No new libraries or dependencies.
- [x] If my PR fixes an issue ticket, I've linked them together.

<sub>Written with some help from [Claude Code](https://claude.com/claude-code).</sub>
