### PR TITLE
Pass UI_URL to the frontend as DSPACE_UI_BASEURL

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       DSPACE_UI_HOST: dspace-angular
       DSPACE_UI_PORT: 4000
       DSPACE_UI_NAMESPACE: /
+      DSPACE_UI_BASEURL: ${UI_URL:-http://127.0.0.1:4000}
       DSPACE_REST_SSL: ${DSPACE_SSL:-false}
       DSPACE_REST_HOST: ${DSPACE_HOST:-localhost}
       DSPACE_REST_PORT: ${DSPACE_REST_PORT}


### PR DESCRIPTION
Ports the fix from dataquest-dev/devops#62 to the `customer/TUL` docker-compose.

## What

Adds `DSPACE_UI_BASEURL: ${UI_URL:-http://127.0.0.1:4000}` to the `dspace-angular` service environment, so the public UI URL is forwarded into the frontend container.

## Why

The frontend never received `UI_URL`, so `ui.baseUrl` kept the built-in default `http://localhost:4000`, while the backend already gets the correct value via `dspace.ui.url`. On DSpace 9.x, `server.ts` builds Angular's SSR host allowlist from `ui.baseUrl`; a request with any other `Host` is rejected, DSpace falls back to client-side rendering and answers 200 for every route — including routes that do not exist.

See dataquest-dev/devops#62 for full context and verification.